### PR TITLE
Renamed many unknown functions

### DIFF
--- a/graph_search.py
+++ b/graph_search.py
@@ -209,7 +209,6 @@ def match_iter(instrs, graph, slices=10):  # Iteratively try to find a match
         return matches[0][1]
     elif not matches:  # No match anywhere
         return None
-    return None
     potential = {t[1] for t in matches}  # All potential matches
     for _ in range(slices):  # Slice the list randomly and search for matches
         start = random.randint(1, len(instrs))
@@ -219,8 +218,7 @@ def match_iter(instrs, graph, slices=10):  # Iteratively try to find a match
         elif end < start:
             start, end = end, start
         matches = match_instrs(instrs[start:end], graph)
-        min_len = max((end - start) // 2, 1)
-        new_set = {t[1]-2*start for t in matches if t[0] >= min_len}
+        new_set = {t[1]-2*start for t in matches}
         potential = potential & new_set  # Take intersection of old and new locations
         if not potential:
             return None

--- a/pokeemerald_jp.cfg
+++ b/pokeemerald_jp.cfg
@@ -6,41 +6,41 @@ arm_func 0x8000374 _intr.ret
 thumb_func 0x80003a4 AgbMain
 thumb_func 0x80004d8 UpdateLinkAndCallCallbacks
 thumb_func 0x800051c InitMainCallbacks
-thumb_func 0x8000540
-thumb_func 0x8000554
-thumb_func 0x8000560
+thumb_func 0x8000540 SetMainCallback2
+thumb_func 0x8000554 StartTimer1
+thumb_func 0x8000560 SeedRngAndSetTrainerId
 thumb_func 0x8000588
-thumb_func 0x8000594
+thumb_func 0x8000594 EnableVCountIntrAtLine150
 thumb_func 0x80005bc InitKeys
-thumb_func 0x80005e4
-thumb_func 0x8000684
-thumb_func 0x80006f0
-thumb_func 0x80006fc
-thumb_func 0x8000708
-thumb_func 0x8000714
-thumb_func 0x800072c
-thumb_func 0x8000738
+thumb_func 0x80005e4 ReadKeys
+thumb_func 0x8000684 InitIntrHandlers
+thumb_func 0x80006f0 SetVBlankCallback
+thumb_func 0x80006fc SetHBlankCallback
+thumb_func 0x8000708 SetVCountCallback
+thumb_func 0x8000714 RestoreSerialTimer3IntrHandlers
+thumb_func 0x800072c SetSerialCallback
+thumb_func 0x8000738 VBlankIntr
 thumb_func 0x8000800
-thumb_func 0x8000814
-thumb_func 0x8000844
-thumb_func 0x8000878
+thumb_func 0x8000814 HBlankIntr
+thumb_func 0x8000844 VCountIntr
+thumb_func 0x8000878 SerialIntr
 thumb_func 0x80008a8 nullsub_29
 thumb_func 0x80008ac WaitForVBlank
 thumb_func 0x80008dc
 thumb_func 0x80008e8
-thumb_func 0x80008f4
-thumb_func 0x8000964
+thumb_func 0x80008f4 DoSoftReset
+thumb_func 0x8000964 GetRivalSonDaughterString
 thumb_func 0x8000988 PutMemBlockHeader
 thumb_func 0x80009a4
-thumb_func 0x80009b8
+thumb_func 0x80009b8 AllocInternal
 thumb_func 0x8000a34
-thumb_func 0x8000b14
+thumb_func 0x8000b14 AllocZeroedInternal
 thumb_func 0x8000b54 CheckMemBlockInternal
-thumb_func 0x8000bac
+thumb_func 0x8000bac InitHeap
 thumb_func 0x8000bc8
-thumb_func 0x8000bdc
-thumb_func 0x8000bf0
-thumb_func 0x8000c04
+thumb_func 0x8000bdc AllocZeroed
+thumb_func 0x8000bf0 Free
+thumb_func 0x8000c04 CheckMemBlock
 thumb_func 0x8000c18 CheckHeap
 thumb_func 0x8000c48 ClearDma3Requests
 thumb_func 0x8000c80 ProcessDma3Requests
@@ -52,58 +52,58 @@ thumb_func 0x80010cc CopyBufferedValueToGpuReg
 thumb_func 0x8001110 CopyBufferedValuesToGpuRegs
 thumb_func 0x8001144 SetGpuReg
 thumb_func 0x80011d0 GetGpuReg
-thumb_func 0x8001200
-thumb_func 0x8001220
+thumb_func 0x8001200 SetGpuRegBits
+thumb_func 0x8001220 ClearGpuRegBits
 thumb_func 0x8001240 SyncRegIE
 thumb_func 0x8001274 EnableInterrupts
 thumb_func 0x80012a0 DisableInterrupts
-thumb_func 0x80012cc
+thumb_func 0x80012cc UpdateRegDispstatIntrBits
 thumb_func 0x8001308 ResetBgs
-thumb_func 0x8001320
-thumb_func 0x800133c
+thumb_func 0x8001320 SetBgModeInternal
+thumb_func 0x800133c GetBgMode
 thumb_func 0x800134c ResetBgControlStructs
 thumb_func 0x800136c Unused_ResetBgControlStruct
 thumb_func 0x8001398 SetBgControlAttributes
-thumb_func 0x80014c4
-thumb_func 0x8001578
-thumb_func 0x8001600
+thumb_func 0x80014c4 GetBgControlAttribute
+thumb_func 0x8001578 LoadBgVram
+thumb_func 0x8001600 ShowBgInternal
 thumb_func 0x800167c HideBgInternal
-thumb_func 0x80016b0
-thumb_func 0x80016d4
-thumb_func 0x80016f0
+thumb_func 0x80016b0 SyncBgVisibilityAndMode
+thumb_func 0x80016d4 SetTextModeAndHideBgs
+thumb_func 0x80016f0 SetBgAffineInternal
 thumb_func 0x80017bc
 thumb_func 0x80017d0
 thumb_func 0x80017d4 ResetBgsAndClearDma3BusyFlags
 thumb_func 0x8001800 InitBgsFromTemplates
 thumb_func 0x80018c8 InitBgFromTemplate
-thumb_func 0x800194c
+thumb_func 0x800194c SetBgMode
 thumb_func 0x800195c LoadBgTiles
 thumb_func 0x8001a14 LoadBgTilemap
-thumb_func 0x8001a64
-thumb_func 0x8001aec
-thumb_func 0x8001b48
-thumb_func 0x8001b5c
-thumb_func 0x8001b70
-thumb_func 0x8001c34
-thumb_func 0x8001d1c
-thumb_func 0x8001e58
-thumb_func 0x8001e94
-thumb_func 0x8001fd0
-thumb_func 0x800200c
-thumb_func 0x800204c
-thumb_func 0x800212c
-thumb_func 0x8002160
-thumb_func 0x8002194
-thumb_func 0x80021cc
-thumb_func 0x8002248
+thumb_func 0x8001a64 Unused_LoadBgPalette
+thumb_func 0x8001aec IsDma3ManagerBusyWithBgCopy
+thumb_func 0x8001b48 ShowBg
+thumb_func 0x8001b5c HideBg
+thumb_func 0x8001b70 SetBgAttribute
+thumb_func 0x8001c34 GetBgAttribute
+thumb_func 0x8001d1c ChangeBgX
+thumb_func 0x8001e58 GetBgX
+thumb_func 0x8001e94 ChangeBgY
+thumb_func 0x8001fd0 GetBgY
+thumb_func 0x800200c SetBgAffine
+thumb_func 0x800204c Unused_AdjustBgMosaic
+thumb_func 0x800212c SetBgTilemapBuffer
+thumb_func 0x8002160 UnsetBgTilemapBuffer
+thumb_func 0x8002194 GetBgTilemapBuffer
+thumb_func 0x80021cc CopyToBgTilemapBuffer
+thumb_func 0x8002248 CopyBgTilemapBufferToVram
 thumb_func 0x80022b0 CopyToBgTilemapBufferRect
 thumb_func 0x80023b4 CopyToBgTilemapBufferRect_ChangePalette
-thumb_func 0x80023f8
+thumb_func 0x80023f8 CopyRectToBgTilemapBufferRect
 thumb_func 0x80025e0 FillBgTilemapBufferRect_Palette0
 thumb_func 0x80026e0 FillBgTilemapBufferRect
-thumb_func 0x800271c
-thumb_func 0x80028c8
-thumb_func 0x8002938
+thumb_func 0x800271c WriteSequenceToBgTilemapBuffer
+thumb_func 0x80028c8 GetBgMetricTextMode
+thumb_func 0x8002938 GetBgMetricAffineMode
 thumb_func 0x8002990 GetTileMapIndexFromCoords
 thumb_func 0x80029c8 CopyTileMapEntry
 thumb_func 0x8002a24
@@ -111,83 +111,83 @@ thumb_func 0x8002a78
 thumb_func 0x8002a8c IsTileMapOutsideWram
 thumb_func 0x8002ab8 BlitBitmapRect4BitWithoutColorKey
 thumb_func 0x8002afc BlitBitmapRect4Bit
-thumb_func 0x8002cdc
+thumb_func 0x8002cdc FillBitmapRect4Bit
 thumb_func 0x8002d98 BlitBitmapRect4BitTo8Bit
 thumb_func 0x8002fe8 FillBitmapRect8Bit
 thumb_func 0x800308c nullsub_420
-thumb_func 0x8003090
-thumb_func 0x8003250
-thumb_func 0x80033a8
-thumb_func 0x8003444
-thumb_func 0x80034d4
-thumb_func 0x8003528
-thumb_func 0x80035a8
-thumb_func 0x800365c
-thumb_func 0x80036bc
-thumb_func 0x8003774
-thumb_func 0x80037c4
+thumb_func 0x8003090 InitWindows
+thumb_func 0x8003250 AddWindow
+thumb_func 0x80033a8 AddWindowWithoutTileMap
+thumb_func 0x8003444 RemoveWindow
+thumb_func 0x80034d4 FreeAllWindowBuffers
+thumb_func 0x8003528 CopyWindowToVram
+thumb_func 0x80035a8 CopyWindowRectToVram
+thumb_func 0x800365c PutWindowTilemap
+thumb_func 0x80036bc PutWindowRectTilemapOverridePalette
+thumb_func 0x8003774 ClearWindowTilemap
+thumb_func 0x80037c4 PutWindowRectTilemap
 thumb_func 0x8003874 BlitBitmapToWindow
-thumb_func 0x80038ac
-thumb_func 0x800396c
+thumb_func 0x80038ac BlitBitmapRectToWindow
+thumb_func 0x800396c BlitBitmapRectToWindowWithColorKey
 thumb_func 0x8003a34
-thumb_func 0x8003ac0
-thumb_func 0x8003b18
+thumb_func 0x8003ac0 CopyToWindowPixelBuffer
+thumb_func 0x8003b18 FillWindowPixelBuffer
 thumb_func 0x8003b64 ScrollWindow
-thumb_func 0x8003f28
-thumb_func 0x8003f78
-thumb_func 0x800401c
+thumb_func 0x8003f28 CallWindowFunction
+thumb_func 0x8003f78 SetWindowAttribute
+thumb_func 0x800401c GetWindowAttribute
 thumb_func 0x8004100
 thumb_func 0x800412c nullsub_301
-thumb_func 0x8004130
+thumb_func 0x8004130 AddWindow8Bit
 thumb_func 0x8004238 FillWindowPixelBuffer8Bit
 thumb_func 0x8004278 FillWindowPixelRect8Bit
 thumb_func 0x8004304 BlitBitmapRectToWindow4BitTo8Bit
-thumb_func 0x80043d0
+thumb_func 0x80043d0 CopyWindowToVram8Bit
 thumb_func 0x8004448
 thumb_func 0x8004474
 thumb_func 0x8004480
 thumb_func 0x800449c AddTextPrinterParameterized
-thumb_func 0x8004548
+thumb_func 0x8004548 AddTextPrinter
 thumb_func 0x8004630
 thumb_func 0x80046a8
-thumb_func 0x80046b8
+thumb_func 0x80046b8 RenderFont
 thumb_func 0x80046e4
 thumb_func 0x8004798 SaveTextColors
-thumb_func 0x80047b8
+thumb_func 0x80047b8 RestoreTextColors
 thumb_func 0x80047c8
 thumb_func 0x8004808 GetLastTextColor
 thumb_func 0x8004850
-thumb_func 0x8004e50
-thumb_func 0x8005358
-thumb_func 0x800538c
-thumb_func 0x80053c4
-thumb_func 0x80053fc
-thumb_func 0x8005434
-thumb_func 0x800546c
-thumb_func 0x80054a4
-thumb_func 0x80054d4
-thumb_func 0x80055ac
+thumb_func 0x8004e50 EReader_IsReceivedDataValid
+thumb_func 0x8005358 Font0Func
+thumb_func 0x800538c Font1Func
+thumb_func 0x80053c4 Font2Func
+thumb_func 0x80053fc Font3Func
+thumb_func 0x8005434 Font4Func
+thumb_func 0x800546c Font5Func
+thumb_func 0x80054a4 TextPrinterInitDownArrowCounters
+thumb_func 0x80054d4 TextPrinterDrawDownArrow
+thumb_func 0x80055ac TextPrinterClearDownArrow
 thumb_func 0x80055e0 TextPrinterWaitAutoMode
-thumb_func 0x80055fc
-thumb_func 0x8005648
-thumb_func 0x800568c
-thumb_func 0x8005760
-thumb_func 0x8005c48
-thumb_func 0x8005d7c
+thumb_func 0x80055fc TextPrinterWaitWithDownArrow
+thumb_func 0x8005648 TextPrinterWait
+thumb_func 0x800568c DrawDownArrow
+thumb_func 0x8005760 RenderText
+thumb_func 0x8005c48 GetStringWidthFixedWidthFont
+thumb_func 0x8005d7c GetFontWidthFunc
 thumb_func 0x8005dac
-thumb_func 0x8005f7c
-thumb_func 0x8006124
-thumb_func 0x8006174
-thumb_func 0x8006184
-thumb_func 0x8006194
-thumb_func 0x80061a4
-thumb_func 0x80061b4
+thumb_func 0x8005f7c RenderTextFont9
+thumb_func 0x8006124 DrawKeypadIcon
+thumb_func 0x8006174 GetKeypadIconTileOffset
+thumb_func 0x8006184 GetKeypadIconWidth
+thumb_func 0x8006194 GetKeypadIconHeight
+thumb_func 0x80061a4 SetDefaultFontsPointer
+thumb_func 0x80061b4 GetFontAttribute
 thumb_func 0x800629c
-thumb_func 0x80062b4
+thumb_func 0x80062b4 DecompressGlyphFont9
 thumb_func 0x8006300
 thumb_func 0x8006304
 thumb_func 0x8006350
-thumb_func 0x8006354
+thumb_func 0x8006354 ether_effect_related
 thumb_func 0x80063f8
 thumb_func 0x8006418
 thumb_func 0x80064b4
@@ -197,42 +197,42 @@ thumb_func 0x800657c
 thumb_func 0x8006620
 thumb_func 0x8006640
 thumb_func 0x800668c ResetSpriteData
-thumb_func 0x80066d8
+thumb_func 0x80066d8 AnimateSprites
 thumb_func 0x8006724 BuildOamBuffer
-thumb_func 0x8006770
+thumb_func 0x8006770 UpdateOamCoords
 thumb_func 0x8006834 BuildSpritePriorities
-thumb_func 0x8006874
+thumb_func 0x8006874 SortSprites
 thumb_func 0x8006a34 CopyMatricesToOamBuffer
 thumb_func 0x8006a80 AddSpritesToOamBuffer
-thumb_func 0x8006b0c
-thumb_func 0x8006b60
-thumb_func 0x8006bcc
-thumb_func 0x8006c14
-thumb_func 0x8006d6c
+thumb_func 0x8006b0c CreateSprite
+thumb_func 0x8006b60 CreateSpriteAtEnd
+thumb_func 0x8006bcc CreateInvisibleSprite
+thumb_func 0x8006c14 CreateSpriteAt
+thumb_func 0x8006d6c CreateSpriteAndAnimate
 thumb_func 0x8006e00 DestroySprite
 thumb_func 0x8006e68 ResetOamRange
-thumb_func 0x8006ea0
+thumb_func 0x8006ea0 LoadOam
 thumb_func 0x8006ed0 ClearSpriteCopyRequests
 thumb_func 0x8006f10 ResetOamMatrices
 thumb_func 0x8006f3c SetOamMatrix
-thumb_func 0x8006f5c
+thumb_func 0x8006f5c ResetSprite
 thumb_func 0x8006f70 CalcCenterToCornerVec
-thumb_func 0x8006fb4
-thumb_func 0x80070d0
+thumb_func 0x8006fb4 AllocSpriteTiles
+thumb_func 0x80070d0 SpriteTileAllocBitmapOp
 thumb_func 0x8007140 nullsub_141
-thumb_func 0x8007144
+thumb_func 0x8007144 ProcessSpriteCopyRequests
 thumb_func 0x80071a0 RequestSpriteFrameImageCopy
 thumb_func 0x8007204 RequestSpriteCopy
 thumb_func 0x8007254 CopyFromSprites
 thumb_func 0x800727c CopyToSprites
 thumb_func 0x80072a4 ResetAllSprites
 thumb_func 0x80072e0 FreeSpriteTiles
-thumb_func 0x80072fc
+thumb_func 0x80072fc FreeSpritePalette
 thumb_func 0x800730c FreeSpriteOamMatrix
 thumb_func 0x8007338 DestroySpriteAndFreeResources
-thumb_func 0x8007358
+thumb_func 0x8007358 AnimateSprite
 thumb_func 0x80073a0 BeginAnim
-thumb_func 0x8007490
+thumb_func 0x8007490 ContinueAnim
 thumb_func 0x8007530 AnimCmd_frame
 thumb_func 0x80075dc AnimCmd_end
 thumb_func 0x80075f4 AnimCmd_jump
@@ -241,7 +241,7 @@ thumb_func 0x80076dc BeginAnimLoop
 thumb_func 0x8007714 ContinueAnimLoop
 thumb_func 0x8007734 JumpToTopOfAnimLoop
 thumb_func 0x80077a8 BeginAffineAnim
-thumb_func 0x800783c
+thumb_func 0x800783c ContinueAffineAnim
 thumb_func 0x80078f0 AffineAnimDelay
 thumb_func 0x8007924 AffineAnimCmd_loop
 thumb_func 0x8007958 BeginAffineAnimLoop
@@ -254,7 +254,7 @@ thumb_func 0x8007af0 CopyOamMatrix
 thumb_func 0x8007b10 GetSpriteMatrixNum
 thumb_func 0x8007b30
 thumb_func 0x8007b40
-thumb_func 0x8007b6c
+thumb_func 0x8007b6c obj_update_pos2
 thumb_func 0x8007c08 SetSpriteOamFlipBits
 thumb_func 0x8007c7c AffineAnimStateRestartAnim
 thumb_func 0x8007c98 AffineAnimStateStartAnim
@@ -262,7 +262,7 @@ thumb_func 0x8007cc0 AffineAnimStateReset
 thumb_func 0x8007ce8 ApplyAffineAnimFrameAbsolute
 thumb_func 0x8007d0c DecrementAnimDelayCounter
 thumb_func 0x8007d34 DecrementAffineAnimDelayCounter
-thumb_func 0x8007d64
+thumb_func 0x8007d64 ApplyAffineAnimFrameRelativeAndUpdateMatrix
 thumb_func 0x8007dfc
 thumb_func 0x8007e14 GetAffineAnimFrame
 thumb_func 0x8007e80 ApplyAffineAnimFrame
@@ -278,8 +278,8 @@ thumb_func 0x8008094 ResetAffineAnimData
 thumb_func 0x80080c8
 thumb_func 0x8008100 FreeOamMatrix
 thumb_func 0x8008140 InitSpriteAffineAnim
-thumb_func 0x8008190
-thumb_func 0x8008210
+thumb_func 0x8008190 SetOamMatrixRotationScaling
+thumb_func 0x8008210 LoadSpriteSheet
 thumb_func 0x8008254 LoadSpriteSheets
 thumb_func 0x8008280 FreeSpriteTilesByTag
 thumb_func 0x80082f8 FreeSpriteTileRanges
@@ -290,17 +290,17 @@ thumb_func 0x80083dc AllocSpriteTileRange
 thumb_func 0x8008424 FreeAllSpritePalettes
 thumb_func 0x800845c LoadSpritePalette
 thumb_func 0x80084a8 LoadSpritePalettes
-thumb_func 0x80084d4
+thumb_func 0x80084d4 DoLoadSpritePalette
 thumb_func 0x80084ec AllocSpritePalette
-thumb_func 0x800851c
+thumb_func 0x800851c IndexOfSpritePaletteTag
 thumb_func 0x8008554
 thumb_func 0x8008564 FreeSpritePaletteByTag
-thumb_func 0x800858c
-thumb_func 0x8008598
-thumb_func 0x8008604
-thumb_func 0x8008828
-thumb_func 0x800885c
-thumb_func 0x8008888
+thumb_func 0x800858c SetSubspriteTables
+thumb_func 0x8008598 AddSpriteToOamBuffer
+thumb_func 0x8008604 AddSubspritesToOamBuffer
+thumb_func 0x8008828 StringCopy10
+thumb_func 0x800885c StringGetEnd10
+thumb_func 0x8008888 StringCopy7
 thumb_func 0x80088b8 StringCopy
 thumb_func 0x80088d8 StringAppend
 thumb_func 0x80088f0 StringCopyN
@@ -312,8 +312,8 @@ thumb_func 0x80089ac IsStringLengthAtLeast
 thumb_func 0x80089d8
 thumb_func 0x8008a78
 thumb_func 0x8008b18
-thumb_func 0x8008bcc
-thumb_func 0x8008cb8
+thumb_func 0x8008bcc StringExpandPlaceholders
+thumb_func 0x8008cb8 StringBraille
 thumb_func 0x8008d18
 thumb_func 0x8008d20
 thumb_func 0x8008d2c
@@ -328,52 +328,52 @@ thumb_func 0x8008da4
 thumb_func 0x8008dac
 thumb_func 0x8008db4
 thumb_func 0x8008dbc
-thumb_func 0x8008dc4
+thumb_func 0x8008dc4 GetExpandedPlaceholder
 thumb_func 0x8008de8 StringFill
 thumb_func 0x8008e14 StringCopyPadded
-thumb_func 0x8008e68
+thumb_func 0x8008e68 StringFillWithTerminator
 thumb_func 0x8008e78 StringCopyN_Multibyte
 thumb_func 0x8008eb8 StringLength_Multibyte
 thumb_func 0x8008ed8 WriteColorChangeControlCode
 thumb_func 0x8008f14 IsStringJapanese
 thumb_func 0x8008f38
-thumb_func 0x8008f68
-thumb_func 0x8008fa0
-thumb_func 0x8008fb0
+thumb_func 0x8008f68 LoadHeldItemIcons
+thumb_func 0x8008fa0 Task_DestroySelf
+thumb_func 0x8008fb0 InitLinkTestBG
 thumb_func 0x8009088
-thumb_func 0x800910c
-thumb_func 0x80091c4
-thumb_func 0x80091d4
+thumb_func 0x800910c LinkTestScreen
+thumb_func 0x80091c4 SetLocalLinkPlayerId
+thumb_func 0x80091d4 InitLocalLinkPlayer
 thumb_func 0x8009258
-thumb_func 0x800926c
-thumb_func 0x8009298
-thumb_func 0x80092d0
-thumb_func 0x8009384
-thumb_func 0x80093b4
-thumb_func 0x800949c
-thumb_func 0x8009558
-thumb_func 0x800957c
-thumb_func 0x80095f4
-thumb_func 0x800963c
-thumb_func 0x8009928
+thumb_func 0x800926c InitLink
+thumb_func 0x8009298 Task_TriggerHandshake
+thumb_func 0x80092d0 OpenLink
+thumb_func 0x8009384 CloseLink
+thumb_func 0x80093b4 TestBlockTransfer
+thumb_func 0x800949c LinkTestProcessKeyInput
+thumb_func 0x8009558 CB2_LinkTest
+thumb_func 0x800957c LinkMain2
+thumb_func 0x80095f4 HandleReceiveRemoteLinkPlayer
+thumb_func 0x800963c EmeraldBattleTowerRecordToRuby
+thumb_func 0x8009928 BuildSendCmd
 thumb_func 0x8009ab0
-thumb_func 0x8009ad4
+thumb_func 0x8009ad4 IsSendingKeysToLink
 thumb_func 0x8009b08
 thumb_func 0x8009b24
 thumb_func 0x8009b44
-thumb_func 0x8009b64
+thumb_func 0x8009b64 GetLinkPlayerCount
 thumb_func 0x8009b90
 thumb_func 0x8009bd4
 thumb_func 0x8009c04
-thumb_func 0x8009c28
+thumb_func 0x8009c28 Link_AnyPartnersPlayingRubyOrSapphire
 thumb_func 0x8009c40
-thumb_func 0x8009c70
-thumb_func 0x8009c8c
-thumb_func 0x8009e00
+thumb_func 0x8009c70 OpenLinkTimed
+thumb_func 0x8009c8c GetLinkPlayerDataExchangeStatusTimed
+thumb_func 0x8009e00 IsLinkPlayerDataExchangeComplete
 thumb_func 0x8009e68 GetLinkPlayerTrainerId
-thumb_func 0x8009e80
-thumb_func 0x8009ea4
-thumb_func 0x8009eb8
+thumb_func 0x8009e80 ResetLinkPlayers
+thumb_func 0x8009ea4 ResetBlockSend
+thumb_func 0x8009eb8 InitBlockSend
 thumb_func 0x8009f28 LinkCB_BlockSendBegin
 thumb_func 0x8009f4c LinkCB_BlockSend
 thumb_func 0x8009fb0
@@ -381,25 +381,25 @@ thumb_func 0x8009fbc
 thumb_func 0x8009fdc
 thumb_func 0x800a010
 thumb_func 0x800a01c
-thumb_func 0x800a02c
+thumb_func 0x800a02c GetMultiplayerId
 thumb_func 0x800a054 bitmask_all_link_players_but_self
-thumb_func 0x800a070
+thumb_func 0x800a070 SendBlock
 thumb_func 0x800a09c
-thumb_func 0x800a0e4
-thumb_func 0x800a114
-thumb_func 0x800a14c
-thumb_func 0x800a178
-thumb_func 0x800a1b0
+thumb_func 0x800a0e4 IsLinkTaskFinished
+thumb_func 0x800a114 GetBlockReceivedStatus
+thumb_func 0x800a14c SetBlockReceivedFlag
+thumb_func 0x800a178 ResetBlockReceivedFlags
+thumb_func 0x800a1b0 ResetBlockReceivedFlag
 thumb_func 0x800a1e4 CheckShouldAdvanceLinkState
 thumb_func 0x800a20c LinkTestCalcBlockChecksum
 thumb_func 0x800a23c LinkTest_prnthexchar
 thumb_func 0x800a274 LinkTest_prntchar
 thumb_func 0x800a2ac LinkTest_prnthex
-thumb_func 0x800a300
+thumb_func 0x800a300 LinkTest_prntint
 thumb_func 0x800a3a0 LinkTest_prntstr
-thumb_func 0x800a3e8
+thumb_func 0x800a3e8 LinkCB_RequestPlayerDataExchange
 thumb_func 0x800a414
-thumb_func 0x800a558
+thumb_func 0x800a558 SetLinkDebugValues
 thumb_func 0x800a56c
 thumb_func 0x800a59c
 thumb_func 0x800a5c8
@@ -409,8 +409,8 @@ thumb_func 0x800a624
 thumb_func 0x800a6b8
 thumb_func 0x800a6dc
 thumb_func 0x800a75c
-thumb_func 0x800a770
-thumb_func 0x800a780
+thumb_func 0x800a770 GetLinkPlayerCount_2
+thumb_func 0x800a780 IsLinkMaster
 thumb_func 0x800a7ac
 thumb_func 0x800a7b8
 thumb_func 0x800a7f8
@@ -419,47 +419,47 @@ thumb_func 0x800a870
 thumb_func 0x800a8d4
 thumb_func 0x800a90c
 thumb_func 0x800a938
-thumb_func 0x800a990
+thumb_func 0x800a990 CheckErrorStatus
 thumb_func 0x800a9f4
-thumb_func 0x800aa0c
+thumb_func 0x800aa0c CB2_LinkError
 thumb_func 0x800ab5c
-thumb_func 0x800ac14
-thumb_func 0x800ac7c
-thumb_func 0x800adc4
+thumb_func 0x800ac14 BtlController_EmitCmd42
+thumb_func 0x800ac7c CB2_PrintErrorMessage
+thumb_func 0x800adc4 GetSioMultiSI
 thumb_func 0x800add4 IsSioMultiMaster
-thumb_func 0x800adfc
+thumb_func 0x800adfc IsLinkConnectionEstablished
 thumb_func 0x800ae0c
 thumb_func 0x800ae18
 thumb_func 0x800ae24
 thumb_func 0x800ae80
-thumb_func 0x800aee0
+thumb_func 0x800aee0 HandleLinkConnection
 thumb_func 0x800af5c
 thumb_func 0x800af78
 thumb_func 0x800af94
-thumb_func 0x800afb0
+thumb_func 0x800afb0 GetLinkRecvQueueLength
 thumb_func 0x800afd8
 thumb_func 0x800afec
-thumb_func 0x800aff8
-thumb_func 0x800b050
-thumb_func 0x800b0e4
-thumb_func 0x800b0f4
-thumb_func 0x800b220
-thumb_func 0x800b24c
-thumb_func 0x800b27c
-thumb_func 0x800b364
-thumb_func 0x800b474
-thumb_func 0x800b4e4
-thumb_func 0x800b4f4
+thumb_func 0x800aff8 DisableSerial
+thumb_func 0x800b050 EnableSerial
+thumb_func 0x800b0e4 ResetSerial
+thumb_func 0x800b0f4 LinkMain1
+thumb_func 0x800b220 CheckMasterOrSlave
+thumb_func 0x800b24c InitTimer
+thumb_func 0x800b27c EnqueueSendCmd
+thumb_func 0x800b364 DequeueRecvCmds
+thumb_func 0x800b474 LinkVSync
+thumb_func 0x800b4e4 Timer3Intr
+thumb_func 0x800b4f4 SerialCB
 thumb_func 0x800b57c
-thumb_func 0x800b58c
-thumb_func 0x800b688
-thumb_func 0x800b7a0
+thumb_func 0x800b58c DoHandshake
+thumb_func 0x800b688 DoRecv
+thumb_func 0x800b7a0 DoSend
 thumb_func 0x800b854 StopTimer
-thumb_func 0x800b888
+thumb_func 0x800b888 SendRecvDone
 thumb_func 0x800b8b8 ResetSendBuffer
 thumb_func 0x800b90c ResetRecvBuffer
 thumb_func 0x800b97c
-thumb_func 0x800b9c8
+thumb_func 0x800b9c8 rfu_REQ_sendData_wrapper
 thumb_func 0x800ba08
 thumb_func 0x800ba5c
 thumb_func 0x800ba88
@@ -470,7 +470,7 @@ thumb_func 0x800bbe8
 thumb_func 0x800bccc
 thumb_func 0x800bd38
 thumb_func 0x800be28
-thumb_func 0x800bfec
+thumb_func 0x800bfec rfu_syncVBlank_
 thumb_func 0x800c008
 thumb_func 0x800c200
 thumb_func 0x800c270
@@ -511,17 +511,17 @@ thumb_func 0x800d860
 thumb_func 0x800d948
 thumb_func 0x800da00
 thumb_func 0x800da5c
-thumb_func 0x800da80
-thumb_func 0x800db50
-thumb_func 0x800dbb4
+thumb_func 0x800da80 CreateWirelessStatusIndicatorSprite
+thumb_func 0x800db50 DestroyWirelessStatusIndicatorSprite
+thumb_func 0x800dbb4 LoadWirelessStatusIndicatorSpriteGfx
 thumb_func 0x800dbf0
 thumb_func 0x800dc28
 thumb_func 0x800dc40
-thumb_func 0x800de44
+thumb_func 0x800de44 CopyTrainerRecord
 thumb_func 0x800de54 NameIsNotEmpty
-thumb_func 0x800de74
+thumb_func 0x800de74 RecordMixTrainerNames
 thumb_func 0x800e004
-thumb_func 0x800e070
+thumb_func 0x800e070 WipeTrainerNameRecords
 thumb_func 0x800e0c0 nullsub_5
 thumb_func 0x800e0c4 nullsub_4
 thumb_func 0x800e0c8
@@ -535,7 +535,7 @@ thumb_func 0x800e578
 thumb_func 0x800e5c0
 thumb_func 0x800e608
 thumb_func 0x800e7d0
-thumb_func 0x800e7e8
+thumb_func 0x800e7e8 SaveSuccessCallback
 thumb_func 0x800e7f4
 thumb_func 0x800e87c
 thumb_func 0x800e894
@@ -550,8 +550,8 @@ thumb_func 0x800ea3c
 thumb_func 0x800ea48
 thumb_func 0x800ea70
 thumb_func 0x800ead4
-thumb_func 0x800eb08
-thumb_func 0x800eb78
+thumb_func 0x800eb08 BattleAICmd_if_in_hwords
+thumb_func 0x800eb78 IsRfuRecvQueueEmpty
 thumb_func 0x800ebb8
 thumb_func 0x800eca0
 thumb_func 0x800ef58
@@ -560,7 +560,7 @@ thumb_func 0x800f0f8
 thumb_func 0x800f1bc
 thumb_func 0x800f1e8
 thumb_func 0x800f20c
-thumb_func 0x800f254
+thumb_func 0x800f254 rfu_func_080F97B8
 thumb_func 0x800f29c
 thumb_func 0x800f2a4 IsSendingKeysToRfu
 thumb_func 0x800f2c4
@@ -575,18 +575,18 @@ thumb_func 0x800f7bc
 thumb_func 0x800f7f8
 thumb_func 0x800f934
 thumb_func 0x800f968
-thumb_func 0x800fa4c
+thumb_func 0x800fa4c rfufunc_80F9F44
 thumb_func 0x800fab0
-thumb_func 0x800fb28
+thumb_func 0x800fb28 rfufunc_80FA020
 thumb_func 0x800fc00
 thumb_func 0x800fc1c
 thumb_func 0x800fc48
 thumb_func 0x800fc68
-thumb_func 0x800fc98
+thumb_func 0x800fc98 OpponentHandleEndBounceEffect
 thumb_func 0x800fccc
 thumb_func 0x800fd2c
 thumb_func 0x800fd64
-thumb_func 0x800fd94
+thumb_func 0x800fd94 task_add_05_task_del_08FA224_when_no_RfuFunc
 thumb_func 0x800fdb8
 thumb_func 0x800fe58
 thumb_func 0x800fe90
@@ -594,7 +594,7 @@ thumb_func 0x800ff34
 thumb_func 0x800ff54
 thumb_func 0x800ff8c
 thumb_func 0x800ffb0
-thumb_func 0x800ffd0
+thumb_func 0x800ffd0 rfu_get_multiplayer_id
 thumb_func 0x800fff4
 thumb_func 0x8010000
 thumb_func 0x8010028
@@ -613,7 +613,7 @@ thumb_func 0x8010568
 thumb_func 0x80105a4
 thumb_func 0x80107fc
 thumb_func 0x80108a4
-thumb_func 0x8010990
+thumb_func 0x8010990 rfu_REQ_recvData_then_sendData
 thumb_func 0x80109b0
 thumb_func 0x8010a0c
 thumb_func 0x8010a38
@@ -641,11 +641,11 @@ thumb_func 0x8011554
 thumb_func 0x8011564
 thumb_func 0x8011570
 thumb_func 0x801158c
-thumb_func 0x801159c
+thumb_func 0x801159c Rfu_IsMaster
 thumb_func 0x80115a8
 thumb_func 0x80115b4
 thumb_func 0x80115d4
-thumb_func 0x80115e8
+thumb_func 0x80115e8 atk57
 thumb_func 0x801167c
 thumb_func 0x8011690
 thumb_func 0x80116bc
@@ -676,7 +676,7 @@ thumb_func 0x8011fd8
 thumb_func 0x80120a8
 thumb_func 0x8012134
 thumb_func 0x80121d4
-thumb_func 0x8012244
+thumb_func 0x8012244 BerryBlenderLinkBecomeLeader
 thumb_func 0x8012288
 thumb_func 0x8012a64
 thumb_func 0x8012ac4
@@ -687,7 +687,7 @@ thumb_func 0x8012d0c
 thumb_func 0x8012d7c
 thumb_func 0x8012dd8
 thumb_func 0x8012e9c
-thumb_func 0x8012fa8
+thumb_func 0x8012fa8 BerryBlenderLinkJoinGroup
 thumb_func 0x8012fec
 thumb_func 0x8013690
 thumb_func 0x80136dc
@@ -711,25 +711,25 @@ thumb_func 0x8013f14
 thumb_func 0x8014298
 thumb_func 0x80144cc
 thumb_func 0x80144e0
-thumb_func 0x8014508
+thumb_func 0x8014508 MEvent_CreateTask_Leader
 thumb_func 0x8014548
 thumb_func 0x8014a04
 thumb_func 0x8014a50
-thumb_func 0x8014db0
+thumb_func 0x8014db0 MEvent_CreateTask_CardOrNewsOverWireless
 thumb_func 0x8014dfc
-thumb_func 0x8015114
+thumb_func 0x8015114 UnionRoomSpecial
 thumb_func 0x8015160
 thumb_func 0x801516c
 thumb_func 0x8015194
 thumb_func 0x80151b8
 thumb_func 0x80151d0
 thumb_func 0x80151e8
-thumb_func 0x8016398
+thumb_func 0x8016398 var_800D_set_xB
 thumb_func 0x80163b0
 thumb_func 0x80163f0
 thumb_func 0x8016448
 thumb_func 0x8016490
-thumb_func 0x80165e4
+thumb_func 0x80165e4 sp182_move_string
 thumb_func 0x8016610
 thumb_func 0x80167b0
 thumb_func 0x8016900
@@ -740,14 +740,14 @@ thumb_func 0x8016ad0
 thumb_func 0x8016b00
 thumb_func 0x8016b30
 thumb_func 0x8016b5c
-thumb_func 0x8016b74
+thumb_func 0x8016b74 PrintOnTextbox
 thumb_func 0x8016bc8
 thumb_func 0x8016c28
 thumb_func 0x8016c78
 thumb_func 0x8016c88
-thumb_func 0x8016d5c
+thumb_func 0x8016d5c MainMenu_FormatSavegameBadges
 thumb_func 0x8016e74
-thumb_func 0x8016e98
+thumb_func 0x8016e98 Contest_RunTextPrinters
 thumb_func 0x8016ea4
 thumb_func 0x8017044
 thumb_func 0x80170b0
@@ -759,11 +759,11 @@ thumb_func 0x801727c
 thumb_func 0x8017360
 thumb_func 0x80173fc
 thumb_func 0x8017440
-thumb_func 0x8017468
+thumb_func 0x8017468 StartFieldEffectForEventObject
 thumb_func 0x8017484
 thumb_func 0x80175ec nullsub_30
 thumb_func 0x80175f0
-thumb_func 0x80176b0
+thumb_func 0x80176b0 UpdateHpTextInHealthbox
 thumb_func 0x8017770
 thumb_func 0x80177b8
 thumb_func 0x80177c4
@@ -783,51 +783,51 @@ thumb_func 0x8017c88
 thumb_func 0x8017c98
 thumb_func 0x8017cdc
 thumb_func 0x8017ebc
-thumb_func 0x8017ed0
-thumb_func 0x8017ee8
+thumb_func 0x8017ed0 c2_mystery_gift_e_reader_run
+thumb_func 0x8017ee8 HandleMysteryGiftOrEReaderSetup
 thumb_func 0x80180e4
-thumb_func 0x8018110
-thumb_func 0x8018138
+thumb_func 0x8018110 c2_ereader
+thumb_func 0x8018138 MainCB_FreeAllBuffersAndReturnToInitTitleScreen
 thumb_func 0x8018180
-thumb_func 0x801822c
-thumb_func 0x8018240
-thumb_func 0x80182e0
-thumb_func 0x801832c
-thumb_func 0x8018388
-thumb_func 0x80183a4
-thumb_func 0x8018438
-thumb_func 0x8018460
-thumb_func 0x8018488
-thumb_func 0x80184c8
-thumb_func 0x80184fc
-thumb_func 0x8018560
-thumb_func 0x80186b4
-thumb_func 0x8018804
-thumb_func 0x8018818
-thumb_func 0x8018874
+thumb_func 0x801822c MG_DrawTextBorder
+thumb_func 0x8018240 MG_DrawCheckerboardPattern
+thumb_func 0x80182e0 ClearScreenInBg0
+thumb_func 0x801832c AddTextPrinterToWindow1
+thumb_func 0x8018388 ClearTextWindow
+thumb_func 0x80183a4 MG_PrintTextOnWindow1AndWaitButton
+thumb_func 0x8018438 HideDownArrow
+thumb_func 0x8018460 ShowDownArrow
+thumb_func 0x8018488 unref_HideDownArrowAndWaitButton
+thumb_func 0x80184c8 PrintStringAndWait2Seconds
+thumb_func 0x80184fc MysteryGift_HandleThreeOptionMenu
+thumb_func 0x8018560 mevent_message_print_and_prompt_yes_no
+thumb_func 0x80186b4 BufferMonTrainerMemo
+thumb_func 0x8018804 ValidateCardOrNews
+thumb_func 0x8018818 HandleLoadWonderCardOrNews
+thumb_func 0x8018874 DestroyNewsOrCard
 thumb_func 0x801888c
-thumb_func 0x80188b8
-thumb_func 0x80188dc
-thumb_func 0x80188fc
-thumb_func 0x8018974
-thumb_func 0x8018aa4
-thumb_func 0x8018b0c
+thumb_func 0x80188b8 mevent_message_prompt_discard
+thumb_func 0x80188dc mevent_message_was_thrown_away
+thumb_func 0x80188fc mevent_save_game
+thumb_func 0x8018974 mevent_message
+thumb_func 0x8018aa4 PrintMGSuccessMessage
+thumb_func 0x8018b0c mevent_message_stamp_card_etc_send_status
 thumb_func 0x8018bdc
-thumb_func 0x8018c14
-thumb_func 0x8018c5c
+thumb_func 0x8018c14 task_add_00_mystery_gift
+thumb_func 0x8018c5c PrintMGSendStatus
 thumb_func 0x8019328
-thumb_func 0x8019330
-thumb_func 0x8019350
+thumb_func 0x8019330 bgid_upload_textbox_1
+thumb_func 0x8019350 is_walking_or_running
 thumb_func 0x8019370
 thumb_func 0x8019388
 thumb_func 0x80193d8
-thumb_func 0x8019428
+thumb_func 0x8019428 IsUnionRoomPlayerHidden
 thumb_func 0x8019444
 thumb_func 0x801945c
-thumb_func 0x8019474
-thumb_func 0x8019490
-thumb_func 0x80194b0
-thumb_func 0x80194d0
+thumb_func 0x8019474 SetUnionRoomPlayerGfx
+thumb_func 0x8019490 CreateUnionRoomPlayerEventObject
+thumb_func 0x80194b0 RemoveUnionRoomPlayerEventObject
+thumb_func 0x80194d0 SetUnionRoomPlayerEnterExitMovement
 thumb_func 0x8019548
 thumb_func 0x80195b4
 thumb_func 0x801960c
@@ -836,8 +836,8 @@ thumb_func 0x8019720
 thumb_func 0x801976c
 thumb_func 0x80197ac
 thumb_func 0x8019838
-thumb_func 0x8019878
-thumb_func 0x80198bc
+thumb_func 0x8019878 unknown_ItemMenu_Show
+thumb_func 0x80198bc DestroyWonderNews
 thumb_func 0x80198d8
 thumb_func 0x801990c
 thumb_func 0x80199a0
@@ -880,27 +880,27 @@ thumb_func 0x801ab1c
 thumb_func 0x801ab30
 thumb_func 0x801ab44
 thumb_func 0x801ab50
-thumb_func 0x801aba0
+thumb_func 0x801aba0 ItemUseInBattle_Escape
 thumb_func 0x801abe4
-thumb_func 0x801abf8
+thumb_func 0x801abf8 WonderNews_Test_Unk_02
 thumb_func 0x801ac1c
 thumb_func 0x801ac50
 thumb_func 0x801ac74
-thumb_func 0x801acb0
+thumb_func 0x801acb0 DestroyWonderCard
 thumb_func 0x801ace4
-thumb_func 0x801ad40
+thumb_func 0x801ad40 CreateSetStatusSprite
 thumb_func 0x801ad8c
 thumb_func 0x801adc8
 thumb_func 0x801adf0
 thumb_func 0x801ae28
-thumb_func 0x801ae5c
+thumb_func 0x801ae5c GetWonderCardFlagID
 thumb_func 0x801ae80 WonderCard_ResetInternalReceivedFlag
 thumb_func 0x801ae98 IsWonderCardFlagIDInValidRange
-thumb_func 0x801aeb8
+thumb_func 0x801aeb8 CheckReceivedGiftFromWonderCard
 thumb_func 0x801aef8
 thumb_func 0x801af20
 thumb_func 0x801af64
-thumb_func 0x801af8c
+thumb_func 0x801af8c special_0x4a
 thumb_func 0x801afc8
 thumb_func 0x801b040
 thumb_func 0x801b160
@@ -908,17 +908,17 @@ thumb_func 0x801b1ac
 thumb_func 0x801b1c8
 thumb_func 0x801b208 MEventStruct_Unk1442CC_CompareField_unk_16
 thumb_func 0x801b230
-thumb_func 0x801b244
-thumb_func 0x801b2b0
+thumb_func 0x801b244 MEventStruct_Unk1442CC_GetValueNFrom_unk_20
+thumb_func 0x801b2b0 MovementType_FaceDownAndRight_callback
 thumb_func 0x801b354
 thumb_func 0x801b458
 thumb_func 0x801b464
-thumb_func 0x801b4a8
+thumb_func 0x801b4a8 WonderCard_Test_Unk_08_6
 thumb_func 0x801b524
 thumb_func 0x801b550
 thumb_func 0x801b5b8
 thumb_func 0x801b5d8
-thumb_func 0x801b670
+thumb_func 0x801b670 DestroyWonderCardResources
 thumb_func 0x801b69c
 thumb_func 0x801b8b0
 thumb_func 0x801b9f0
@@ -926,7 +926,7 @@ thumb_func 0x801bca4
 thumb_func 0x801c04c
 thumb_func 0x801c17c
 thumb_func 0x801c224
-thumb_func 0x801c280
+thumb_func 0x801c280 DestroyWonderNewsResources
 thumb_func 0x801c2ac
 thumb_func 0x801c588
 thumb_func 0x801c754
@@ -935,49 +935,49 @@ thumb_func 0x801c7d4
 thumb_func 0x801c8b4
 thumb_func 0x801c95c
 thumb_func 0x801ca6c
-thumb_func 0x801cb24
+thumb_func 0x801cb24 mevent_srv_init_wnews
 thumb_func 0x801cb48
 thumb_func 0x801cb6c
-thumb_func 0x801cba8
-thumb_func 0x801cbfc
+thumb_func 0x801cba8 mevent_srv_init_common
+thumb_func 0x801cbfc mevent_srv_free_resources
 thumb_func 0x801cc20
-thumb_func 0x801cc60
+thumb_func 0x801cc60 mevent_first_if_not_null_else_second
 thumb_func 0x801cc6c mevent_compare_pointers
-thumb_func 0x801cc84
-thumb_func 0x801cc8c
+thumb_func 0x801cc84 common_mainseq_0
+thumb_func 0x801cc8c common_mainseq_1
 thumb_func 0x801cc90
 thumb_func 0x801ccac
 thumb_func 0x801ccc8
 thumb_func 0x801d240
-thumb_func 0x801d294
-thumb_func 0x801d2b8
-thumb_func 0x801d2f4
-thumb_func 0x801d304
-thumb_func 0x801d310
-thumb_func 0x801d31c
-thumb_func 0x801d36c
-thumb_func 0x801d390
-thumb_func 0x801d3ac
-thumb_func 0x801d3e0
+thumb_func 0x801d294 mevent_client_do_init
+thumb_func 0x801d2b8 mevent_client_do_exec
+thumb_func 0x801d2f4 mevent_client_inc_flag
+thumb_func 0x801d304 mevent_client_get_buffer
+thumb_func 0x801d310 mevent_client_set_param
+thumb_func 0x801d31c mevent_client_init
+thumb_func 0x801d36c mevent_client_free_resources
+thumb_func 0x801d390 mevent_client_jmp_buffer
+thumb_func 0x801d3ac mevent_client_send_word
+thumb_func 0x801d3e0 mainseq_0
 thumb_func 0x801d408
 thumb_func 0x801d40c mainseq_2
 thumb_func 0x801d42c mainseq_3
-thumb_func 0x801d44c
+thumb_func 0x801d44c mainseq_4
 thumb_func 0x801d620 mainseq_5
-thumb_func 0x801d638
-thumb_func 0x801d670
-thumb_func 0x801d6a4
-thumb_func 0x801d6d0
-thumb_func 0x801d6dc
+thumb_func 0x801d638 mainseq_6
+thumb_func 0x801d670 mainseq_7
+thumb_func 0x801d6a4 mevent_client_exec
+thumb_func 0x801d6d0 mevent_srv_sub_recv
+thumb_func 0x801d6dc mevent_srv_sub_send
 thumb_func 0x801d6e8 mevent_srv_sub_init
 thumb_func 0x801d714 mevent_srv_sub_init_send
-thumb_func 0x801d738
-thumb_func 0x801d748
-thumb_func 0x801d764
+thumb_func 0x801d738 mevent_srv_sub_init_recv
+thumb_func 0x801d748 mevent_recv_block
+thumb_func 0x801d764 mevent_has_received
 thumb_func 0x801d788
-thumb_func 0x801d798
-thumb_func 0x801d86c
-thumb_func 0x801d978
+thumb_func 0x801d798 mevent_receive_func
+thumb_func 0x801d86c mevent_send_func
+thumb_func 0x801d978 GenerateRandomNews
 thumb_func 0x801d9d0
 thumb_func 0x801d9ec
 thumb_func 0x801da30
@@ -989,9 +989,9 @@ thumb_func 0x801db54
 thumb_func 0x801dbbc
 thumb_func 0x801dbf4
 thumb_func 0x801dc54
-thumb_func 0x801dc78
-thumb_func 0x801dd44
-thumb_func 0x801dd5c
+thumb_func 0x801dc78 c2_081284E0
+thumb_func 0x801dd44 FoundBlackGlasses
+thumb_func 0x801dd5c ScrCmd_startcontest
 thumb_func 0x801dd78
 thumb_func 0x801ddc0
 thumb_func 0x801ddd0
@@ -1036,7 +1036,7 @@ thumb_func 0x801ef8c
 thumb_func 0x801ef98
 thumb_func 0x801efa4
 thumb_func 0x801efe0
-thumb_func 0x801efec
+thumb_func 0x801efec copy_strings_to_sav1
 thumb_func 0x801f0c4
 thumb_func 0x801f2e0
 thumb_func 0x801f344
@@ -1118,9 +1118,9 @@ thumb_func 0x8020b58
 thumb_func 0x8020b68
 thumb_func 0x8020b74
 thumb_func 0x8020c90
-thumb_func 0x8020ca4
+thumb_func 0x8020ca4 PlaySE
 thumb_func 0x8020cbc
-thumb_func 0x8020ce0
+thumb_func 0x8020ce0 PutPokeblockListMenuString
 thumb_func 0x8020d74
 thumb_func 0x8021038
 thumb_func 0x802117c
@@ -1184,18 +1184,18 @@ thumb_func 0x80243d0
 thumb_func 0x8024410
 thumb_func 0x8024434
 thumb_func 0x8024448
-thumb_func 0x802445c
-thumb_func 0x8024478
-thumb_func 0x80244a0
-thumb_func 0x80244cc
-thumb_func 0x802450c
-thumb_func 0x8024548
+thumb_func 0x802445c ApplyNewEncryptionKeyToBerryPowder
+thumb_func 0x8024478 HasEnoughBerryPowder_
+thumb_func 0x80244a0 HasEnoughBerryPowder
+thumb_func 0x80244cc GiveBerryPowder
+thumb_func 0x802450c TakeBerryPowder_
+thumb_func 0x8024548 TakeBerryPowder
 thumb_func 0x8024588 GetBerryPowder
-thumb_func 0x80245a0
-thumb_func 0x80245f8
+thumb_func 0x80245a0 PrintBerryPowderAmount
+thumb_func 0x80245f8 DrawPlayerPowderAmount
 thumb_func 0x8024654
 thumb_func 0x8024678
-thumb_func 0x80246e0
+thumb_func 0x80246e0 RemoveBerryPowderVendorMenu
 thumb_func 0x8024704
 thumb_func 0x80247e4
 thumb_func 0x80247f8
@@ -1228,7 +1228,7 @@ thumb_func 0x8025acc
 thumb_func 0x8025b18
 thumb_func 0x8025bd4
 thumb_func 0x8025ca0
-thumb_func 0x8025d10
+thumb_func 0x8025d10 BagMenu_SwapItems
 thumb_func 0x8025e0c
 thumb_func 0x8025f94
 thumb_func 0x8025fac
@@ -1278,14 +1278,14 @@ thumb_func 0x802760c
 thumb_func 0x80276fc
 thumb_func 0x802771c
 thumb_func 0x8027788
-thumb_func 0x80277e8
-thumb_func 0x80277f8
+thumb_func 0x80277e8 IncrementWithLimit
+thumb_func 0x80277f8 Min
 thumb_func 0x8027808
 thumb_func 0x802781c
 thumb_func 0x802786c
 thumb_func 0x802788c
 thumb_func 0x802792c
-thumb_func 0x8027a4c
+thumb_func 0x8027a4c AddWallpaperSetsMenu
 thumb_func 0x8027a64
 thumb_func 0x8027afc
 thumb_func 0x8027b28
@@ -1436,7 +1436,7 @@ thumb_func 0x802c494
 thumb_func 0x802c4b0
 thumb_func 0x802c4d4
 thumb_func 0x802c4fc
-thumb_func 0x802c50c
+thumb_func 0x802c50c SafariHandleStatusAnimation
 thumb_func 0x802c52c
 thumb_func 0x802c574
 thumb_func 0x802c5a0
@@ -1551,23 +1551,23 @@ thumb_func 0x802eac0
 thumb_func 0x802ebb4
 thumb_func 0x802ec0c
 thumb_func 0x802ec60
-thumb_func 0x802ed30
-thumb_func 0x802ed48
+thumb_func 0x802ed30 RtcDisableInterrupts
+thumb_func 0x802ed48 RtcRestoreInterrupts
 thumb_func 0x802ed5c ConvertBcdToBinary
-thumb_func 0x802ed84
+thumb_func 0x802ed84 IsLeapYear
 thumb_func 0x802edb8 ConvertDateToDayCount
 thumb_func 0x802ee44 RtcGetDayCount
-thumb_func 0x802ee80
+thumb_func 0x802ee80 RtcInit
 thumb_func 0x802eee0
-thumb_func 0x802eeec
-thumb_func 0x802ef1c
-thumb_func 0x802ef34
+thumb_func 0x802eeec RtcGetInfo
+thumb_func 0x802ef1c RtcGetDateTime
+thumb_func 0x802ef34 RtcGetStatus
 thumb_func 0x802ef4c RtcGetRawInfo
-thumb_func 0x802ef60
-thumb_func 0x802f05c
+thumb_func 0x802ef60 RtcCheckInfo
+thumb_func 0x802f05c RtcReset
 thumb_func 0x802f070
 thumb_func 0x802f0a8
-thumb_func 0x802f0e0
+thumb_func 0x802f0e0 FormatHexRtcTime
 thumb_func 0x802f0f8
 thumb_func 0x802f130
 thumb_func 0x802f168 RtcCalcTimeDifference
@@ -1576,102 +1576,102 @@ thumb_func 0x802f218 RtcInitLocalTimeOffset
 thumb_func 0x802f22c RtcCalcLocalTimeOffset
 thumb_func 0x802f260 CalcTimeDifference
 thumb_func 0x802f2c8 RtcGetMinuteCount
-thumb_func 0x802f300
-thumb_func 0x802f314
+thumb_func 0x802f300 RtcGetLocalDayCount
+thumb_func 0x802f314 CB2_MainMenu
 thumb_func 0x802f32c
 thumb_func 0x802f340
-thumb_func 0x802f34c
-thumb_func 0x802f358
-thumb_func 0x802f53c
+thumb_func 0x802f34c CB2_ReinitMainMenu
+thumb_func 0x802f358 InitMainMenu
+thumb_func 0x802f53c BuyMenuBuildListMenuTemplate
 thumb_func 0x802f718
-thumb_func 0x802f76c
+thumb_func 0x802f76c Task_MainMenuCheckBattery
 thumb_func 0x802f80c
 thumb_func 0x802f860
-thumb_func 0x802fdb0
-thumb_func 0x802fde0
+thumb_func 0x802fdb0 Task_HighlightSelectedMainMenuItem
+thumb_func 0x802fde0 HandleMainMenuInput
 thumb_func 0x802ff4c Task_HandleMainMenuInput
 thumb_func 0x802ff7c
-thumb_func 0x8030284
-thumb_func 0x80302e4
-thumb_func 0x80303d8
-thumb_func 0x80304f0
+thumb_func 0x8030284 Task_HandleMainMenuBPressed
+thumb_func 0x80302e4 Task_DisplayMainMenuInvalidActionError
+thumb_func 0x80303d8 HighlightSelectedMainMenuItem
+thumb_func 0x80304f0 Task_NewGameBirchSpeech_Init
 thumb_func 0x803058c
-thumb_func 0x80305f0
-thumb_func 0x8030668
-thumb_func 0x803070c
-thumb_func 0x803076c
-thumb_func 0x80307b0
-thumb_func 0x8030854
-thumb_func 0x803090c
-thumb_func 0x8030958
-thumb_func 0x80309d0
-thumb_func 0x8030a14
+thumb_func 0x80305f0 Task_NewGameBirchSpeech_WaitToShowBirch
+thumb_func 0x8030668 Task_NewGameBirchSpeech_WaitForSpriteFadeInWelcome
+thumb_func 0x803070c Task_NewGameBirchSpeech_ThisIsAPokemon
+thumb_func 0x803076c Task_NewGameBirchSpeech_MainSpeech
+thumb_func 0x80307b0 Task_NewGameBirchSpeechSub_InitPokeBall
+thumb_func 0x8030854 Task_NewGameBirchSpeechSub_WaitForLotad
+thumb_func 0x803090c Task_NewGameBirchSpeech_AndYouAre
+thumb_func 0x8030958 Task_NewGameBirchSpeech_StartBirchLotadPlatformFade
+thumb_func 0x80309d0 Task_NewGameBirchSpeech_SlidePlatformAway
+thumb_func 0x8030a14 Task_NewGameBirchSpeech_StartPlayerFadeIn
 thumb_func 0x8030ac4 Task_NewGameBirchSpeech_WaitForPlayerFadeIn
-thumb_func 0x8030b08
-thumb_func 0x8030b48
-thumb_func 0x8030b78
-thumb_func 0x8030c14
-thumb_func 0x8030cbc
+thumb_func 0x8030b08 Task_NewGameBirchSpeech_BoyOrGirl
+thumb_func 0x8030b48 Task_NewGameBirchSpeech_WaitToShowGenderMenu
+thumb_func 0x8030b78 Task_NewGameBirchSpeech_ChooseGender
+thumb_func 0x8030c14 Task_NewGameBirchSpeech_SlideOutOldGenderSprite
+thumb_func 0x8030cbc Task_NewGameBirchSpeech_SlideInNewGenderSprite
 thumb_func 0x8030d14
-thumb_func 0x8030d54
-thumb_func 0x8030d80
-thumb_func 0x8030dd0
+thumb_func 0x8030d54 Task_NewGameBirchSpeech_WaitForWhatsYourNameToPrint
+thumb_func 0x8030d80 Task_NewGameBirchSpeech_WaitPressBeforeNameChoice
+thumb_func 0x8030dd0 Task_NewGameBirchSpeech_StartNamingScreen
 thumb_func 0x8030e44
-thumb_func 0x8030e84
-thumb_func 0x8030ec8
-thumb_func 0x8030f60
-thumb_func 0x8030f98
-thumb_func 0x803107c
-thumb_func 0x8031124
-thumb_func 0x8031204
+thumb_func 0x8030e84 Task_NewGameBirchSpeech_CreateNameYesNo
+thumb_func 0x8030ec8 Task_NewGameBirchSpeech_ProcessNameYesNoMenu
+thumb_func 0x8030f60 Task_NewGameBirchSpeech_SlidePlatformAway2
+thumb_func 0x8030f98 Task_NewGameBirchSpeech_ReshowBirchLotad
+thumb_func 0x803107c Task_NewGameBirchSpeech_WaitForSpriteFadeInAndTextPrinter
+thumb_func 0x8031124 Task_NewGameBirchSpeech_AreYouReady
+thumb_func 0x8031204 Task_NewGameBirchSpeech_ShrinkPlayer
 thumb_func 0x80312c0 Task_NewGameBirchSpeech_WaitForPlayerShrink
-thumb_func 0x80312fc
+thumb_func 0x80312fc Task_NewGameBirchSpeech_FadePlayerToWhite
 thumb_func 0x8031370
-thumb_func 0x80313b8
+thumb_func 0x80313b8 CB2_NewGameBirchSpeech_ReturnFromNamingScreen
 thumb_func 0x8031614 nullsub_35
 thumb_func 0x8031618 SpriteCB_MovePlayerDownWhileShrinking
-thumb_func 0x8031634
-thumb_func 0x803166c
-thumb_func 0x803179c
-thumb_func 0x803180c
-thumb_func 0x803187c
-thumb_func 0x80318ec
-thumb_func 0x803195c
-thumb_func 0x80319c8
-thumb_func 0x8031a08
-thumb_func 0x8031a74
+thumb_func 0x8031634 NewGameBirchSpeech_CreateLotadSprite
+thumb_func 0x803166c AddBirchSpeechObjects
+thumb_func 0x803179c Task_NewGameBirchSpeech_FadeOutTarget1InTarget2
+thumb_func 0x803180c NewGameBirchSpeech_StartFadeOutTarget1InTarget2
+thumb_func 0x803187c Task_NewGameBirchSpeech_FadeInTarget1OutTarget2
+thumb_func 0x80318ec NewGameBirchSpeech_StartFadeInTarget1OutTarget2
+thumb_func 0x803195c Task_NewGameBirchSpeech_FadePlatformIn
+thumb_func 0x80319c8 NewGameBirchSpeech_StartFadePlatformIn
+thumb_func 0x8031a08 Task_NewGameBirchSpeech_FadePlatformOut
+thumb_func 0x8031a74 NewGameBirchSpeech_StartFadePlatformOut
 thumb_func 0x8031ab4
-thumb_func 0x8031b20
-thumb_func 0x8031b30
+thumb_func 0x8031b20 NewGameBirchSpeech_ProcessGenderMenuInput
+thumb_func 0x8031b30 NewGameBirchSpeech_SetDefaultPlayerName
 thumb_func 0x8031b84
 thumb_func 0x8031be8
 thumb_func 0x8031c00
 thumb_func 0x8031c4c
 thumb_func 0x8031cb0
 thumb_func 0x8031d28
-thumb_func 0x8031d9c
-thumb_func 0x8031de4
-thumb_func 0x8031f48
-thumb_func 0x8031f90
+thumb_func 0x8031d9c LoadMainMenuWindowFrameTiles
+thumb_func 0x8031de4 DrawMainMenuWindowBorder
+thumb_func 0x8031f48 ClearMainMenuWindowTilemap
+thumb_func 0x8031f90 NewGameBirchSpeech_ClearGenderWindowTilemap
 thumb_func 0x8031fd8
-thumb_func 0x8032010
-thumb_func 0x8032098
-thumb_func 0x80320c4
+thumb_func 0x8032010 NewGameBirchSpeech_ClearWindow
+thumb_func 0x8032098 NewGameBirchSpeech_ShowPokeBallPrinterCallback
+thumb_func 0x80320c4 CreateYesNoMenuParameterized
 thumb_func 0x803213c
 thumb_func 0x8032174
-thumb_func 0x80324b4
-thumb_func 0x80324ec
-thumb_func 0x8032534
+thumb_func 0x80324b4 Task_NewGameBirchSpeech_ReturnFromNamingScreenShowTextbox
+thumb_func 0x80324ec HandleLinkBattleSetup
+thumb_func 0x8032534 SetUpBattleVarsAndBirchZigzagoon
 thumb_func 0x8032600
-thumb_func 0x80326bc
-thumb_func 0x8032b58
-thumb_func 0x8032ee8
-thumb_func 0x8033050
-thumb_func 0x80330dc
+thumb_func 0x80326bc InitSinglePlayerBtlControllers
+thumb_func 0x8032b58 InitLinkBtlControllers
+thumb_func 0x8032ee8 SetBattlePartyIds
+thumb_func 0x8033050 PrepareBufferDataTransfer
+thumb_func 0x80330dc CreateTasksForSendRecvLinkBuffers
 thumb_func 0x803318c PrepareBufferDataTransferLink
-thumb_func 0x803330c
+thumb_func 0x803330c Task_HandleSendLinkBuffersData
 thumb_func 0x80334e0
-thumb_func 0x80335f4
+thumb_func 0x80335f4 Task_HandleCopyReceivedLinkBuffersData
 thumb_func 0x803374c BtlController_EmitGetMonData
 thumb_func 0x8033770 BtlController_EmitGetRawMonData
 thumb_func 0x8033798 BtlController_EmitSetMonData
@@ -1687,68 +1687,68 @@ thumb_func 0x80338fc BtlController_EmitPaletteFade
 thumb_func 0x803391c BtlController_EmitSuccessBallThrowAnim
 thumb_func 0x803393c BtlController_EmitBallThrowAnim
 thumb_func 0x803395c BtlController_EmitPause
-thumb_func 0x80339a4
-thumb_func 0x8033a7c
+thumb_func 0x80339a4 BtlController_EmitMoveAnimation
+thumb_func 0x8033a7c BtlController_EmitPrintSelectionString
 thumb_func 0x8033b74
-thumb_func 0x8033c3c
-thumb_func 0x8033c68
-thumb_func 0x8033c88
-thumb_func 0x8033cc4
-thumb_func 0x8033cf8
-thumb_func 0x8033d34
-thumb_func 0x8033d54
-thumb_func 0x8033d8c
-thumb_func 0x8033dc0
-thumb_func 0x8033e14
-thumb_func 0x8033e50
-thumb_func 0x8033e70
-thumb_func 0x8033eb8
-thumb_func 0x8033f20
-thumb_func 0x8033f68
-thumb_func 0x8033fb0
-thumb_func 0x8033fdc
-thumb_func 0x8034014
-thumb_func 0x8034040
-thumb_func 0x803406c
-thumb_func 0x803408c
-thumb_func 0x80340ac
-thumb_func 0x80340cc
-thumb_func 0x80340ec
+thumb_func 0x8033c3c BtlController_EmitChooseAction
+thumb_func 0x8033c68 BtlController_EmitUnknownYesNoBox
+thumb_func 0x8033c88 BtlController_EmitChooseMove
+thumb_func 0x8033cc4 BtlController_EmitChooseItem
+thumb_func 0x8033cf8 BtlController_EmitChoosePokemon
+thumb_func 0x8033d34 BtlController_EmitCmd23
+thumb_func 0x8033d54 BtlController_EmitHealthBarUpdate
+thumb_func 0x8033d8c BtlController_EmitExpUpdate
+thumb_func 0x8033dc0 BtlController_EmitStatusIconUpdate
+thumb_func 0x8033e14 BtlController_EmitStatusAnimation
+thumb_func 0x8033e50 BtlController_EmitStatusXor
+thumb_func 0x8033e70 BtlController_EmitDataTransfer
+thumb_func 0x8033eb8 BtlController_EmitDMA3Transfer
+thumb_func 0x8033f20 BtlController_EmitPlayBGM
+thumb_func 0x8033f68 BtlController_EmitCmd32
+thumb_func 0x8033fb0 BtlController_EmitTwoReturnValues
+thumb_func 0x8033fdc BtlController_EmitChosenMonReturnValue
+thumb_func 0x8034014 BtlController_EmitOneReturnValue
+thumb_func 0x8034040 BtlController_EmitOneReturnValue_Duplicate
+thumb_func 0x803406c BtlController_EmitCmd37
+thumb_func 0x803408c BtlController_EmitCmd38
+thumb_func 0x80340ac BtlController_EmitCmd39
+thumb_func 0x80340cc BtlController_EmitCmd40
+thumb_func 0x80340ec BtlController_EmitHitAnimation
 thumb_func 0x803410c
-thumb_func 0x803412c
-thumb_func 0x8034158
-thumb_func 0x8034184
-thumb_func 0x80341a4
-thumb_func 0x80341c4
-thumb_func 0x80341e4
-thumb_func 0x803422c
-thumb_func 0x803424c
-thumb_func 0x803426c
-thumb_func 0x8034290
-thumb_func 0x80342bc
-thumb_func 0x8034300
-thumb_func 0x8034320
+thumb_func 0x803412c BtlController_EmitPlaySE
+thumb_func 0x8034158 BtlController_EmitPlayFanfareOrBGM
+thumb_func 0x8034184 BtlController_EmitFaintingCry
+thumb_func 0x80341a4 BtlController_EmitIntroSlide
+thumb_func 0x80341c4 BtlController_EmitIntroTrainerBallThrow
+thumb_func 0x80341e4 BtlController_EmitDrawPartyStatusSummary
+thumb_func 0x803422c BtlController_EmitHidePartyStatusSummary
+thumb_func 0x803424c BtlController_EmitEndBounceEffect
+thumb_func 0x803426c BtlController_EmitSpriteInvisibility
+thumb_func 0x8034290 BtlController_EmitBattleAnimation
+thumb_func 0x80342bc BtlController_EmitLinkStandbyMsg
+thumb_func 0x8034300 BtlController_EmitResetActionMoveSelection
+thumb_func 0x8034320 BtlController_EmitCmd55
 thumb_func 0x8034370
 thumb_func 0x803437c
-thumb_func 0x8034388
-thumb_func 0x80343bc
-thumb_func 0x80343e4
-thumb_func 0x8034418
-thumb_func 0x8034448
+thumb_func 0x8034388 LoadCompressedSpriteSheet
+thumb_func 0x80343bc LoadCompressedSpriteSheetOverrideBuffer
+thumb_func 0x80343e4 LoadCompressedSpritePalette
+thumb_func 0x8034418 LoadCompressedSpritePaletteOverrideBuffer
+thumb_func 0x8034448 DecompressPicFromTable
 thumb_func 0x8034480 HandleLoadSpecialPokePic
 thumb_func 0x80344ac
-thumb_func 0x8034568
+thumb_func 0x8034568 Unused_LZDecompressWramIndirect
 thumb_func 0x8034574
-thumb_func 0x80347cc
-thumb_func 0x80347e0
-thumb_func 0x803481c
+thumb_func 0x80347cc GetDecompressedDataSize
+thumb_func 0x80347e0 LoadCompressedSpriteSheetUsingHeap
+thumb_func 0x803481c LoadCompressedSpritePaletteUsingHeap
 thumb_func 0x8034860
 thumb_func 0x8034898
 thumb_func 0x8034954 HandleLoadSpecialPokePic_2
-thumb_func 0x8034980
+thumb_func 0x8034980 DecompressPicFromTable_DontHandleDeoxys
 thumb_func 0x80349a8 HandleLoadSpecialPokePic_DontHandleDeoxys
-thumb_func 0x80349d4
-thumb_func 0x8034a88
+thumb_func 0x80349d4 LoadSpecialPokePic_DontHandleDeoxys
+thumb_func 0x8034a88 DuplicateDeoxysTiles
 thumb_func 0x8034aac
 thumb_func 0x8034b20
 thumb_func 0x8034b6c
@@ -1760,41 +1760,41 @@ thumb_func 0x8035118
 thumb_func 0x8035234
 thumb_func 0x80352d4
 thumb_func 0x8035370
-thumb_func 0x80353c8
-thumb_func 0x803540c
+thumb_func 0x80353c8 SharesTileWithAnyActive
+thumb_func 0x803540c SharesPalWithAnyActive
 thumb_func 0x8035450
 thumb_func 0x8035460
 thumb_func 0x80354a0
-thumb_func 0x80354b0
+thumb_func 0x80354b0 BattleInitBgsAndWindows
 thumb_func 0x8035528
-thumb_func 0x8035564
-thumb_func 0x80355c8
+thumb_func 0x8035564 LoadBattleMenuWindowGfx
+thumb_func 0x80355c8 DrawMainBattleBackground
 thumb_func 0x80358f8
 thumb_func 0x8035938
 thumb_func 0x8035aa0
-thumb_func 0x8035bc8
-thumb_func 0x8035fb8
+thumb_func 0x8035bc8 UpdateFastPaletteFade
+thumb_func 0x8035fb8 DrawBattleEntryBackground
 thumb_func 0x8036224
-thumb_func 0x80365b4
-thumb_func 0x8036628
+thumb_func 0x80365b4 CB2_InitBattle
+thumb_func 0x8036628 CB2_InitBattleInternal
 thumb_func 0x80368b0
-thumb_func 0x8036998
-thumb_func 0x8036a5c
+thumb_func 0x8036998 SetPlayerBerryDataInBattleStruct
+thumb_func 0x8036a5c SetAllPlayersBerryData
 thumb_func 0x8036d0c
-thumb_func 0x8036e00
+thumb_func 0x8036e00 CB2_HandleStartBattle
 thumb_func 0x8037274
 thumb_func 0x8037770
-thumb_func 0x803782c
-thumb_func 0x8037a7c
-thumb_func 0x8037b44
-thumb_func 0x80380fc
-thumb_func 0x8038178
-thumb_func 0x80381c0
+thumb_func 0x803782c CB2_PreInitMultiBattle
+thumb_func 0x8037a7c CB2_PreInitIngamePlayerPartnerBattle
+thumb_func 0x8037b44 CB2_HandleStartMultiBattle
+thumb_func 0x80380fc BattleMainCB2
+thumb_func 0x8038178 FreeRestoreBattleData
+thumb_func 0x80381c0 CB2_QuitRecordedBattle
 thumb_func 0x8038204
 thumb_func 0x8038214
 thumb_func 0x80382c4
 thumb_func 0x80386b8
-thumb_func 0x80386dc
+thumb_func 0x80386dc VBlankCB_Battle
 thumb_func 0x80387b4 nullsub_34
 thumb_func 0x80387b8
 thumb_func 0x8038828
@@ -1806,15 +1806,15 @@ thumb_func 0x8038e94
 thumb_func 0x8038f5c
 thumb_func 0x8039030
 thumb_func 0x8039050
-thumb_func 0x8039420
+thumb_func 0x8039420 SpriteCb_WildMon
 thumb_func 0x8039450 SpriteCb_MoveWildMonToRight
-thumb_func 0x803947c
-thumb_func 0x80394d8
+thumb_func 0x803947c SpriteCb_WildMonShowHealthbox
+thumb_func 0x80394d8 SpriteCb_WildMonAnimate
 thumb_func 0x80394fc nullsub_37
 thumb_func 0x8039500
 thumb_func 0x8039514
-thumb_func 0x8039578
-thumb_func 0x803968c
+thumb_func 0x8039578 SpriteCB_FaintOpponentMon
+thumb_func 0x803968c SpriteCB_AnimFaintOpponent
 thumb_func 0x803971c
 thumb_func 0x8039738
 thumb_func 0x8039770
@@ -1824,9 +1824,9 @@ thumb_func 0x8039804 oac_poke_ally_
 thumb_func 0x8039834
 thumb_func 0x8039840 nullsub_38
 thumb_func 0x8039844
-thumb_func 0x803986c
-thumb_func 0x803998c
-thumb_func 0x8039a3c
+thumb_func 0x803986c DoBounceEffect
+thumb_func 0x803998c EndBounceEffect
+thumb_func 0x8039a3c SpriteCB_BounceEffect
 thumb_func 0x8039a88
 thumb_func 0x8039aa4
 thumb_func 0x8039ac8
@@ -1835,162 +1835,162 @@ thumb_func 0x8039b0c nullsub_39
 thumb_func 0x8039b10 BeginBattleIntro
 thumb_func 0x8039b34
 thumb_func 0x8039b40
-thumb_func 0x8039b84
-thumb_func 0x8039ec8
-thumb_func 0x803a3a0
-thumb_func 0x803a804
-thumb_func 0x803a878
-thumb_func 0x803a8c8
-thumb_func 0x803abc4
-thumb_func 0x803ad64
-thumb_func 0x803ad9c
-thumb_func 0x803adc4
-thumb_func 0x803ae20
-thumb_func 0x803aea0
-thumb_func 0x803af58
+thumb_func 0x8039b84 BattleStartClearSetData
+thumb_func 0x8039ec8 SwitchInClearSetData
+thumb_func 0x803a3a0 FaintClearSetData
+thumb_func 0x803a804 BattleIntroGetMonsData
+thumb_func 0x803a878 BattleIntroPrepareBackgroundSlide
+thumb_func 0x803a8c8 BattleIntroDrawTrainersOrMonsSprites
+thumb_func 0x803abc4 BattleIntroDrawPartySummaryScreens
+thumb_func 0x803ad64 BattleIntroPrintTrainerWantsToBattle
+thumb_func 0x803ad9c BattleIntroPrintWildMonAttacked
+thumb_func 0x803adc4 BattleIntroPrintOpponentSendsOut
+thumb_func 0x803ae20 BattleIntroOpponent2SendsOutMonAnimation
+thumb_func 0x803aea0 BattleIntroOpponent1SendsOutMonAnimation
+thumb_func 0x803af58 BattleIntroRecordMonsToDex
 thumb_func 0x803aff0
-thumb_func 0x803b010
-thumb_func 0x803b070
-thumb_func 0x803b10c
+thumb_func 0x803b010 BattleIntroPrintPlayerSendsOut
+thumb_func 0x803b070 BattleIntroPlayer2SendsOutMonAnimation
+thumb_func 0x803b10c BattleIntroPlayer1SendsOutMonAnimation
 thumb_func 0x803b1dc
-thumb_func 0x803b26c
-thumb_func 0x803b548
-thumb_func 0x803b600
-thumb_func 0x803b7cc
+thumb_func 0x803b26c TryDoEventsBeforeFirstTurn
+thumb_func 0x803b548 HandleEndTurn_ContinueBattle
+thumb_func 0x803b600 BattleTurnPassed
+thumb_func 0x803b7cc IsRunningFromBattleImpossible
 thumb_func 0x803b9e4
-thumb_func 0x803bab8
-thumb_func 0x803c9fc
+thumb_func 0x803bab8 HandleTurnActionSelectionState
+thumb_func 0x803c9fc AllAtActionConfirmed
 thumb_func 0x803ca3c
 thumb_func 0x803cb20 SwapTurnOrder
-thumb_func 0x803cb54
-thumb_func 0x803cf2c
-thumb_func 0x803d1c4
+thumb_func 0x803cb54 GetWhoStrikesFirst
+thumb_func 0x803cf2c SetActionsAndBattlersTurnOrder
+thumb_func 0x803d1c4 TurnValuesCleanUp
 thumb_func 0x803d2e4 SpecialStatusesClear
-thumb_func 0x803d334
-thumb_func 0x803d45c
+thumb_func 0x803d334 CheckFocusPunch_ClearVarsBeforeTurnStarts
+thumb_func 0x803d45c RunTurnActionsFunctions
 thumb_func 0x803d488
-thumb_func 0x803d504
-thumb_func 0x803d700
-thumb_func 0x803d7e0
+thumb_func 0x803d504 HandleEndTurn_BattleWon
+thumb_func 0x803d700 HandleEndTurn_BattleLost
+thumb_func 0x803d7e0 HandleEndTurn_RanFromBattle
 thumb_func 0x803d8c4 HandleEndTurn_MonFled
-thumb_func 0x803d918
-thumb_func 0x803da80
-thumb_func 0x803daf4
+thumb_func 0x803d918 HandleEndTurn_FinishBattle
+thumb_func 0x803da80 FreeResetData_ReturnToOvOrDoEvolutions
+thumb_func 0x803daf4 TryEvolvePokemon
 thumb_func 0x803db88 WaitForEvoSceneToFinish
-thumb_func 0x803dbb0
-thumb_func 0x803dc58
+thumb_func 0x803dbb0 ReturnFromBattleToOverworld
+thumb_func 0x803dc58 RunBattleScriptCommands_PopCallbacksStack
 thumb_func 0x803dccc
-thumb_func 0x803dcf8
+thumb_func 0x803dcf8 HandleAction_UseMove
 thumb_func 0x803e4a8 HandleAction_Switch
-thumb_func 0x803e54c
-thumb_func 0x803e860
-thumb_func 0x803ea88
+thumb_func 0x803e54c HandleAction_UseItem
+thumb_func 0x803e860 TryRunFromBattle
+thumb_func 0x803ea88 HandleAction_Run
 thumb_func 0x803ebe8 HandleAction_WatchesCarefully
 thumb_func 0x803ec30 HandleAction_SafariZoneBallThrow
-thumb_func 0x803ec90
-thumb_func 0x803ed60
-thumb_func 0x803ee30
+thumb_func 0x803ec90 HandleAction_ThrowPokeblock
+thumb_func 0x803ed60 HandleAction_GoNear
+thumb_func 0x803ee30 HandleAction_SafariZoneRun
 thumb_func 0x803ee6c HandleAction_WallyBallThrow
 thumb_func 0x803eee4 HandleAction_TryFinish
 thumb_func 0x803ef0c HandleAction_NothingIsFainted
-thumb_func 0x803ef40
-thumb_func 0x803f00c
-thumb_func 0x803f0c0
-thumb_func 0x803f188
-thumb_func 0x803f2bc
-thumb_func 0x803f3d0
-thumb_func 0x803f440
+thumb_func 0x803ef40 HandleAction_ActionFinished
+thumb_func 0x803f00c GetBattlerForBattleScript
+thumb_func 0x803f0c0 PressurePPLose
+thumb_func 0x803f188 PressurePPLoseOnUsingImprison
+thumb_func 0x803f2bc PressurePPLoseOnUsingPerishSong
+thumb_func 0x803f3d0 MarkAllBattlersForControllerExec
+thumb_func 0x803f440 MarkBattlerForControllerExec
 thumb_func 0x803f490
 thumb_func 0x803f4e0 CancelMultiTurnMoves
-thumb_func 0x803f54c
-thumb_func 0x803f5a4
+thumb_func 0x803f54c WasUnableToUseMove
+thumb_func 0x803f5a4 PrepareStringBattle
 thumb_func 0x803f5c8 ResetSentPokesToOpponentValue
 thumb_func 0x803f62c
 thumb_func 0x803f6b0
 thumb_func 0x803f718 BattleScriptPush
 thumb_func 0x803f73c BattleScriptPushCursor
 thumb_func 0x803f764 BattleScriptPop
-thumb_func 0x803f78c
-thumb_func 0x803fb0c
-thumb_func 0x803fd08
-thumb_func 0x803fd70
-thumb_func 0x803fe10
-thumb_func 0x8040564
-thumb_func 0x8040fa4
-thumb_func 0x8041368
+thumb_func 0x803f78c TrySetCantSelectMoveBattleScript
+thumb_func 0x803fb0c CheckMoveLimitations
+thumb_func 0x803fd08 AreAllMovesUnusable
+thumb_func 0x803fd70 GetImprisonedMovesCount
+thumb_func 0x803fe10 DoFieldEndTurnEffects
+thumb_func 0x8040564 DoBattlerEndTurnEffects
+thumb_func 0x8040fa4 HandleWishPerishSongOnTurnEnd
+thumb_func 0x8041368 HandleFaintedMonActions
 thumb_func 0x804165c TryClearRageStatuses
 thumb_func 0x80416ac
-thumb_func 0x8042034
-thumb_func 0x80422fc
-thumb_func 0x8042468
+thumb_func 0x8042034 HasNoMonsToSwitch
+thumb_func 0x80422fc CastformDataTypeChange
+thumb_func 0x8042468 AbilityBattleEffects
 thumb_func 0x8044098 BattleScriptExecute
 thumb_func 0x80440d8 BattleScriptPushCursorAndCallback
-thumb_func 0x804411c
+thumb_func 0x804411c ItemBattleEffects
 thumb_func 0x80454a8 ClearFuryCutterDestinyBondGrudge
 thumb_func 0x80454f4
-thumb_func 0x8045520
-thumb_func 0x8045884
-thumb_func 0x80458fc
-thumb_func 0x8045c3c
-thumb_func 0x8045fec
-thumb_func 0x804607c
+thumb_func 0x8045520 GetMoveTarget
+thumb_func 0x8045884 HasObedientBitSet
+thumb_func 0x80458fc IsMonDisobedient
+thumb_func 0x8045c3c atk00_attackcanceler
+thumb_func 0x8045fec JumpIfMoveFailed
+thumb_func 0x804607c atk40_jumpifaffectedbyprotect
 thumb_func 0x80460ec JumpIfMoveAffectedByProtect
-thumb_func 0x8046158
-thumb_func 0x80462a0
+thumb_func 0x8046158 AccuracyCalcHelper
+thumb_func 0x80462a0 atk01_accuracycheck
 thumb_func 0x8046628 atk02_attackstring
-thumb_func 0x804667c
-thumb_func 0x8046858
-thumb_func 0x80469cc
-thumb_func 0x8046abc
-thumb_func 0x8046ba0
-thumb_func 0x8046c78
-thumb_func 0x8046ee8
-thumb_func 0x804716c
-thumb_func 0x8047224
-thumb_func 0x80473fc
-thumb_func 0x80474f8
-thumb_func 0x8047534
-thumb_func 0x80476e4
-thumb_func 0x8047870
+thumb_func 0x804667c atk03_ppreduce
+thumb_func 0x8046858 atk04_critcalc
+thumb_func 0x80469cc atk05_damagecalc
+thumb_func 0x8046abc AI_CalcDmg
+thumb_func 0x8046ba0 ModulateDmgByType
+thumb_func 0x8046c78 atk06_typecalc
+thumb_func 0x8046ee8 CheckWonderGuardAndLevitate
+thumb_func 0x804716c ModulateDmgByType2
+thumb_func 0x8047224 TypeCalc
+thumb_func 0x80473fc AI_TypeCalc
+thumb_func 0x80474f8 Unused_ApplyRandomDmgMultiplier
+thumb_func 0x8047534 atk07_adjustnormaldamage
+thumb_func 0x80476e4 atk08_adjustnormaldamage2
+thumb_func 0x8047870 atk09_attackanimation
 thumb_func 0x8047a08
-thumb_func 0x8047a28
-thumb_func 0x8047b04
+thumb_func 0x8047a28 atk0B_healthbarupdate
+thumb_func 0x8047b04 atk0C_datahpupdate
 thumb_func 0x8047efc atk0D_critmessage
-thumb_func 0x8047f50
-thumb_func 0x8048020
+thumb_func 0x8047f50 atk0E_effectivenesssound
+thumb_func 0x8048020 atk0F_resultmessage
 thumb_func 0x80481d0 atk10_printstring
-thumb_func 0x8048210
-thumb_func 0x8048254
+thumb_func 0x8048210 atk11_printselectionstring
+thumb_func 0x8048254 atk12_waitmessage
 thumb_func 0x80482b0 atk13_printfromtable
-thumb_func 0x8048304
+thumb_func 0x8048304 atk14_printselectionstringfromtable
 thumb_func 0x8048368 GetBattlerTurnOrderNum
-thumb_func 0x80483a0
-thumb_func 0x8049614
-thumb_func 0x8049700
-thumb_func 0x8049710
-thumb_func 0x8049720
-thumb_func 0x804979c
-thumb_func 0x8049a80
-thumb_func 0x8049abc
-thumb_func 0x8049b44
-thumb_func 0x8049bbc
-thumb_func 0x8049c34
-thumb_func 0x8049d1c
-thumb_func 0x8049d94
-thumb_func 0x8049e8c
-thumb_func 0x8049f10
-thumb_func 0x8049f6c
-thumb_func 0x804a900
+thumb_func 0x80483a0 SetMoveEffect
+thumb_func 0x8049614 atk15_seteffectwithchance
+thumb_func 0x8049700 atk16_seteffectprimary
+thumb_func 0x8049710 atk17_seteffectsecondary
+thumb_func 0x8049720 atk18_clearstatusfromeffect
+thumb_func 0x804979c atk19_tryfaintmon
+thumb_func 0x8049a80 atk1A_dofaintanimation
+thumb_func 0x8049abc atk1B_cleareffectsonfaint
+thumb_func 0x8049b44 atk1C_jumpifstatus
+thumb_func 0x8049bbc atk1D_jumpifstatus2
+thumb_func 0x8049c34 atk1E_jumpifability
+thumb_func 0x8049d1c atk1F_jumpifsideaffecting
+thumb_func 0x8049d94 atk20_jumpifstat
+thumb_func 0x8049e8c atk21_jumpifstatus3condition
+thumb_func 0x8049f10 atk22_jumpiftype
+thumb_func 0x8049f6c atk23_getexp
+thumb_func 0x804a900 atk24
 thumb_func 0x804ab60 MoveValuesCleanUp
-thumb_func 0x804aba0
-thumb_func 0x804abb8
-thumb_func 0x804abd0
+thumb_func 0x804aba0 atk25_movevaluescleanup
+thumb_func 0x804abb8 atk26_setmultihit
+thumb_func 0x804abd0 atk27_decrementmultihit
 thumb_func 0x804ac18 atk28_goto
-thumb_func 0x804ac38
-thumb_func 0x804acd8
-thumb_func 0x804ad80
-thumb_func 0x804ae34
-thumb_func 0x804aebc
+thumb_func 0x804ac38 atk29_jumpifbyte
+thumb_func 0x804acd8 atk2A_jumpifhalfword
+thumb_func 0x804ad80 atk2B_jumpifword
+thumb_func 0x804ae34 atk2C_jumpifarrayequal
+thumb_func 0x804aebc atk2D_jumpifarraynotequal
 thumb_func 0x804af40 atk2E_setbyte
 thumb_func 0x804af68 atk2F_addbyte
 thumb_func 0x804af94 atk30_subbyte
@@ -2004,234 +2004,234 @@ thumb_func 0x804b154 atk37_bichalfword
 thumb_func 0x804b18c atk38_bicword
 thumb_func 0x804b1d0 atk39_pause
 thumb_func 0x804b210
-thumb_func 0x804b230
-thumb_func 0x804b288
-thumb_func 0x804b294
-thumb_func 0x804b2d4
-thumb_func 0x804b2ec
-thumb_func 0x804b328
-thumb_func 0x804b358
-thumb_func 0x804b3b4
-thumb_func 0x804b400
-thumb_func 0x804b41c
-thumb_func 0x804b4e0
-thumb_func 0x804b5ac
-thumb_func 0x804b608
-thumb_func 0x804b7fc
-thumb_func 0x804c224
-thumb_func 0x804c474
-thumb_func 0x804c4c4
-thumb_func 0x804c534
-thumb_func 0x804c718
-thumb_func 0x804c7e0
+thumb_func 0x804b230 atk3B_healthbar_update
+thumb_func 0x804b288 atk3C_return
+thumb_func 0x804b294 atk3D_end
+thumb_func 0x804b2d4 atk3E_end2
+thumb_func 0x804b2ec atk3F_end3
+thumb_func 0x804b328 atk41_call
+thumb_func 0x804b358 atk42_jumpiftype2
+thumb_func 0x804b3b4 atk43_jumpifabilitypresent
+thumb_func 0x804b400 atk44_endselectionscript
+thumb_func 0x804b41c atk45_playanimation
+thumb_func 0x804b4e0 atk46_playanimation2
+thumb_func 0x804b5ac atk47_setgraphicalstatchangevalues
+thumb_func 0x804b608 atk48_playstatchangeanimation
+thumb_func 0x804b7fc atk49_moveend
+thumb_func 0x804c224 atk4A_typecalc2
+thumb_func 0x804c474 atk4B_returnatktoball
+thumb_func 0x804c4c4 atk4C_getswitchedmondata
+thumb_func 0x804c534 atk4D_switchindataupdate
+thumb_func 0x804c718 atk4E_switchinanim
+thumb_func 0x804c7e0 atk4F_jumpifcantswitch
 thumb_func 0x804cb40
 thumb_func 0x804cbb8
-thumb_func 0x804d450
-thumb_func 0x804d6dc
+thumb_func 0x804d450 atk51_switchhandleorder
+thumb_func 0x804d6dc atk52_switchineffects
 thumb_func 0x804d9d8
-thumb_func 0x804da08
-thumb_func 0x804da44
-thumb_func 0x804da80
+thumb_func 0x804da08 atk54_playse
+thumb_func 0x804da44 atk55_fanfare
+thumb_func 0x804da80 atk56_playfaintcry
 thumb_func 0x804dab0
-thumb_func 0x804dae8
-thumb_func 0x804db1c
-thumb_func 0x804dc68
-thumb_func 0x804dff8
-thumb_func 0x804e138
-thumb_func 0x804e1c8
-thumb_func 0x804e2f0
-thumb_func 0x804e37c
-thumb_func 0x804e430
-thumb_func 0x804e480
-thumb_func 0x804e4b0
-thumb_func 0x804e578
-thumb_func 0x804e5a8
-thumb_func 0x804e60c
-thumb_func 0x804e69c
-thumb_func 0x804e744
-thumb_func 0x804e7d8
+thumb_func 0x804dae8 atk58_returntoball
+thumb_func 0x804db1c atk59_handlelearnnewmove
+thumb_func 0x804dc68 atk5A_yesnoboxlearnmove
+thumb_func 0x804dff8 RegionMap_GetMarineCaveCoords
+thumb_func 0x804e138 atk5C_hitanimation
+thumb_func 0x804e1c8 RubyBattleTowerRecordToEmerald
+thumb_func 0x804e2f0 atk5D_getmoneyreward
+thumb_func 0x804e37c atk5E
+thumb_func 0x804e430 atk5F_swapattackerwithtarget
+thumb_func 0x804e480 atk60_incrementgamestat
+thumb_func 0x804e4b0 atk61_drawpartystatussummary
+thumb_func 0x804e578 atk62_hidepartystatussummary
+thumb_func 0x804e5a8 atk63_jumptocalledmove
+thumb_func 0x804e60c atk64_statusanimation
+thumb_func 0x804e69c atk65_status2animation
+thumb_func 0x804e744 atk66_chosenstatusanimation
+thumb_func 0x804e7d8 atk67_yesnobox
 thumb_func 0x804e8bc atk68_cancelallactions
-thumb_func 0x804e8f4
-thumb_func 0x804ea70
+thumb_func 0x804e8f4 atk69_adjustsetdamage
+thumb_func 0x804ea70 atk6A_removeitem
 thumb_func 0x804eae0 atk6B_atknameinbuff1
-thumb_func 0x804eb1c
-thumb_func 0x804ed18
-thumb_func 0x804ed5c
+thumb_func 0x804eb1c atk6C_drawlvlupbox
+thumb_func 0x804ed18 DrawLevelUpWindow1
+thumb_func 0x804ed5c DrawLevelUpWindow2
 thumb_func 0x804ed94
 thumb_func 0x804ede4
-thumb_func 0x804ee38
+thumb_func 0x804ee38 PutLevelAndGenderOnLvlUpBox
 thumb_func 0x804ef50
-thumb_func 0x804ef90
-thumb_func 0x804f05c
-thumb_func 0x804f0a4
-thumb_func 0x804f0e0
-thumb_func 0x804f0f8
-thumb_func 0x804f118
-thumb_func 0x804f14c
+thumb_func 0x804ef90 PutMonIconOnLvlUpBox
+thumb_func 0x804f05c SpriteCB_MonIconOnLvlUpBox
+thumb_func 0x804f0a4 IsMonGettingExpSentOut
+thumb_func 0x804f0e0 atk6D_resetsentmonsvalue
+thumb_func 0x804f0f8 atk6E_setatktoplayer0
+thumb_func 0x804f118 atk6F_makevisible
+thumb_func 0x804f14c atk70_recordlastability
 thumb_func 0x804f180 BufferMoveToLearnIntoBattleTextBuff2
-thumb_func 0x804f1a8
-thumb_func 0x804f1c0
-thumb_func 0x804f204
-thumb_func 0x804f2b0
-thumb_func 0x804f360
-thumb_func 0x804f3b8
-thumb_func 0x804f998
-thumb_func 0x804fad4
-thumb_func 0x804fbf0
-thumb_func 0x804fc50
-thumb_func 0x804fcf4
-thumb_func 0x804fd70
-thumb_func 0x804fed8
-thumb_func 0x804ff2c
-thumb_func 0x804fff8
-thumb_func 0x80500b8
-thumb_func 0x8050138
-thumb_func 0x8050208
-thumb_func 0x8050250
-thumb_func 0x8050260
-thumb_func 0x80502fc
-thumb_func 0x8050378
-thumb_func 0x80503f4
-thumb_func 0x8050514
+thumb_func 0x804f1a8 atk71_buffermovetolearn
+thumb_func 0x804f1c0 atk72_jumpifplayerran
+thumb_func 0x804f204 atk73_hpthresholds
+thumb_func 0x804f2b0 atk74_hpthresholds2
+thumb_func 0x804f360 atk75_useitemonopponent
+thumb_func 0x804f3b8 atk76_various
+thumb_func 0x804f998 atk77_setprotectlike
+thumb_func 0x804fad4 atk78_faintifabilitynotdamp
+thumb_func 0x804fbf0 atk79_setatkhptozero
+thumb_func 0x804fc50 atk7A_jumpifnexttargetvalid
+thumb_func 0x804fcf4 atk7B_tryhealhalfhealth
+thumb_func 0x804fd70 atk7C_trymirrormove
+thumb_func 0x804fed8 atk7D_setrain
+thumb_func 0x804ff2c atk7E_setreflect
+thumb_func 0x804fff8 atk7F_setseeded
+thumb_func 0x80500b8 atk80_manipulatedamage
+thumb_func 0x8050138 atk81_trysetrest
+thumb_func 0x8050208 atk82_jumpifnotfirstturn
+thumb_func 0x8050250 atk83_nop
+thumb_func 0x8050260 UproarWakeUpCheck
+thumb_func 0x80502fc atk84_jumpifcantmakeasleep
+thumb_func 0x8050378 atk85_stockpile
+thumb_func 0x80503f4 atk86_stockpiletobasedamage
+thumb_func 0x8050514 atk87_stockpiletohpheal
 thumb_func 0x80505f8 atk88_negativedamage
-thumb_func 0x805062c
+thumb_func 0x805062c ChangeStatBuffs
 thumb_func 0x8050ab0 atk89_statbuffchange
 thumb_func 0x8050afc atk8A_normalisebuffs
 thumb_func 0x8050b50 atk8B_setbide
 thumb_func 0x8050bc0 atk8C_confuseifrepeatingattackends
-thumb_func 0x8050c00
+thumb_func 0x8050c00 atk8D_setmultihitcounter
 thumb_func 0x8050c4c atk8E_initmultihitstring
-thumb_func 0x8050c74
-thumb_func 0x8050d3c
-thumb_func 0x8051034
-thumb_func 0x80511d8
-thumb_func 0x8051274
-thumb_func 0x8051340
+thumb_func 0x8050c74 TryDoForceSwitchOut
+thumb_func 0x8050d3c atk8F_forcerandomswitch
+thumb_func 0x8051034 atk90_tryconversiontypechange
+thumb_func 0x80511d8 atk91_givepaydaymoney
+thumb_func 0x8051274 atk92_setlightscreen
+thumb_func 0x8051340 atk93_tryKO
 thumb_func 0x8051694 atk94_damagetohalftargethp
-thumb_func 0x80516d0
-thumb_func 0x8051728
-thumb_func 0x80518a0
-thumb_func 0x8051a58
-thumb_func 0x8051b68
-thumb_func 0x8051c10
-thumb_func 0x8051c6c
-thumb_func 0x8051e0c
+thumb_func 0x80516d0 atk95_setsandstorm
+thumb_func 0x8051728 atk96_weatherdamage
+thumb_func 0x80518a0 atk97_tryinfatuating
+thumb_func 0x8051a58 atk98_updatestatusicon
+thumb_func 0x8051b68 atk99_setmist
+thumb_func 0x8051c10 atk9A_setfocusenergy
+thumb_func 0x8051c6c atk9B_transformdataexecution
+thumb_func 0x8051e0c atk9C_setsubstitute
 thumb_func 0x8051ec8 IsMoveUncopyableByMimic
-thumb_func 0x8051f10
-thumb_func 0x80520ec
+thumb_func 0x8051f10 atk9D_mimicattackcopy
+thumb_func 0x80520ec atk9E_metronome
 thumb_func 0x8052194 atk9F_dmgtolevel
-thumb_func 0x80521c4
-thumb_func 0x8052218
-thumb_func 0x8052310
-thumb_func 0x8052408
-thumb_func 0x805254c
-thumb_func 0x8052680
-thumb_func 0x8052744
+thumb_func 0x80521c4 atkA0_psywavedamageeffect
+thumb_func 0x8052218 atkA1_counterdamagecalculator
+thumb_func 0x8052310 atkA2_mirrorcoatdamagecalculator
+thumb_func 0x8052408 atkA3_disablelastusedattack
+thumb_func 0x805254c atkA4_trysetencore
+thumb_func 0x8052680 atkA5_painsplitdmgcalc
+thumb_func 0x8052744 atkA6_settypetorandomresistance
 thumb_func 0x8052944 atkA7_setalwayshitflag
-thumb_func 0x805299c
-thumb_func 0x8052b58
+thumb_func 0x805299c atkA8_copymovepermanently
+thumb_func 0x8052b58 IsTwoTurnsMove
 thumb_func 0x8052b94 IsInvalidForSleepTalkOrAssist
-thumb_func 0x8052bbc
-thumb_func 0x8052c28
+thumb_func 0x8052bbc AttacksThisTurn
+thumb_func 0x8052c28 atkA9_trychoosesleeptalkmove
 thumb_func 0x8052d60 atkAA_setdestinybond
-thumb_func 0x8052d90
-thumb_func 0x8052df0
-thumb_func 0x8052e08
-thumb_func 0x8052e70
-thumb_func 0x8053048
-thumb_func 0x805332c
-thumb_func 0x80533b0
+thumb_func 0x8052d90 TrySetDestinyBondToHappen
+thumb_func 0x8052df0 atkAB_trysetdestinybondtohappen
+thumb_func 0x8052e08 atkAC_remaininghptopower
+thumb_func 0x8052e70 atkAD_tryspiteppreduce
+thumb_func 0x8053048 atkAE_healpartystatus
+thumb_func 0x805332c atkAF_cursetarget
+thumb_func 0x80533b0 atkB0_trysetspikes
 thumb_func 0x805343c atkB1_setforesight
-thumb_func 0x805346c
-thumb_func 0x8053524
-thumb_func 0x80536a0
-thumb_func 0x8053708
-thumb_func 0x80537bc
-thumb_func 0x8053840
-thumb_func 0x805390c
-thumb_func 0x80539b4
-thumb_func 0x8053ad8
-thumb_func 0x8053c6c
-thumb_func 0x8053cc4
+thumb_func 0x805346c atkB2_trysetperishsong
+thumb_func 0x8053524 atkB3_rolloutdamagecalculation
+thumb_func 0x80536a0 atkB4_jumpifconfusedandstatmaxed
+thumb_func 0x8053708 atkB5_furycuttercalc
+thumb_func 0x80537bc atkB6_happinesstodamagecalculation
+thumb_func 0x8053840 atkB7_presentdamagecalculation
+thumb_func 0x805390c atkB8_setsafeguard
+thumb_func 0x80539b4 atkB9_magnitudedamagecalculation
+thumb_func 0x8053ad8 atkBA_jumpifnopursuitswitchdmg
+thumb_func 0x8053c6c atkBB_setsunny
+thumb_func 0x8053cc4 atkBC_maxattackhalvehp
 thumb_func 0x8053d44 atkBD_copyfoestats
-thumb_func 0x8053d8c
+thumb_func 0x8053d8c atkBE_rapidspinfree
 thumb_func 0x8053ed8 atkBF_setdefensecurlbit
-thumb_func 0x8053f08
-thumb_func 0x8054010
+thumb_func 0x8053f08 atkC0_recoverbasedonsunlight
+thumb_func 0x8054010 atkC1_hiddenpowercalc
 thumb_func 0x8054134 atkC2_selectfirstvalidtarget
-thumb_func 0x80541a8
-thumb_func 0x80542f4
-thumb_func 0x8054504
-thumb_func 0x8054588
+thumb_func 0x80541a8 atkC3_trysetfutureattack
+thumb_func 0x80542f4 atkC4_trydobeatup
+thumb_func 0x8054504 atkC5_setsemiinvulnerablebit
+thumb_func 0x8054588 atkC6_clearsemiinvulnerablebit
 thumb_func 0x8054618 atkC7_setminimize
-thumb_func 0x8054658
-thumb_func 0x80546b0
-thumb_func 0x805474c
+thumb_func 0x8054658 atkC8_sethail
+thumb_func 0x80546b0 atkC9_jumpifattackandspecialattackcannotfall
+thumb_func 0x805474c atkCA_setforcedtarget
 thumb_func 0x8054798 atkCB_setcharge
-thumb_func 0x80547fc
-thumb_func 0x8054870
-thumb_func 0x80548f4
-thumb_func 0x805494c
-thumb_func 0x80549a8
-thumb_func 0x8054a1c
-thumb_func 0x8054ac4
-thumb_func 0x8054d58
-thumb_func 0x8054dd0
-thumb_func 0x8054ea4
+thumb_func 0x80547fc atkCC_callterrainattack
+thumb_func 0x8054870 atkCD_cureifburnedparalysedorpoisoned
+thumb_func 0x80548f4 atkCE_settorment
+thumb_func 0x805494c atkCF_jumpifnodamage
+thumb_func 0x80549a8 atkD0_settaunt
+thumb_func 0x8054a1c atkD1_trysethelpinghand
+thumb_func 0x8054ac4 atkD2_tryswapitems
+thumb_func 0x8054d58 atkD3_trycopyability
+thumb_func 0x8054dd0 atkD4_trywish
+thumb_func 0x8054ea4 atkD5_trysetroots
 thumb_func 0x8054efc atkD6_doubledamagedealtifdamaged
-thumb_func 0x8054f5c
-thumb_func 0x8054fcc
-thumb_func 0x8055038
-thumb_func 0x805509c
-thumb_func 0x8055134
-thumb_func 0x805523c
-thumb_func 0x8055294
-thumb_func 0x805532c
-thumb_func 0x80554ac
-thumb_func 0x8055530
-thumb_func 0x80555ac
-thumb_func 0x8055688
-thumb_func 0x8055704
-thumb_func 0x8055758
-thumb_func 0x8055810
-thumb_func 0x8055a0c
-thumb_func 0x8055a74
-thumb_func 0x8055ab4
-thumb_func 0x8055b6c
-thumb_func 0x8055c24
-thumb_func 0x8055ccc
-thumb_func 0x8055d7c
-thumb_func 0x8055e40
-thumb_func 0x8055e94
-thumb_func 0x8055f10
-thumb_func 0x80562b8
-thumb_func 0x8056460
-thumb_func 0x80564dc
-thumb_func 0x805664c
-thumb_func 0x8056784
-thumb_func 0x80567bc
-thumb_func 0x80567fc
+thumb_func 0x8054f5c atkD7_setyawn
+thumb_func 0x8054fcc atkD8_setdamagetohealthdifference
+thumb_func 0x8055038 atkD9_scaledamagebyhealthratio
+thumb_func 0x805509c atkDA_tryswapabilities
+thumb_func 0x8055134 atkDB_tryimprison
+thumb_func 0x805523c atkDC_trysetgrudge
+thumb_func 0x8055294 atkDD_weightdamagecalculation
+thumb_func 0x805532c atkDE_assistattackselect
+thumb_func 0x80554ac atkDF_trysetmagiccoat
+thumb_func 0x8055530 atkE0_trysetsnatch
+thumb_func 0x80555ac atkE1_trygetintimidatetarget
+thumb_func 0x8055688 atkE2_switchoutabilities
+thumb_func 0x8055704 atkE3_jumpifhasnohp
+thumb_func 0x8055758 atkE4_getsecretpowereffect
+thumb_func 0x8055810 atkE5_pickup
+thumb_func 0x8055a0c atkE6_docastformchangeanimation
+thumb_func 0x8055a74 atkE7_trycastformdatachange
+thumb_func 0x8055ab4 atkE8_settypebasedhalvers
+thumb_func 0x8055b6c atkE9_setweatherballtype
+thumb_func 0x8055c24 atkEA_tryrecycleitem
+thumb_func 0x8055ccc atkEB_settypetoterrain
+thumb_func 0x8055d7c atkEC_pursuitrelated
+thumb_func 0x8055e40 atkEF_snatchsetbattlers
+thumb_func 0x8055e94 atkEE_removelightscreenreflect
+thumb_func 0x8055f10 atkEF_handleballthrow
+thumb_func 0x80562b8 atkF0_givecaughtmon
+thumb_func 0x8056460 atkF1_trysetcaughtmondexflags
+thumb_func 0x80564dc atkF2_displaydexinfo
+thumb_func 0x805664c HandleBattleWindow
+thumb_func 0x8056784 BattleCreateYesNoCursorAt
+thumb_func 0x80567bc BattleDestroyYesNoCursorAt
+thumb_func 0x80567fc atkF3_trygivecaughtmonnick
 thumb_func 0x8056a88 atkF4_subattackerhpbydmg
 thumb_func 0x8056ab8 atkF5_removeattackerstatus1
-thumb_func 0x8056ae0
-thumb_func 0x8056aec
-thumb_func 0x8056b08
-thumb_func 0x8056b38
-thumb_func 0x8056c38
-thumb_func 0x8056d04
+thumb_func 0x8056ae0 atkF6_finishaction
+thumb_func 0x8056aec atkF7_finishturn
+thumb_func 0x8056b08 atkF8_trainerslideout
+thumb_func 0x8056b38 AllocateBattleResources
+thumb_func 0x8056c38 FreeBattleResources
+thumb_func 0x8056d04 AdjustFriendshipOnBattleFaint
 thumb_func 0x8056dec
 thumb_func 0x8056e6c
 thumb_func 0x8057068 nullsub_401
 thumb_func 0x805706c SetControllerToPlayer
-thumb_func 0x805709c
+thumb_func 0x805709c PlayerBufferExecCompleted
 thumb_func 0x8057114
 thumb_func 0x8057164 CompleteOnBankSpritePosX_0
 thumb_func 0x8057198
 thumb_func 0x8057400
-thumb_func 0x8057434
-thumb_func 0x805780c
+thumb_func 0x8057434 HandleInputChooseTarget
+thumb_func 0x805780c HandleInputChooseMove
 thumb_func 0x8057bcc
-thumb_func 0x8057d48
+thumb_func 0x8057d48 HandleMoveSwitching
 thumb_func 0x8058308
 thumb_func 0x80583c0
 thumb_func 0x8058454
@@ -2247,158 +2247,158 @@ thumb_func 0x8058d10
 thumb_func 0x8058d40
 thumb_func 0x8058db0
 thumb_func 0x8058dc8
-thumb_func 0x8058f40
+thumb_func 0x8058f40 Task_PrepareToGiveExpWithExpBar
 thumb_func 0x8059010
-thumb_func 0x8059154
-thumb_func 0x80591b4
-thumb_func 0x805926c
+thumb_func 0x8059154 Task_LaunchLvlUpAnim
+thumb_func 0x80591b4 Task_UpdateLvlInHealthbox
+thumb_func 0x805926c DestroyExpTaskAndCompleteOnInactiveTextPrinter
 thumb_func 0x80592b8
 thumb_func 0x8059354
 thumb_func 0x80593c4
-thumb_func 0x80593dc
-thumb_func 0x8059438
-thumb_func 0x80594b4
-thumb_func 0x80594f0
+thumb_func 0x80593dc OpenPartyMenuToChooseMon
+thumb_func 0x8059438 WaitForMonSelection
+thumb_func 0x80594b4 OpenBagAndChooseItem
+thumb_func 0x80594f0 CompleteWhenChoseItem
 thumb_func 0x805952c
 thumb_func 0x8059568
-thumb_func 0x80595e4
+thumb_func 0x80595e4 PlayerHandleUnknownYesNoInput
 thumb_func 0x80596bc
 thumb_func 0x8059734
-thumb_func 0x805976c
+thumb_func 0x805976c MoveSelectionDisplayPpNumber
 thumb_func 0x80597e0
-thumb_func 0x805983c
+thumb_func 0x805983c MoveSelectionCreateCursorAt
 thumb_func 0x8059884
-thumb_func 0x80598c8
-thumb_func 0x8059910
+thumb_func 0x80598c8 ActionSelectionCreateCursorAt
+thumb_func 0x8059910 MoveSelectionDestroyCursorAt
 thumb_func 0x805995c
 thumb_func 0x805996c
 thumb_func 0x805997c
 thumb_func 0x80599ac
-thumb_func 0x80599dc
+thumb_func 0x80599dc PrintLinkStandbyMsg
 thumb_func 0x8059a10
-thumb_func 0x8059a84
-thumb_func 0x805a230
+thumb_func 0x8059a84 CopyPlayerMonData
+thumb_func 0x805a230 PlayerHandleGetRawMonData
 thumb_func 0x805a2b8
-thumb_func 0x805a310
-thumb_func 0x805ad0c
+thumb_func 0x805a310 SetPlayerMonData
+thumb_func 0x805ad0c PlayerHandleSetRawMonData
 thumb_func 0x805ad80 PlayerHandleLoadMonSprite
 thumb_func 0x805ade8 PlayerHandleSwitchInAnim
 thumb_func 0x805ae74
-thumb_func 0x805aff0
+thumb_func 0x805aff0 PlayerHandleReturnMonToBall
 thumb_func 0x805b080
-thumb_func 0x805b10c
-thumb_func 0x805b480
-thumb_func 0x805b614
-thumb_func 0x805b6d4
-thumb_func 0x805b7c0
-thumb_func 0x805b7e0
-thumb_func 0x805b834
-thumb_func 0x805b894
-thumb_func 0x805b8c4
+thumb_func 0x805b10c PlayerHandleDrawTrainerPic
+thumb_func 0x805b480 PlayerHandleTrainerSlide
+thumb_func 0x805b614 PlayerHandleTrainerSlideBack
+thumb_func 0x805b6d4 PlayerHandleFaintAnimation
+thumb_func 0x805b7c0 PlayerHandlePaletteFade
+thumb_func 0x805b7e0 PlayerHandleSuccessBallThrowAnim
+thumb_func 0x805b834 PlayerHandleBallThrowAnim
+thumb_func 0x805b894 PlayerHandlePause
+thumb_func 0x805b8c4 PlayerHandleMoveAnimation
 thumb_func 0x805ba18
-thumb_func 0x805bb9c
-thumb_func 0x805bbfc
+thumb_func 0x805bb9c PlayerHandlePrintString
+thumb_func 0x805bbfc PlayerHandlePrintSelectionString
 thumb_func 0x805bc20
-thumb_func 0x805bc60
-thumb_func 0x805bccc
-thumb_func 0x805bd30
-thumb_func 0x805bd74
-thumb_func 0x805bdc4
-thumb_func 0x805be2c
-thumb_func 0x805be64
-thumb_func 0x805bec8
-thumb_func 0x805c008
-thumb_func 0x805c02c
-thumb_func 0x805c144
-thumb_func 0x805c1e0
+thumb_func 0x805bc60 PlayerHandleChooseAction
+thumb_func 0x805bccc PlayerHandleUnknownYesNoBox
+thumb_func 0x805bd30 HandleChooseMoveAfterDma3
+thumb_func 0x805bd74 PlayerChooseMoveInBattlePalace
+thumb_func 0x805bdc4 PlayerHandleChooseMove
+thumb_func 0x805be2c InitMoveSelectionsVarsAndStrings
+thumb_func 0x805be64 PlayerHandleChooseItem
+thumb_func 0x805bec8 PlayerHandleChoosePokemon
+thumb_func 0x805c008 PlayerHandleCmd23
+thumb_func 0x805c02c PlayerHandleHealthBarUpdate
+thumb_func 0x805c144 PlayerHandleExpUpdate
+thumb_func 0x805c1e0 PlayerHandleStatusIconUpdate
 thumb_func 0x805c258 PlayerHandleStatusAnimation
-thumb_func 0x805c2c0
+thumb_func 0x805c2c0 PlayerHandleStatusXor
 thumb_func 0x805c32c
-thumb_func 0x805c338
-thumb_func 0x805c3ec
-thumb_func 0x805c41c
+thumb_func 0x805c338 PlayerHandleDMA3Transfer
+thumb_func 0x805c3ec PlayerHandlePlayBGM
+thumb_func 0x805c41c ScrCmd_choosecontestmon
 thumb_func 0x805c428
 thumb_func 0x805c43c
 thumb_func 0x805c450
 thumb_func 0x805c464
 thumb_func 0x805c478
-thumb_func 0x805c494
-thumb_func 0x805c4cc
-thumb_func 0x805c4e4
+thumb_func 0x805c494 PlayerHandleCmd38
+thumb_func 0x805c4cc PlayerHandleCmd39
+thumb_func 0x805c4e4 PlayerHandleCmd40
 thumb_func 0x805c50c
 thumb_func 0x805c57c
-thumb_func 0x805c588
-thumb_func 0x805c5cc
-thumb_func 0x805c628
+thumb_func 0x805c588 PlayerHandlePlaySE
+thumb_func 0x805c5cc PlayerHandlePlayFanfareOrBGM
+thumb_func 0x805c628 PlayerHandleFaintingCry
 thumb_func 0x805c668
-thumb_func 0x805c69c
+thumb_func 0x805c69c PlayerHandleIntroTrainerBallThrow
 thumb_func 0x805c81c
-thumb_func 0x805c884
-thumb_func 0x805c990
+thumb_func 0x805c884 task05_08033660
+thumb_func 0x805c990 PlayerHandleDrawPartyStatusSummary
 thumb_func 0x805ca54
-thumb_func 0x805ca9c
-thumb_func 0x805caec
-thumb_func 0x805cb10
-thumb_func 0x805cb70
-thumb_func 0x805cbe4
-thumb_func 0x805cc48
-thumb_func 0x805ccb0
+thumb_func 0x805ca9c PlayerHandleHidePartyStatusSummary
+thumb_func 0x805caec PlayerHandleEndBounceEffect
+thumb_func 0x805cb10 PlayerHandleSpriteInvisibility
+thumb_func 0x805cb70 PlayerHandleBattleAnimation
+thumb_func 0x805cbe4 PlayerHandleLinkStandbyMsg
+thumb_func 0x805cc48 PlayerHandleResetActionMoveSelection
+thumb_func 0x805ccb0 PlayerHandleCmd55
 thumb_func 0x805cd30 nullsub_41
-thumb_func 0x805cd34
-thumb_func 0x805cd74
-thumb_func 0x805cdb8
+thumb_func 0x805cd34 GetSecretBaseMapName
+thumb_func 0x805cd74 FreeBattleSpritesData
+thumb_func 0x805cdb8 ChooseMoveAndTargetInBattlePalace
 thumb_func 0x805d0c4
-thumb_func 0x805d210
+thumb_func 0x805d210 BattlePalaceGetTargetRetValue
 thumb_func 0x805d330
 thumb_func 0x805d38c
 thumb_func 0x805d3c8
 thumb_func 0x805d408
-thumb_func 0x805d424
-thumb_func 0x805d524
+thumb_func 0x805d424 InitAndLaunchChosenStatusAnimation
+thumb_func 0x805d524 TryHandleLaunchBattleTableAnimation
 thumb_func 0x805d664
 thumb_func 0x805d674
 thumb_func 0x805d6bc ShouldAnimBeDoneRegardlessOfSubsitute
-thumb_func 0x805d6e0
+thumb_func 0x805d6e0 InitAndLaunchSpecialAnimation
 thumb_func 0x805d750
 thumb_func 0x805d760
 thumb_func 0x805d7a8
-thumb_func 0x805d7ac
-thumb_func 0x805d828
-thumb_func 0x805d998
+thumb_func 0x805d7ac mplay_80342A4
+thumb_func 0x805d828 BattleLoadOpponentMonSpriteGfx
+thumb_func 0x805d998 BattleLoadPlayerMonSpriteGfx
 thumb_func 0x805db4c nullsub_40
 thumb_func 0x805db50 nullsub_9
-thumb_func 0x805db54
-thumb_func 0x805dba0
+thumb_func 0x805db54 DecompressTrainerFrontPic
+thumb_func 0x805dba0 DecompressTrainerBackPic
 thumb_func 0x805dbfc nullsub_8
-thumb_func 0x805dc00
-thumb_func 0x805dc18
-thumb_func 0x805dca8
-thumb_func 0x805ddd4
-thumb_func 0x805ddf4
-thumb_func 0x805df6c
-thumb_func 0x805df94
+thumb_func 0x805dc00 FreeTrainerFrontPicPalette
+thumb_func 0x805dc18 BattleLoadAllHealthBoxesGfxAtOnce
+thumb_func 0x805dca8 BattleLoadAllHealthBoxesGfx
+thumb_func 0x805ddd4 LoadBattleBarGfx
+thumb_func 0x805ddf4 BattleInitAllSprites
+thumb_func 0x805df6c ClearSpritesHealthboxAnimData
+thumb_func 0x805df94 ClearSpritesBattlerHealthboxAnimData
 thumb_func 0x805dfb0 CopyAllBattleSpritesInvisibilities
 thumb_func 0x805e024 CopyBattleSpriteInvisibility
-thumb_func 0x805e064
+thumb_func 0x805e064 HandleSpeciesGfxDataChange
 thumb_func 0x805e3f8
-thumb_func 0x805e510
+thumb_func 0x805e510 LoadBattleMonGfxAndAnimate
 thumb_func 0x805e568 TrySetBehindSubstituteSpriteBit
 thumb_func 0x805e590 ClearBehindSubstituteBit
-thumb_func 0x805e5ac
-thumb_func 0x805e67c
-thumb_func 0x805e6d0
-thumb_func 0x805e704
+thumb_func 0x805e5ac HandleLowHpMusicChange
+thumb_func 0x805e67c BattleStopLowHpSound
+thumb_func 0x805e6d0 GetMonHPBarLevel
+thumb_func 0x805e704 HandleBattleLowHpMusicChange
 thumb_func 0x805e7b8
-thumb_func 0x805e8a0
-thumb_func 0x805e98c
+thumb_func 0x805e8a0 LoadAndCreateEnemyShadowSprites
+thumb_func 0x805e98c SpriteCB_EnemyShadow
 thumb_func 0x805ea64
-thumb_func 0x805ea70
+thumb_func 0x805ea70 SetBattlerShadowSpriteCallback
 thumb_func 0x805eafc HideBattlerShadowSprite
 thumb_func 0x805eb30
 thumb_func 0x805eba0 ClearTemporarySpeciesSpriteData
-thumb_func 0x805ebd8
-thumb_func 0x805ecb0
-thumb_func 0x805ed2c
+thumb_func 0x805ebd8 AllocateMonSpritesGfx
+thumb_func 0x805ecb0 FreeMonSpritesGfx
+thumb_func 0x805ed2c ShouldPlayNormalMonCry
 thumb_func 0x805ed7c nullsub_18
 thumb_func 0x805ed80
 thumb_func 0x805ed9c
@@ -2420,47 +2420,47 @@ thumb_func 0x805f8ec
 thumb_func 0x805f9dc
 thumb_func 0x805faa4
 thumb_func 0x805fad4
-thumb_func 0x805fb04
-thumb_func 0x805fb7c
+thumb_func 0x805fb04 OpponentBufferExecCompleted
+thumb_func 0x805fb7c OpponentHandleGetMonData
 thumb_func 0x805fbf0
-thumb_func 0x806039c
+thumb_func 0x806039c OpponentHandleGetRawMonData
 thumb_func 0x8060424
-thumb_func 0x806047c
+thumb_func 0x806047c SetOpponentMonData
 thumb_func 0x8060d9c OpponentHandleSetRawMonData
-thumb_func 0x8060e10
+thumb_func 0x8060e10 OpponentHandleLoadMonSprite
 thumb_func 0x8060f68 OpponentHandleSwitchInAnim
 thumb_func 0x8060fc8
-thumb_func 0x8061158
+thumb_func 0x8061158 OpponentHandleReturnMonToBall
 thumb_func 0x80611f0
-thumb_func 0x806127c
+thumb_func 0x806127c OpponentHandleDrawTrainerPic
 thumb_func 0x80614c0
-thumb_func 0x80616d4
+thumb_func 0x80616d4 OpponentHandleTrainerSlideBack
 thumb_func 0x8061780
-thumb_func 0x806182c
+thumb_func 0x806182c RunSaveCallback
 thumb_func 0x8061838
 thumb_func 0x8061844
 thumb_func 0x8061850
-thumb_func 0x806185c
+thumb_func 0x806185c OpponentHandleMoveAnimation
 thumb_func 0x8061994
-thumb_func 0x8061b18
+thumb_func 0x8061b18 OpponentHandlePrintString
 thumb_func 0x8061b74
-thumb_func 0x8061b80
+thumb_func 0x8061b80 OpponentHandleChooseAction
 thumb_func 0x8061b90
-thumb_func 0x8061b9c
-thumb_func 0x8061d40
-thumb_func 0x8061d6c
+thumb_func 0x8061b9c OpponentHandleChooseMove
+thumb_func 0x8061d40 OpponentHandleChooseItem
+thumb_func 0x8061d6c OpponentHandleChoosePokemon
 thumb_func 0x8061e6c
-thumb_func 0x8061e78
+thumb_func 0x8061e78 OpponentHandleHealthBarUpdate
 thumb_func 0x8061f68
-thumb_func 0x8061f74
-thumb_func 0x8061fec
+thumb_func 0x8061f74 OpponentHandleStatusIconUpdate
+thumb_func 0x8061fec OpponentHandleStatusAnimation
 thumb_func 0x8062054
 thumb_func 0x8062060
 thumb_func 0x806206c
 thumb_func 0x8062078
 thumb_func 0x8062084
-thumb_func 0x8062090
-thumb_func 0x806209c
+thumb_func 0x8062090 RfuVSync
+thumb_func 0x806209c SwapRentalMons
 thumb_func 0x80620a8
 thumb_func 0x80620b4
 thumb_func 0x80620c0
@@ -2469,9 +2469,9 @@ thumb_func 0x8062114
 thumb_func 0x806212c
 thumb_func 0x8062154
 thumb_func 0x80621c4
-thumb_func 0x80621d0
+thumb_func 0x80621d0 OpponentHandlePlaySE
 thumb_func 0x8062214
-thumb_func 0x8062270
+thumb_func 0x8062270 OpponentHandleFaintingCry
 thumb_func 0x80622ac
 thumb_func 0x80622e0
 thumb_func 0x80623f0
@@ -2480,25 +2480,25 @@ thumb_func 0x80624fc
 thumb_func 0x8062610
 thumb_func 0x8062658
 thumb_func 0x80626a8
-thumb_func 0x80626b4
-thumb_func 0x8062714
-thumb_func 0x806277c
+thumb_func 0x80626b4 OpponentHandleSpriteInvisibility
+thumb_func 0x8062714 OpponentHandleBattleAnimation
+thumb_func 0x806277c WallyHandleCmd38
 thumb_func 0x8062788
-thumb_func 0x8062794
+thumb_func 0x8062794 OpponentHandleCmd55
 thumb_func 0x80627d8 nullsub_43
-thumb_func 0x80627dc
-thumb_func 0x806283c
-thumb_func 0x8062a38
-thumb_func 0x8062ca4
-thumb_func 0x8062da0
+thumb_func 0x80627dc ShouldSwitchIfPerishSong
+thumb_func 0x806283c ShouldSwitchIfWonderGuard
+thumb_func 0x8062a38 FindMonThatAbsorbsOpponentsMove
+thumb_func 0x8062ca4 ShouldSwitchIfNaturalCure
+thumb_func 0x8062da0 HasSuperEffectiveMoveAgainstOpponents
 thumb_func 0x8062f00 AreStatsRaised
-thumb_func 0x8062f48
-thumb_func 0x80631f8
-thumb_func 0x8063464
-thumb_func 0x80635ec
-thumb_func 0x8063674
+thumb_func 0x8062f48 FindMonWithFlagsAndSuperEffective
+thumb_func 0x80631f8 ShouldSwitch
+thumb_func 0x8063464 AI_TrySwitchOrUseItem
+thumb_func 0x80635ec ModulateByTypeEffectiveness
+thumb_func 0x8063674 GetMostSuitableMonToSwitchInto
 thumb_func 0x8063a68 GetAI_ItemType
-thumb_func 0x8063ac4
+thumb_func 0x8063ac4 ShouldUseItem
 thumb_func 0x8063f74 nullsub_11
 thumb_func 0x8063f78
 thumb_func 0x8063f94
@@ -2520,223 +2520,223 @@ thumb_func 0x8064a34
 thumb_func 0x8064b24
 thumb_func 0x8064bec
 thumb_func 0x8064c1c
-thumb_func 0x8064c4c
+thumb_func 0x8064c4c LinkOpponentBufferExecCompleted
 thumb_func 0x8064cc4
-thumb_func 0x8064d38
+thumb_func 0x8064d38 CopyLinkOpponentMonData
 thumb_func 0x80654e4
 thumb_func 0x80654f0
 thumb_func 0x8065548
 thumb_func 0x8065e68
-thumb_func 0x8065edc
+thumb_func 0x8065edc LinkOpponentHandleLoadMonSprite
 thumb_func 0x806602c
 thumb_func 0x8066078
-thumb_func 0x8066208
+thumb_func 0x8066208 LinkOpponentHandleReturnMonToBall
 thumb_func 0x80662a0
-thumb_func 0x806632c
-thumb_func 0x806663c
+thumb_func 0x806632c LinkOpponentHandleDrawTrainerPic
+thumb_func 0x806663c LinkOpponentHandleTrainerSlide
 thumb_func 0x8066778
-thumb_func 0x8066824
+thumb_func 0x8066824 LinkOpponentHandleFaintAnimation
 thumb_func 0x80668d0
 thumb_func 0x80668dc
-thumb_func 0x80668e8
-thumb_func 0x80668f4
+thumb_func 0x80668e8 LinkOpponentHandleBallThrowAnim
+thumb_func 0x80668f4 LinkOpponentHandlePause
 thumb_func 0x8066900
 thumb_func 0x8066a54
-thumb_func 0x8066bd8
+thumb_func 0x8066bd8 LinkOpponentHandlePrintString
 thumb_func 0x8066c30
-thumb_func 0x8066c3c
-thumb_func 0x8066c48
-thumb_func 0x8066c54
-thumb_func 0x8066c60
-thumb_func 0x8066c6c
-thumb_func 0x8066c78
-thumb_func 0x8066c84
-thumb_func 0x8066d74
-thumb_func 0x8066d80
-thumb_func 0x8066df8
-thumb_func 0x8066e60
-thumb_func 0x8066e6c
-thumb_func 0x8066e78
-thumb_func 0x8066e84
-thumb_func 0x8066e90
-thumb_func 0x8066e9c
-thumb_func 0x8066ea8
-thumb_func 0x8066eb4
-thumb_func 0x8066ec0
+thumb_func 0x8066c3c LinkOpponentHandleChooseAction
+thumb_func 0x8066c48 LinkOpponentHandleUnknownYesNoBox
+thumb_func 0x8066c54 LinkOpponentHandleChooseMove
+thumb_func 0x8066c60 LinkOpponentHandleChooseItem
+thumb_func 0x8066c6c LinkOpponentHandleChoosePokemon
+thumb_func 0x8066c78 LinkOpponentHandleCmd23
+thumb_func 0x8066c84 LinkOpponentHandleHealthBarUpdate
+thumb_func 0x8066d74 LinkOpponentHandleExpUpdate
+thumb_func 0x8066d80 LinkOpponentHandleStatusIconUpdate
+thumb_func 0x8066df8 LinkOpponentHandleStatusAnimation
+thumb_func 0x8066e60 LinkOpponentHandleStatusXor
+thumb_func 0x8066e6c LinkOpponentHandleDataTransfer
+thumb_func 0x8066e78 LinkOpponentHandleDMA3Transfer
+thumb_func 0x8066e84 LinkOpponentHandlePlayBGM
+thumb_func 0x8066e90 LinkOpponentHandleCmd32
+thumb_func 0x8066e9c LinkOpponentHandleTwoReturnValues
+thumb_func 0x8066ea8 LinkOpponentHandleChosenMonReturnValue
+thumb_func 0x8066eb4 LinkOpponentHandleOneReturnValue
+thumb_func 0x8066ec0 LinkOpponentHandleOneReturnValue_Duplicate
 thumb_func 0x8066ecc LinkOpponentHandleCmd37
 thumb_func 0x8066ee8 LinkOpponentHandleCmd38
 thumb_func 0x8066f20 LinkOpponentHandleCmd39
 thumb_func 0x8066f38 LinkOpponentHandleCmd40
-thumb_func 0x8066f60
-thumb_func 0x8066fd0
-thumb_func 0x8066fdc
+thumb_func 0x8066f60 LinkOpponentHandleHitAnimation
+thumb_func 0x8066fd0 LinkOpponentHandleCmd42
+thumb_func 0x8066fdc LinkOpponentHandlePlaySE
 thumb_func 0x8067020
 thumb_func 0x806707c
 thumb_func 0x80670b8
-thumb_func 0x80670ec
+thumb_func 0x80670ec LinkOpponentHandleIntroTrainerBallThrow
 thumb_func 0x80671fc
 thumb_func 0x80672e0
 thumb_func 0x80672fc
 thumb_func 0x8067410
 thumb_func 0x8067458 LinkOpponentHandleHidePartyStatusSummary
-thumb_func 0x80674a8
-thumb_func 0x80674b4
-thumb_func 0x8067514
-thumb_func 0x8067588
-thumb_func 0x80675a8
-thumb_func 0x80675b4
+thumb_func 0x80674a8 LinkOpponentHandleEndBounceEffect
+thumb_func 0x80674b4 LinkOpponentHandleSpriteInvisibility
+thumb_func 0x8067514 LinkOpponentHandleBattleAnimation
+thumb_func 0x8067588 LinkOpponentHandleLinkStandbyMsg
+thumb_func 0x80675a8 LinkOpponentHandleResetActionMoveSelection
+thumb_func 0x80675b4 LinkOpponentHandleCmd55
 thumb_func 0x8067654 nullsub_441
 thumb_func 0x8067658 ZeroBoxMonData
-thumb_func 0x8067670
+thumb_func 0x8067670 ZeroMonData
 thumb_func 0x80676f0 ZeroPlayerPartyMons
 thumb_func 0x8067710 ZeroEnemyPartyMons
-thumb_func 0x8067730
-thumb_func 0x80677a0
-thumb_func 0x8067a74
-thumb_func 0x8067adc
-thumb_func 0x8067bdc
-thumb_func 0x8067c44
-thumb_func 0x8067c84
-thumb_func 0x8067cf8
+thumb_func 0x8067730 CreateMon
+thumb_func 0x80677a0 CreateBoxMon
+thumb_func 0x8067a74 CreateMonWithNature
+thumb_func 0x8067adc CreateMonWithGenderNatureLetter
+thumb_func 0x8067bdc CreateMaleMon
+thumb_func 0x8067c44 CreateMonWithIVsPersonality
+thumb_func 0x8067c84 CreateMonWithIVsOTID
+thumb_func 0x8067cf8 CreateMonWithEVSpread
 thumb_func 0x8067d80
-thumb_func 0x8067ed0
+thumb_func 0x8067ed0 CreateBattleTowerMon2
 thumb_func 0x8068080
-thumb_func 0x8068174
+thumb_func 0x8068174 CreateMonWithEVSpreadNatureOTID
 thumb_func 0x806823c
-thumb_func 0x80683e8
+thumb_func 0x80683e8 CreateObedientMon
 thumb_func 0x8068438
-thumb_func 0x8068550
-thumb_func 0x80685e4
+thumb_func 0x8068550 GetDeoxysStat
+thumb_func 0x80685e4 SetDeoxysStats
 thumb_func 0x8068688
 thumb_func 0x80686f0
-thumb_func 0x8068758
+thumb_func 0x8068758 CreateObedientEnemyMon
 thumb_func 0x80687b8 CalculateBoxMonChecksum
-thumb_func 0x806884c
-thumb_func 0x8068b44
+thumb_func 0x806884c CalculateMonStats
+thumb_func 0x8068b44 BoxMonToMon
 thumb_func 0x8068b94 GetLevelFromMonExp
 thumb_func 0x8068c00 GetLevelFromBoxMonExp
-thumb_func 0x8068c6c
-thumb_func 0x8068c80
-thumb_func 0x8068cf0
-thumb_func 0x8068d34
+thumb_func 0x8068c6c GiveMoveToMon
+thumb_func 0x8068c80 GiveMoveToBoxMon
+thumb_func 0x8068cf0 GiveMoveToBattleMon
+thumb_func 0x8068d34 SetMonMoveSlot
 thumb_func 0x8068d74 SetBattleMonMoveSlot
 thumb_func 0x8068da4
 thumb_func 0x8068db0 GiveBoxMonInitialMoveset
-thumb_func 0x8068e58
-thumb_func 0x8068f64
-thumb_func 0x8069010
-thumb_func 0x80690bc
-thumb_func 0x806992c
-thumb_func 0x8069a18
-thumb_func 0x8069a74
-thumb_func 0x8069af4
-thumb_func 0x8069b04
-thumb_func 0x8069b60
-thumb_func 0x8069ba8
-thumb_func 0x8069c6c
-thumb_func 0x8069d00
+thumb_func 0x8068e58 MonTryLearningNewMove
+thumb_func 0x8068f64 DeleteFirstMoveAndGiveMoveToMon
+thumb_func 0x8069010 DeleteFirstMoveAndGiveMoveToBoxMon
+thumb_func 0x80690bc CalculateBaseDamage
+thumb_func 0x806992c CountAliveMonsInBattle
+thumb_func 0x8069a18 ShouldGetStatBadgeBoost
+thumb_func 0x8069a74 GetDefaultMoveTarget
+thumb_func 0x8069af4 GetMonGender
+thumb_func 0x8069b04 GetBoxMonGender
+thumb_func 0x8069b60 GetGenderFromSpeciesAndPersonality
+thumb_func 0x8069ba8 SetMultiuseSpriteTemplateToPokemon
+thumb_func 0x8069c6c SetMultiuseSpriteTemplateToTrainerBack
+thumb_func 0x8069d00 SetMultiuseSpriteTemplateToTrainerFront
 thumb_func 0x8069d68 EncryptBoxMon
 thumb_func 0x8069d8c DecryptBoxMon
-thumb_func 0x8069db0
-thumb_func 0x806a058
+thumb_func 0x8069db0 GetSubstruct
+thumb_func 0x806a058 GetMonData
 thumb_func 0x806a1b4
-thumb_func 0x806a774
-thumb_func 0x806a864
+thumb_func 0x806a774 SetMonData
+thumb_func 0x806a864 SetBoxMonData
 thumb_func 0x806aed0
-thumb_func 0x806aedc
-thumb_func 0x806af58
+thumb_func 0x806aedc GiveMonToPlayer
+thumb_func 0x806af58 SendMonToPC
 thumb_func 0x806b004
 thumb_func 0x806b048
-thumb_func 0x806b08c
-thumb_func 0x806b100
-thumb_func 0x806b15c
-thumb_func 0x806b1a0
-thumb_func 0x806b1d4
+thumb_func 0x806b08c GetMonsStateToDoubles
+thumb_func 0x806b100 GetMonsStateToDoubles_2
+thumb_func 0x806b15c GetAbilityBySpecies
+thumb_func 0x806b1a0 GetMonAbility
+thumb_func 0x806b1d4 CreateSecretBaseEnemyParty
 thumb_func 0x806b2f8
 thumb_func 0x806b338
-thumb_func 0x806b378
-thumb_func 0x806b3ac
+thumb_func 0x806b378 IsPlayerPartyAndPokemonStorageFull
+thumb_func 0x806b3ac IsPokemonStorageFull
 thumb_func 0x806b3dc
-thumb_func 0x806b424
-thumb_func 0x806b46c
+thumb_func 0x806b424 CalculatePPWithBonus
+thumb_func 0x806b46c RemoveMonPPBonus
 thumb_func 0x806b4a8 RemoveBattleMonPPBonus
-thumb_func 0x806b4c0
+thumb_func 0x806b4c0 CopyPlayerPartyMonToBattleData
 thumb_func 0x806b7c8 ExecuteTableBasedItemEffect
-thumb_func 0x806b7ec
+thumb_func 0x806b7ec PokemonUseItemEffects
 thumb_func 0x806c830
-thumb_func 0x806c8a0
+thumb_func 0x806c8a0 GetItemEffectParamOffset
 thumb_func 0x806c9e8
 thumb_func 0x806ca3c
-thumb_func 0x806cb34
-thumb_func 0x806cb4c
-thumb_func 0x806cb5c
+thumb_func 0x806cb34 GetNature
+thumb_func 0x806cb4c GetNatureFromPersonality
+thumb_func 0x806cb5c GetEvolutionTargetSpecies
 thumb_func 0x806ce84
 thumb_func 0x806ced0
 thumb_func 0x806cf1c
 thumb_func 0x806cf68
 thumb_func 0x806cf8c
 thumb_func 0x806cfb0
-thumb_func 0x806cfd4
+thumb_func 0x806cfd4 SpeciesToCryId
 thumb_func 0x806d008
-thumb_func 0x806d128
+thumb_func 0x806d128 DrawSpindaSpots
 thumb_func 0x806d23c
 thumb_func 0x806d288
-thumb_func 0x806d2c8
-thumb_func 0x806d300
+thumb_func 0x806d2c8 GetLinkTrainerFlankId
+thumb_func 0x806d300 GetBattlerMultiplayerId
 thumb_func 0x806d324
-thumb_func 0x806d36c
-thumb_func 0x806d3cc
-thumb_func 0x806d570
-thumb_func 0x806d720
-thumb_func 0x806d748
-thumb_func 0x806d810
-thumb_func 0x806d878
-thumb_func 0x806d8d8
-thumb_func 0x806d958
-thumb_func 0x806da08
-thumb_func 0x806daa0
-thumb_func 0x806daf8
-thumb_func 0x806db48
+thumb_func 0x806d36c ModifyStatByNature
+thumb_func 0x806d3cc AdjustFriendship
+thumb_func 0x806d570 MonGainEVs
+thumb_func 0x806d720 GetMonEVCount
+thumb_func 0x806d748 RandomlyGivePartyPokerus
+thumb_func 0x806d810 CheckPartyPokerus
+thumb_func 0x806d878 CheckPartyHasHadPokerus
+thumb_func 0x806d8d8 UpdatePartyPokerusTime
+thumb_func 0x806d958 PartySpreadPokerus
+thumb_func 0x806da08 TryIncrementMonLevel
+thumb_func 0x806daa0 CanMonLearnTMHM
+thumb_func 0x806daf8 CanSpeciesLearnTMHM
+thumb_func 0x806db48 GetMoveRelearnerMoves
 thumb_func 0x806dc98 GetLevelUpMovesBySpecies
-thumb_func 0x806dcf0
-thumb_func 0x806de54
-thumb_func 0x806de8c
+thumb_func 0x806dcf0 GetNumberOfRelearnableMoves
+thumb_func 0x806de54 SpeciesToPokedexNum
+thumb_func 0x806de8c MainMenu_FormatSavegameText
 thumb_func 0x806dea8 ClearBattleMonForms
-thumb_func 0x806dec0
+thumb_func 0x806dec0 GetBattleBGM
 thumb_func 0x806e0d8
-thumb_func 0x806e0f4
+thumb_func 0x806e0f4 PlayMapChosenOrBattleBGM
 thumb_func 0x806e120
 thumb_func 0x806e158
 thumb_func 0x806e194
-thumb_func 0x806e1cc
+thumb_func 0x806e1cc GetMonSpritePalFromSpeciesAndPersonality
 thumb_func 0x806e220
-thumb_func 0x806e258
-thumb_func 0x806e290
+thumb_func 0x806e258 GetMonSpritePalStructFromOtIdPersonality
+thumb_func 0x806e290 IsHMMove2
 thumb_func 0x806e2cc IsMonSpriteNotFlipped
 thumb_func 0x806e2e4
 thumb_func 0x806e30c
-thumb_func 0x806e334
-thumb_func 0x806e360
+thumb_func 0x806e334 IsTradedMon
+thumb_func 0x806e360 IsOtherTrainer
 thumb_func 0x806e3b0
-thumb_func 0x806e3bc
-thumb_func 0x806e420
-thumb_func 0x806e4cc
-thumb_func 0x806e4f4
-thumb_func 0x806e630
+thumb_func 0x806e3bc BoxMonRestorePP
+thumb_func 0x806e420 SetMonPreventsSwitchingString
+thumb_func 0x806e4cc GetWildMonTableIdInAlteringCave
+thumb_func 0x806e4f4 SetWildMonHeldItem
+thumb_func 0x806e630 IsMonShiny
 thumb_func 0x806e65c IsShinyOtIdPersonality
-thumb_func 0x806e684
-thumb_func 0x806e6fc
-thumb_func 0x806e738
-thumb_func 0x806e778
-thumb_func 0x806e7cc
-thumb_func 0x806e898
-thumb_func 0x806e924
-thumb_func 0x806e940
+thumb_func 0x806e684 GetTrainerPartnerName
+thumb_func 0x806e6fc Task_AnimateAfterDelay
+thumb_func 0x806e738 Task_PokemonSummaryAnimateAfterDelay
+thumb_func 0x806e778 BattleAnimateFrontSprite
+thumb_func 0x806e7cc DoMonFrontSpriteAnimation
+thumb_func 0x806e898 PokemonSummaryDoMonAnimation
+thumb_func 0x806e924 StopPokemonAnimationDelayTask
+thumb_func 0x806e940 BattleAnimateBackSprite
 thumb_func 0x806e994
 thumb_func 0x806ea10
 thumb_func 0x806ea7c
 thumb_func 0x806ea8c PlayerGenderToFrontTrainerPicId
-thumb_func 0x806eaa8
+thumb_func 0x806eaa8 HandleSetPokedexFlag
 thumb_func 0x806eb08
 thumb_func 0x806eb38
 thumb_func 0x806eb58 HasTwoFramesAnimation
@@ -2748,18 +2748,18 @@ thumb_func 0x806ef00
 thumb_func 0x806ef7c
 thumb_func 0x806efb8 Sin
 thumb_func 0x806efd4 Cos
-thumb_func 0x806eff4
+thumb_func 0x806eff4 Sin2
 thumb_func 0x806f038 Cos2
 thumb_func 0x806f050 Random
-thumb_func 0x806f07c
+thumb_func 0x806f07c SeedRng
 thumb_func 0x806f094
 thumb_func 0x806f0a4
-thumb_func 0x806f0c4
-thumb_func 0x806f100
-thumb_func 0x806f108
+thumb_func 0x806f0c4 CreateInvisibleSpriteWithCallback
+thumb_func 0x806f100 StoreWordInTwoHalfwords
+thumb_func 0x806f108 LoadWordFromTwoHalfwords
 thumb_func 0x806f118 SetBgAffineStruct
-thumb_func 0x806f144
-thumb_func 0x806f190
+thumb_func 0x806f144 DoBgAffineSet
+thumb_func 0x806f190 CopySpriteTiles
 thumb_func 0x806f32c CountTrailingZeroBits
 thumb_func 0x806f354 CalcCRC16
 thumb_func 0x806f3ac CalcCRC16WithTable
@@ -2767,149 +2767,149 @@ thumb_func 0x806f3f0 CalcByteArraySum
 thumb_func 0x806f410 BlendPalette
 thumb_func 0x806f4b0
 thumb_func 0x806f4d0
-thumb_func 0x806f4f0
-thumb_func 0x806f520
-thumb_func 0x806f58c
+thumb_func 0x806f4f0 CountPokemonInDaycare
+thumb_func 0x806f520 InitDaycareMailRecordMixing
+thumb_func 0x806f58c Daycare_FindEmptySpot
 thumb_func 0x806f5bc
-thumb_func 0x806f64c
-thumb_func 0x806f670
-thumb_func 0x806f6a0
-thumb_func 0x806f6fc
-thumb_func 0x806f750
+thumb_func 0x806f64c StorePokemonInEmptyDaycareSlot
+thumb_func 0x806f670 StoreSelectedPokemonInDaycare
+thumb_func 0x806f6a0 ShiftDaycareSlots
+thumb_func 0x806f6fc ApplyDaycareExperience
+thumb_func 0x806f750 TakeSelectedPokemonFromDaycare
 thumb_func 0x806f7f4 TakeSelectedPokemonMonFromDaycareShiftSlots
 thumb_func 0x806f81c TakePokemonFromDaycare
-thumb_func 0x806f844
-thumb_func 0x806f880
-thumb_func 0x806f8ac
-thumb_func 0x806f8e0
+thumb_func 0x806f844 GetLevelAfterDaycareSteps
+thumb_func 0x806f880 GetNumLevelsGainedFromSteps
+thumb_func 0x806f8ac GetNumLevelsGainedForDaycareMon
+thumb_func 0x806f8e0 GetDaycareCostForSelectedMon
 thumb_func 0x806f918 GetDaycareCostForMon
 thumb_func 0x806f930 GetDaycareCost
 thumb_func 0x806f95c Debug_AddDaycareSteps
-thumb_func 0x806f988
-thumb_func 0x806f9d8
-thumb_func 0x806fa08
+thumb_func 0x806f988 GetNumLevelsGainedFromDaycare
+thumb_func 0x806f9d8 ClearDaycareMonMail
+thumb_func 0x806fa08 ClearDaycareMon
 thumb_func 0x806fa28 ClearAllDaycareData
-thumb_func 0x806fa5c
-thumb_func 0x806fadc
-thumb_func 0x806fb6c
-thumb_func 0x806fc10
-thumb_func 0x806fc38
-thumb_func 0x806fc54
+thumb_func 0x806fa5c GetEggSpecies
+thumb_func 0x806fadc GetSlotToInheritNature
+thumb_func 0x806fb6c _TriggerPendingDaycareEgg
+thumb_func 0x806fc10 _TriggerPendingDaycareMaleEgg
+thumb_func 0x806fc38 TriggerPendingDaycareEgg
+thumb_func 0x806fc54 TriggerPendingDaycareMaleEgg
 thumb_func 0x806fc70 RemoveIVIndexFromList
-thumb_func 0x806fcb8
-thumb_func 0x806fe20
-thumb_func 0x806fec8
+thumb_func 0x806fcb8 InheritIVs
+thumb_func 0x806fe20 GetEggMoves
+thumb_func 0x806fec8 BuildEggMoveset
 thumb_func 0x8070168 RemoveEggFromDayCare
-thumb_func 0x8070180
-thumb_func 0x807019c
-thumb_func 0x80701fc
-thumb_func 0x8070244
-thumb_func 0x8070320
+thumb_func 0x8070180 RejectEggFromDayCare
+thumb_func 0x807019c AlterEggSpeciesWithIncenseItem
+thumb_func 0x80701fc GiveVoltTackleIfLightBall
+thumb_func 0x8070244 DetermineEggSpeciesAndParentSlots
+thumb_func 0x8070320 _GiveEggFromDaycare
 thumb_func 0x80703ac
-thumb_func 0x807044c
+thumb_func 0x807044c AnimSolarbeamSmallOrb
 thumb_func 0x80704d0
-thumb_func 0x80704ec
+thumb_func 0x80704ec _DoEggActions_CheckHatch
 thumb_func 0x80705f8 ShouldEggHatch
 thumb_func 0x8070618 IsEggPending
-thumb_func 0x807062c
-thumb_func 0x8070680
-thumb_func 0x80706bc
-thumb_func 0x80706d8
-thumb_func 0x8070720
+thumb_func 0x807062c _GetDaycareMonNicknames
+thumb_func 0x8070680 GetSelectedMonNickAndSpecies
+thumb_func 0x80706bc GetDaycareMonNicknames
+thumb_func 0x80706d8 GetDaycareState
+thumb_func 0x8070720 GetDaycarePokemonCount
 thumb_func 0x8070744 EggGroupsOverlap
-thumb_func 0x8070774
+thumb_func 0x8070774 GetDaycareCompatibilityScore
 thumb_func 0x8070894 GetDaycareCompatibilityScoreFromSave
-thumb_func 0x80708b4
+thumb_func 0x80708b4 SetDaycareCompatibilityString
 thumb_func 0x80708f4 NameHasGenderSymbol
-thumb_func 0x8070970
-thumb_func 0x80709c0
-thumb_func 0x80709dc
-thumb_func 0x8070a60
-thumb_func 0x8070ac4
-thumb_func 0x8070b38
+thumb_func 0x8070970 AppendGenderSymbol
+thumb_func 0x80709c0 AppendMonGenderSymbol
+thumb_func 0x80709dc GetDaycareLevelMenuText
+thumb_func 0x8070a60 GetDaycareLevelMenuLevelText
+thumb_func 0x8070ac4 DaycareAddTextPrinter
+thumb_func 0x8070b38 DaycarePrintMonNick
 thumb_func 0x8070b74
-thumb_func 0x8070bd8
-thumb_func 0x8070c24
-thumb_func 0x8070ce0
-thumb_func 0x8070d50
-thumb_func 0x8070d68
-thumb_func 0x8070ed0
-thumb_func 0x8070f90
+thumb_func 0x8070bd8 DaycarePrintMonInfo
+thumb_func 0x8070c24 Task_HandleDaycareLevelMenuInput
+thumb_func 0x8070ce0 ShowDaycareLevelMenu
+thumb_func 0x8070d50 FieldCallback_SecretBaseCave
+thumb_func 0x8070d68 CreatedHatchedMon
+thumb_func 0x8070ed0 AddHatchedMonToParty
+thumb_func 0x8070f90 ScriptHatchMon
 thumb_func 0x8070fa4
 thumb_func 0x807101c
-thumb_func 0x8071044
-thumb_func 0x8071134
-thumb_func 0x8071148
-thumb_func 0x8071168
+thumb_func 0x8071044 EggHatchCreateMonSprite
+thumb_func 0x8071134 VBlankCB_EggHatch
+thumb_func 0x8071148 EggHatch
+thumb_func 0x8071168 Task_EggHatch
 thumb_func 0x80711a8
-thumb_func 0x8071400
-thumb_func 0x8071440
-thumb_func 0x8071498
-thumb_func 0x8071844
-thumb_func 0x807189c
-thumb_func 0x8071900
+thumb_func 0x8071400 EggHatchSetMonNickname
+thumb_func 0x8071440 Task_EggHatchPlayBGM
+thumb_func 0x8071498 CB2_EggHatch_1
+thumb_func 0x8071844 SpriteCB_Egg_0
+thumb_func 0x807189c SpriteCB_Egg_1
+thumb_func 0x8071900 SpriteCB_Egg_2
 thumb_func 0x80719b4 SpriteCB_Egg_3
-thumb_func 0x80719d8
-thumb_func 0x8071a58
-thumb_func 0x8071af8
-thumb_func 0x8071b50
-thumb_func 0x8071ba4
-thumb_func 0x8071c24
-thumb_func 0x8071c9c
+thumb_func 0x80719d8 SpriteCB_Egg_4
+thumb_func 0x8071a58 SpriteCB_Egg_5
+thumb_func 0x8071af8 SpriteCB_EggShard
+thumb_func 0x8071b50 CreateRandomEggShardSprite
+thumb_func 0x8071ba4 CreateEggShardSprite
+thumb_func 0x8071c24 EggHatchPrintMessage
+thumb_func 0x8071c9c GetEggStepsToSubtract
 thumb_func 0x8071cf0
-thumb_func 0x8071d14
+thumb_func 0x8071d14 DummiedOutFunction
 thumb_func 0x8071d18
 thumb_func 0x8071eb8
-thumb_func 0x8071eec
-thumb_func 0x8072214
-thumb_func 0x80722b4
-thumb_func 0x80722c4
+thumb_func 0x8071eec CreateBattlerHealthboxSprites
+thumb_func 0x8072214 CreateSafariPlayerHealthboxSprites
+thumb_func 0x80722b4 GetHealthboxElementGfxPtr
+thumb_func 0x80722c4 SpriteCB_HealthBar
 thumb_func 0x8072334 SpriteCB_HealthBoxOther
 thumb_func 0x807235c SetBattleBarStruct
 thumb_func 0x8072394 SetHealthboxSpriteInvisible
 thumb_func 0x80723e0 SetHealthboxSpriteVisible
 thumb_func 0x8072434 UpdateSpritePos
-thumb_func 0x8072454
+thumb_func 0x8072454 DestoryHealthboxSprite
 thumb_func 0x8072494 nullsub_7
 thumb_func 0x8072498 UpdateOamPriorityInAllHealthboxes
-thumb_func 0x8072528
+thumb_func 0x8072528 InitBattlerHealthboxCoords
 thumb_func 0x80725a4
 thumb_func 0x80726f4
-thumb_func 0x80727fc
-thumb_func 0x80729d0
+thumb_func 0x80727fc SwapHpBarsWithHpText
+thumb_func 0x80729d0 PrintSafariMonInfo
 thumb_func 0x8072c10
-thumb_func 0x8072ed8
-thumb_func 0x807352c
+thumb_func 0x8072ed8 CreatePartyStatusSummarySprites
+thumb_func 0x807352c Task_HidePartyStatusSummary
 thumb_func 0x8073704
 thumb_func 0x8073760
 thumb_func 0x8073894
 thumb_func 0x8073974 SpriteCB_StatusSummaryBar
 thumb_func 0x807398c
-thumb_func 0x80739c0
+thumb_func 0x80739c0 SpriteCB_StatusSummaryBallsOnBattleStart
 thumb_func 0x8073a54
 thumb_func 0x8073ac4 SpriteCB_StatusSummaryBallsOnSwitchout
 thumb_func 0x8073ae4
-thumb_func 0x8073d80
-thumb_func 0x8073e68
-thumb_func 0x8074118
+thumb_func 0x8073d80 TryAddPokeballIconToHealthbox
+thumb_func 0x8073e68 UpdateStatusIconInHealthbox
+thumb_func 0x8074118 GetStatusIconForBattlerId
 thumb_func 0x80741e0
 thumb_func 0x8074320
-thumb_func 0x80743f0
-thumb_func 0x8074630
-thumb_func 0x807472c
-thumb_func 0x8074948
-thumb_func 0x8074a1c
+thumb_func 0x80743f0 UpdateHealthboxAttribute
+thumb_func 0x8074630 MoveBattleBar
+thumb_func 0x807472c MoveBattleBarGraphically
+thumb_func 0x8074948 CalcNewBarValue
+thumb_func 0x8074a1c CalcBarFilledPixels
 thumb_func 0x8074ab8
 thumb_func 0x8074b18
-thumb_func 0x8074b78
-thumb_func 0x8074bc4
+thumb_func 0x8074b78 GetScaledExpFraction
+thumb_func 0x8074bc4 GetScaledHPFraction
 thumb_func 0x8074bf0 GetHPBarLevel
 thumb_func 0x8074c24
 thumb_func 0x8074d78
 thumb_func 0x8074dbc
-thumb_func 0x8074df0
-thumb_func 0x8074e58
-thumb_func 0x8075028
+thumb_func 0x8074df0 DoPokeballSendOutAnimation
+thumb_func 0x8074e58 Task_DoPokeballSendOutAnim
+thumb_func 0x8075028 SpriteCB_TestBallThrow
 thumb_func 0x80750dc
 thumb_func 0x80750e8
 thumb_func 0x8075154
@@ -2917,18 +2917,18 @@ thumb_func 0x80751ec
 thumb_func 0x8075240
 thumb_func 0x8075338
 thumb_func 0x8075378
-thumb_func 0x80754c4
-thumb_func 0x807571c
+thumb_func 0x80754c4 Task_PlayCryWhenReleasedFromBall
+thumb_func 0x807571c SpriteCB_ReleaseMonFromBall
 thumb_func 0x80759bc
-thumb_func 0x80759dc
+thumb_func 0x80759dc HandleBallAnimEnd
 thumb_func 0x8075b00
-thumb_func 0x8075bbc
-thumb_func 0x8075c0c
+thumb_func 0x8075bbc SpriteCB_PlayerMonSendOut_1
+thumb_func 0x8075c0c SpriteCB_PlayerMonSendOut_2
 thumb_func 0x8075d7c SpriteCB_ReleaseMon2FromBall
-thumb_func 0x8075da0
-thumb_func 0x8075e00
-thumb_func 0x8075e28
-thumb_func 0x8075e40
+thumb_func 0x8075da0 SpriteCB_OpponentMonSendOut
+thumb_func 0x8075e00 AnimateBallOpenParticlesForPokeball
+thumb_func 0x8075e28 LaunchBallFadeMonTaskForPokeball
+thumb_func 0x8075e40 CreatePokeballSpriteToReleaseMon
 thumb_func 0x8075f2c
 thumb_func 0x8075fe8
 thumb_func 0x8076124
@@ -2940,31 +2940,31 @@ thumb_func 0x8076320
 thumb_func 0x80763b0
 thumb_func 0x80763d4
 thumb_func 0x80763fc
-thumb_func 0x8076440
-thumb_func 0x8076480
-thumb_func 0x80764f0
-thumb_func 0x807651c
-thumb_func 0x8076570
+thumb_func 0x8076440 SpriteCB_HitAnimHealthoxEffect
+thumb_func 0x8076480 LoadBallGfx
+thumb_func 0x80764f0 FreeBallGfx
+thumb_func 0x807651c GetBattlerPokeballItemId
+thumb_func 0x8076570 CheckForFlashMemory
 thumb_func 0x807659c
 thumb_func 0x80765c0
-thumb_func 0x80765e4
-thumb_func 0x8076634
-thumb_func 0x807672c
+thumb_func 0x80765e4 SetSaveBlocksPointers
+thumb_func 0x8076634 MoveSaveBlocks_ResetHeap
+thumb_func 0x807672c UseContinueGameWarp
 thumb_func 0x807673c
-thumb_func 0x8076750
-thumb_func 0x8076764
+thumb_func 0x8076750 SetContinueGameWarpStatus
+thumb_func 0x8076764 SetContinueGameWarpStatusToDynamicWarp
 thumb_func 0x8076780
-thumb_func 0x8076794
-thumb_func 0x80767dc
+thumb_func 0x8076794 SavePlayerParty
+thumb_func 0x80767dc LoadPlayerParty
 thumb_func 0x8076824 SaveEventObjects
 thumb_func 0x807686c LoadEventObjects
-thumb_func 0x80768b4
-thumb_func 0x80768c4
+thumb_func 0x80768b4 SaveSerializedGame
+thumb_func 0x80768c4 LoadSerializedGame
 thumb_func 0x80768d4 LoadPlayerBag
-thumb_func 0x80769e8
-thumb_func 0x8076b08
-thumb_func 0x8076b20
-thumb_func 0x8076b38
+thumb_func 0x80769e8 SavePlayerBag
+thumb_func 0x8076b08 ApplyNewEncryptionKeyToHword
+thumb_func 0x8076b20 ApplyNewEncryptionKeyToWord
+thumb_func 0x8076b38 ApplyNewEncryptionKeyToAllEncryptedData
 thumb_func 0x8076b78
 thumb_func 0x8076bb4
 thumb_func 0x8076bc4
@@ -2995,7 +2995,7 @@ thumb_func 0x80785e0
 thumb_func 0x80785f4
 thumb_func 0x8078618
 thumb_func 0x8078650
-thumb_func 0x807869c
+thumb_func 0x807869c TradeMenuMoveCursor
 thumb_func 0x807875c
 thumb_func 0x80787a0
 thumb_func 0x8078900
@@ -3070,11 +3070,11 @@ thumb_func 0x807aff0
 thumb_func 0x807b044
 thumb_func 0x807b064
 thumb_func 0x807b4cc
-thumb_func 0x807b510
+thumb_func 0x807b510 SetTradeSceneStrings
 thumb_func 0x807b600
 thumb_func 0x807b624
 thumb_func 0x807ca00
-thumb_func 0x807de4c
+thumb_func 0x807de4c c2_08053788
 thumb_func 0x807df14
 thumb_func 0x807df94
 thumb_func 0x807e010
@@ -3082,40 +3082,40 @@ thumb_func 0x807e084
 thumb_func 0x807e0e4
 thumb_func 0x807e174
 thumb_func 0x807e1c4
-thumb_func 0x807e228
+thumb_func 0x807e228 _CreateInGameTradePokemon
 thumb_func 0x807e3b4
-thumb_func 0x807e40c
-thumb_func 0x807e448
+thumb_func 0x807e40c GetTradeSpecies
+thumb_func 0x807e448 CreateInGameTradePokemon
 thumb_func 0x807e464
 thumb_func 0x807e504
 thumb_func 0x807e588
 thumb_func 0x807eaa0
-thumb_func 0x807eb1c
+thumb_func 0x807eb1c DoInGameTradeScene
 thumb_func 0x807eb48
 thumb_func 0x807eb84
 thumb_func 0x807ebd4
 thumb_func 0x807ebe0
-thumb_func 0x807ec48
-thumb_func 0x807ed1c
+thumb_func 0x807ec48 c3_08054588
+thumb_func 0x807ed1c c3_0805465C
 thumb_func 0x807edd4
 thumb_func 0x807ee9c
-thumb_func 0x807f170
-thumb_func 0x807f19c
-thumb_func 0x807f210
+thumb_func 0x807f170 Blender_ControlHitPitch
+thumb_func 0x807f19c VBlankCB0_BerryBlender
+thumb_func 0x807f210 LoadBerryBlenderGfx
 thumb_func 0x807f408
-thumb_func 0x807f46c
+thumb_func 0x807f46c InitBerryBlenderWindows
 thumb_func 0x807f4b8
 thumb_func 0x807f500
 thumb_func 0x807f740
 thumb_func 0x807f79c
 thumb_func 0x807f7c8
-thumb_func 0x807f84c
+thumb_func 0x807f84c Blender_CopyBerryData
 thumb_func 0x807f88c
 thumb_func 0x807f9ac
 thumb_func 0x807fa20
 thumb_func 0x807ff90
 thumb_func 0x808002c
-thumb_func 0x808007c
+thumb_func 0x808007c Blender_SetOpponentsBerryData
 thumb_func 0x8080154
 thumb_func 0x80801c4
 thumb_func 0x80802f0
@@ -3139,24 +3139,24 @@ thumb_func 0x80815cc
 thumb_func 0x80815d8
 thumb_func 0x80815e4
 thumb_func 0x80815f0
-thumb_func 0x80815fc
+thumb_func 0x80815fc Blender_CalculatePokeblock
 thumb_func 0x8081820 BlenderDebug_CalculatePokeblock
 thumb_func 0x808183c
 thumb_func 0x80819b0
-thumb_func 0x80819e4
-thumb_func 0x8081f18
-thumb_func 0x8082060
-thumb_func 0x8082340
+thumb_func 0x80819e4 CB2_HandleBlenderEndGame
+thumb_func 0x8081f18 LinkPlayAgainHandleSaving
+thumb_func 0x8082060 CB2_HandlePlayerLinkPlayAgainChoice
+thumb_func 0x8082340 CB2_HandlePlayerPlayAgainChoice
 thumb_func 0x80824f0
 thumb_func 0x80826d0
-thumb_func 0x8082734
+thumb_func 0x8082734 GetBlenderArrowPosition
 thumb_func 0x8082744
-thumb_func 0x8082810
+thumb_func 0x8082810 BerryBlender_SetBackgroundsPos
 thumb_func 0x8082858
 thumb_func 0x80828a0
 thumb_func 0x8082984
 thumb_func 0x80829b8
-thumb_func 0x80829f8
+thumb_func 0x80829f8 Blender_SetParticipantBerryData
 thumb_func 0x8082a2c
 thumb_func 0x8082adc
 thumb_func 0x8082b5c
@@ -3171,173 +3171,173 @@ thumb_func 0x8082d9c
 thumb_func 0x8082e14
 thumb_func 0x8082e34 TryUpdateBerryBlenderRecord
 thumb_func 0x8082e6c
-thumb_func 0x80832a0
+thumb_func 0x80832a0 Blender_PrintMadePokeblockString
 thumb_func 0x8083350 Blender_SortBasedOnPoints
-thumb_func 0x80833a8
+thumb_func 0x80833a8 Blender_SortScores
 thumb_func 0x80834fc
 thumb_func 0x80837c8
 thumb_func 0x80838c4
-thumb_func 0x808391c
-thumb_func 0x8083a5c
-thumb_func 0x8083b04
+thumb_func 0x808391c TryAddContestLinkTvShow
+thumb_func 0x8083a5c Blender_AddTextPrinter
+thumb_func 0x8083b04 Blender_PrintText
 thumb_func 0x8083b6c PlayTimeCounter_Reset
 thumb_func 0x8083b90 PlayTimeCounter_Start
 thumb_func 0x8083bb8
 thumb_func 0x8083bc4 PlayTimeCounter_Update
 thumb_func 0x8083c2c PlayTimeCounter_SetToMax
-thumb_func 0x8083c54
+thumb_func 0x8083c54 SetTrainerId
 thumb_func 0x8083c64 GetTrainerId
 thumb_func 0x8083c7c CopyTrainerId
-thumb_func 0x8083c98
+thumb_func 0x8083c98 InitPlayerTrainerId
 thumb_func 0x8083cc4 SetDefaultOptions
-thumb_func 0x8083d18
-thumb_func 0x8083d48
-thumb_func 0x8083d88
-thumb_func 0x8083dd4
-thumb_func 0x8083df4
-thumb_func 0x8083e04
-thumb_func 0x8083e28
-thumb_func 0x8083f54
-thumb_func 0x8083fa8
+thumb_func 0x8083d18 ClearPokedexFlags
+thumb_func 0x8083d48 ClearAllContestWinnerPics
+thumb_func 0x8083d88 ClearFrontierRecord
+thumb_func 0x8083dd4 WarpToTruck
+thumb_func 0x8083df4 Sav2_ClearSetDefault
+thumb_func 0x8083e04 ResetMenuAndMonGlobals
+thumb_func 0x8083e28 NewGameInitData
+thumb_func 0x8083f54 ResetMiniGamesResults
+thumb_func 0x8083fa8 DoWhiteOut
 thumb_func 0x8083fe8
-thumb_func 0x8084024
+thumb_func 0x8084024 Overworld_ResetStateAfterTeleport
 thumb_func 0x808406c
-thumb_func 0x80840a8
+thumb_func 0x80840a8 Overworld_ResetStateAfterWhiteOut
 thumb_func 0x8084110
 thumb_func 0x8084130 ResetGameStats
 thumb_func 0x808414c IncrementGameStat
-thumb_func 0x8084180
+thumb_func 0x8084180 GetGameStat
 thumb_func 0x80841b8 SetGameStat
-thumb_func 0x80841ec
-thumb_func 0x808421c
+thumb_func 0x80841ec ApplyNewEncryptionKeyToGameStats
+thumb_func 0x808421c LoadEventObjTemplatesFromHeader
 thumb_func 0x8084268 LoadSaveblockEventObjScripts
-thumb_func 0x8084298
-thumb_func 0x80842d4
-thumb_func 0x8084308
-thumb_func 0x8084330
+thumb_func 0x8084298 Overworld_SetEventObjTemplateCoords
+thumb_func 0x80842d4 Overworld_SetEventObjTemplateMovementType
+thumb_func 0x8084308 mapdata_load_assets_to_gpu_and_full_redraw
+thumb_func 0x8084330 GetMapLayout
 thumb_func 0x8084358 ApplyCurrentWarp
 thumb_func 0x808439c SetWarpData
 thumb_func 0x80843bc IsDummyWarp
 thumb_func 0x80843f8 Overworld_GetMapHeaderByGroupAndId
 thumb_func 0x8084410 GetDestinationWarpMapHeader
-thumb_func 0x8084434
-thumb_func 0x8084484
-thumb_func 0x80844c4
-thumb_func 0x8084540
+thumb_func 0x8084434 LoadCurrentMapData
+thumb_func 0x8084484 LoadSaveblockMapHeader
+thumb_func 0x80844c4 SetPlayerCoordsFromWarp
+thumb_func 0x8084540 WarpIntoMap
 thumb_func 0x8084554 SetWarpDestination
 thumb_func 0x8084590 SetWarpDestinationToMapWarp
 thumb_func 0x80845b0 SetDynamicWarp
 thumb_func 0x80845e4 SetDynamicWarpWithCoords
-thumb_func 0x808461c
-thumb_func 0x8084634
-thumb_func 0x808466c
-thumb_func 0x8084684
+thumb_func 0x808461c SetWarpDestinationToDynamicWarp
+thumb_func 0x8084634 SetWarpDestinationToHealLocation
+thumb_func 0x808466c SetWarpDestinationToLastHealLocation
+thumb_func 0x8084684 SetLastHealLocationWarp
 thumb_func 0x80846c4 UpdateEscapeWarp
 thumb_func 0x808473c SetEscapeWarp
-thumb_func 0x808477c
+thumb_func 0x808477c SetWarpDestinationToEscapeWarp
 thumb_func 0x8084794 SetFixedDiveWarp
-thumb_func 0x80847d0
+thumb_func 0x80847d0 SetWarpDestinationToDiveWarp
 thumb_func 0x80847e8 SetFixedHoleWarp
-thumb_func 0x8084824
-thumb_func 0x808487c
+thumb_func 0x8084824 SetWarpDestinationToFixedHoleWarp
+thumb_func 0x808487c SetWarpDestinationToContinueGameWarp
 thumb_func 0x8084894 SetContinueGameWarp
-thumb_func 0x80848d4
-thumb_func 0x8084914
-thumb_func 0x8084928
-thumb_func 0x8084960
+thumb_func 0x80848d4 SetContinueGameWarpToHealLocation
+thumb_func 0x8084914 SetContinueGameWarpToDynamicWarp
+thumb_func 0x8084928 GetMapConnection
+thumb_func 0x8084960 SetDiveWarp
 thumb_func 0x80849c0 SetDiveWarpEmerge
 thumb_func 0x80849e0 SetDiveWarpDive
-thumb_func 0x8084a00
-thumb_func 0x8084ac8
-thumb_func 0x8084bd0
-thumb_func 0x8084be0
+thumb_func 0x8084a00 LoadMapFromCameraTransition
+thumb_func 0x8084ac8 mli0_load_map
+thumb_func 0x8084bd0 ResetInitialPlayerAvatarState
+thumb_func 0x8084be0 StoreInitialPlayerAvatarState
 thumb_func 0x8084c3c GetInitialPlayerAvatarState
-thumb_func 0x8084c94
-thumb_func 0x8084cf4
-thumb_func 0x8084db8
-thumb_func 0x8084ddc
-thumb_func 0x8084dfc
+thumb_func 0x8084c94 GetAdjustedInitialTransitionFlags
+thumb_func 0x8084cf4 GetAdjustedInitialDirection
+thumb_func 0x8084db8 GetCenterScreenMetatileBehavior
+thumb_func 0x8084ddc Overworld_IsBikingAllowed
+thumb_func 0x8084dfc SetDefaultFlashLevel
 thumb_func 0x8084e54 Overworld_SetFlashLevel
-thumb_func 0x8084e7c
-thumb_func 0x8084e8c
+thumb_func 0x8084e7c Overworld_GetFlashLevel
+thumb_func 0x8084e8c SetCurrentMapLayout
 thumb_func 0x8084ea8
 thumb_func 0x8084eb4
-thumb_func 0x8084ec0
-thumb_func 0x8084f1c
-thumb_func 0x8084f50
-thumb_func 0x8084f80
+thumb_func 0x8084ec0 ShouldLegendaryMusicPlayAtLocation
+thumb_func 0x8084f1c NoMusicInSotopolisWithLegendaries
+thumb_func 0x8084f50 IsInfiltratedWeatherInstitute
+thumb_func 0x8084f80 IsInflitratedSpaceCenter
 thumb_func 0x8084fc4 GetLocationMusic
-thumb_func 0x808503c
-thumb_func 0x80850a0
-thumb_func 0x80850e0
-thumb_func 0x80850ec
-thumb_func 0x808515c
-thumb_func 0x8085168
+thumb_func 0x808503c GetCurrLocationDefaultMusic
+thumb_func 0x80850a0 CallBattleArenaFunction
+thumb_func 0x80850e0 Overworld_ResetMapMusic
+thumb_func 0x80850ec Overworld_PlaySpecialMapMusic
+thumb_func 0x808515c Overworld_SetSavedMusic
+thumb_func 0x8085168 Overworld_ClearSavedMusic
 thumb_func 0x8085178
-thumb_func 0x8085200
-thumb_func 0x808522c
+thumb_func 0x8085200 Overworld_ChangeMusicToDefault
+thumb_func 0x808522c GetTruckCameraBobbingY
 thumb_func 0x8085258 GetMapMusicFadeoutSpeed
-thumb_func 0x8085278
-thumb_func 0x8085308
-thumb_func 0x8085318
-thumb_func 0x8085324
-thumb_func 0x80853a4
-thumb_func 0x8085494
+thumb_func 0x8085278 TryFadeOutOldMapMusic
+thumb_func 0x8085308 BGMusicStopped
+thumb_func 0x8085318 Overworld_FadeOutMapMusic
+thumb_func 0x8085324 PlayAmbientCry
+thumb_func 0x80853a4 UpdateAmbientCry
+thumb_func 0x8085494 ChooseAmbientCrySpecies
 thumb_func 0x80854dc GetMapTypeByGroupAndId
 thumb_func 0x80854f4 GetMapTypeByWarpData
 thumb_func 0x808550c GetCurrentMapType
-thumb_func 0x8085524
+thumb_func 0x8085524 GetLastUsedWarpMapType
 thumb_func 0x8085538 IsMapTypeOutdoors
 thumb_func 0x808555c Overworld_MapTypeAllowsTeleportAndFly
 thumb_func 0x808557c IsMapTypeIndoors
 thumb_func 0x8085598 GetSavedWarpRegionMapSectionId
 thumb_func 0x80855c0 GetCurrentRegionMapSectionId
 thumb_func 0x80855e8 GetCurrentMapBattleScene
-thumb_func 0x8085610
-thumb_func 0x808569c
+thumb_func 0x8085610 InitOverworldBgs
+thumb_func 0x808569c CleanupOverworldWindowsAndTilemaps
 thumb_func 0x80856e8
-thumb_func 0x80856f4
-thumb_func 0x8085714
+thumb_func 0x80856f4 IsUpdateLinkStateCBActive
+thumb_func 0x8085714 DoCB1_Overworld
 thumb_func 0x808576c CB1_Overworld
-thumb_func 0x808578c
-thumb_func 0x80857b8
-thumb_func 0x80857c4
+thumb_func 0x808578c OverworldBasic
+thumb_func 0x80857b8 CB2_OverworldBasic
+thumb_func 0x80857c4 CB2_Overworld
 thumb_func 0x80857f0
 thumb_func 0x80857fc
-thumb_func 0x8085808
-thumb_func 0x8085860
-thumb_func 0x80858c0
-thumb_func 0x8085934
-thumb_func 0x8085964
+thumb_func 0x8085808 map_post_load_hook_exec
+thumb_func 0x8085860 CB2_NewGame
+thumb_func 0x80858c0 CB2_WhiteOut
+thumb_func 0x8085934 CB2_LoadMap
+thumb_func 0x8085964 CB2_LoadMap2
 thumb_func 0x808598c
 thumb_func 0x80859dc
-thumb_func 0x8085a00
+thumb_func 0x8085a00 c2_80567AC
 thumb_func 0x8085a30
-thumb_func 0x8085a5c
-thumb_func 0x8085a80
-thumb_func 0x8085aa8
-thumb_func 0x8085afc
-thumb_func 0x8085b18
-thumb_func 0x8085b34
+thumb_func 0x8085a5c CB2_ReturnToFieldLocal
+thumb_func 0x8085a80 CB2_ReturnToFieldLink
+thumb_func 0x8085aa8 CB2_ReturnToFieldFromMultiplayer
+thumb_func 0x8085afc CB2_ReturnToFieldWithOpenMenu
+thumb_func 0x8085b18 CB2_ReturnToFieldContinueScript
+thumb_func 0x8085b34 CB2_ReturnToFieldContinueScriptPlayMapMusic
 thumb_func 0x8085b50
 thumb_func 0x8085b6c
-thumb_func 0x8085b98
-thumb_func 0x8085c80
-thumb_func 0x8085ce4
-thumb_func 0x8085cf4
-thumb_func 0x8085d14
-thumb_func 0x8085d5c
-thumb_func 0x8085e80
+thumb_func 0x8085b98 CB2_ContinueSavedGame
+thumb_func 0x8085c80 FieldClearVBlankHBlankCallbacks
+thumb_func 0x8085ce4 SetFieldVBlankCallback
+thumb_func 0x8085cf4 VBlankCB_Field
+thumb_func 0x8085d14 InitCurrentFlashLevelScanlineEffect
+thumb_func 0x8085d5c map_loading_iteration_3
+thumb_func 0x8085e80 load_map_stuff
 thumb_func 0x8085f9c
-thumb_func 0x8085ffc
+thumb_func 0x8085ffc map_loading_iteration_2_link
 thumb_func 0x8086114 do_load_map_stuff_loop
-thumb_func 0x808612c
+thumb_func 0x808612c CallTrainerHillFunction
 thumb_func 0x808613c
 thumb_func 0x80861c4
-thumb_func 0x80861dc
+thumb_func 0x80861dc InitOverworldGraphicsRegisters
 thumb_func 0x80862ec
 thumb_func 0x8086340
-thumb_func 0x8086368
+thumb_func 0x8086368 mli4_mapscripts_and_other
 thumb_func 0x80863cc
 thumb_func 0x80863e4
 thumb_func 0x8086410 SetCameraToTrackGuestPlayer
@@ -3345,61 +3345,61 @@ thumb_func 0x808642c SetCameraToTrackGuestPlayer_2
 thumb_func 0x8086448
 thumb_func 0x8086478
 thumb_func 0x8086500 CreateLinkPlayerSprites
-thumb_func 0x808653c
-thumb_func 0x8086590
-thumb_func 0x80865a4
-thumb_func 0x80865b4
-thumb_func 0x80865c8
+thumb_func 0x808653c CB1_UpdateLinkState
+thumb_func 0x8086590 ResetAllMultiplayerState
+thumb_func 0x80865a4 ClearAllPlayerKeys
+thumb_func 0x80865b4 SetKeyInterceptCallback
+thumb_func 0x80865c8 CheckRfuKeepAliveTimer
 thumb_func 0x80865f4 ResetAllTradingStates
-thumb_func 0x808660c
-thumb_func 0x8086644
-thumb_func 0x808667c
+thumb_func 0x808660c AreAllPlayersInTradingState
+thumb_func 0x8086644 IsAnyPlayerInTradingState
+thumb_func 0x808667c HandleLinkPlayerKeyInput
 thumb_func 0x808689c UpdateAllLinkPlayers
-thumb_func 0x8086904
-thumb_func 0x8086970
+thumb_func 0x8086904 UpdateHeldKeyCode
+thumb_func 0x8086970 KeyInterCB_ReadButtons
 thumb_func 0x80869cc GetDirectionForDpadKey
-thumb_func 0x8086a00
-thumb_func 0x8086a14
+thumb_func 0x8086a00 ResetPlayerHeldKeys
+thumb_func 0x8086a14 KeyInterCB_SelfIdle
 thumb_func 0x8086a50
-thumb_func 0x8086a5c
+thumb_func 0x8086a5c KeyInterCB_DeferToEventScript
 thumb_func 0x8086a80
-thumb_func 0x8086aa4
-thumb_func 0x8086ac8
+thumb_func 0x8086aa4 KeyInterCB_DeferToSendQueue
+thumb_func 0x8086ac8 KeyInterCB_DoNothingAndKeepAlive
 thumb_func 0x8086ad4
 thumb_func 0x8086b10
 thumb_func 0x8086b24
-thumb_func 0x8086b28
-thumb_func 0x8086b60
+thumb_func 0x8086b28 KeyInterCB_WaitForPlayersToExit
+thumb_func 0x8086b60 KeyInterCB_SendExitRoomKey
 thumb_func 0x8086b74
 thumb_func 0x8086b78
 thumb_func 0x8086be0
 thumb_func 0x8086bec
 thumb_func 0x8086c00
-thumb_func 0x8086c14
+thumb_func 0x8086c14 QueueExitLinkRoomKey
 thumb_func 0x8086c28
 thumb_func 0x8086c3c LoadTradeRoomPlayer
 thumb_func 0x8086ca4
 thumb_func 0x8086cbc
-thumb_func 0x8086cd4
+thumb_func 0x8086cd4 TryGetTileEventScript
 thumb_func 0x8086cec PlayerIsAtSouthExit
-thumb_func 0x8086d18
-thumb_func 0x8086de4
+thumb_func 0x8086d18 TryInteractWithPlayer
+thumb_func 0x8086de4 GetDirectionForEventScript
 thumb_func 0x8086e74
-thumb_func 0x8086e80
+thumb_func 0x8086e80 InitLinkRoomStartMenuScript
 thumb_func 0x8086e94
-thumb_func 0x8086eb0
+thumb_func 0x8086eb0 CreateConfirmLeaveTradeRoomPrompt
 thumb_func 0x8086ecc
 thumb_func 0x8086ee8
 thumb_func 0x8086efc
 thumb_func 0x8086f2c
 thumb_func 0x8086f98
 thumb_func 0x8086fd0
-thumb_func 0x8086ff4
-thumb_func 0x8087028
-thumb_func 0x8087030
-thumb_func 0x8087044
+thumb_func 0x8086ff4 GetLinkSendQueueLength
+thumb_func 0x8087028 ZeroLinkPlayerEventObject
+thumb_func 0x8087030 ClearLinkPlayerEventObjects
+thumb_func 0x8087044 ZeroEventObject
 thumb_func 0x8087054
-thumb_func 0x8087100
+thumb_func 0x8087100 InitLinkPlayerEventObjectPos
 thumb_func 0x8087140
 thumb_func 0x8087170
 thumb_func 0x80871bc GetSpriteForLinkedPlayer
@@ -3407,51 +3407,51 @@ thumb_func 0x80871dc GetLinkPlayerCoords
 thumb_func 0x8087204 GetLinkPlayerFacingDirection
 thumb_func 0x8087224 GetLinkPlayerElevation
 thumb_func 0x8087248
-thumb_func 0x8087270
-thumb_func 0x80872d0
+thumb_func 0x8087270 GetLinkPlayerIdAt
+thumb_func 0x80872d0 SetPlayerFacingDirection
 thumb_func 0x808733c
 thumb_func 0x808735c
 thumb_func 0x8087360
 thumb_func 0x8087380
-thumb_func 0x8087384
+thumb_func 0x8087384 FacingHandler_DpadMovement
 thumb_func 0x80873ec FacingHandler_ForcedFacingChange
-thumb_func 0x8087404
-thumb_func 0x808740c
-thumb_func 0x8087444
-thumb_func 0x80874a4
-thumb_func 0x8087530
-thumb_func 0x80875f0
-thumb_func 0x80876a8
-thumb_func 0x80876b8
-thumb_func 0x80876d8
-thumb_func 0x8087710
-thumb_func 0x8087748
-thumb_func 0x8087778
-thumb_func 0x80877d4
-thumb_func 0x808782c
+thumb_func 0x8087404 MovementStatusHandler_EnterFreeMode
+thumb_func 0x808740c MovementStatusHandler_TryAdvanceScript
+thumb_func 0x8087444 FlipVerticalAndClearForced
+thumb_func 0x80874a4 LinkPlayerDetectCollision
+thumb_func 0x8087530 CreateLinkPlayerSprite
+thumb_func 0x80875f0 SpriteCB_LinkPlayer
+thumb_func 0x80876a8 mapconnection_get_mapheader
+thumb_func 0x80876b8 InitMap
+thumb_func 0x80876d8 InitMapFromSavedGame
+thumb_func 0x8087710 InitBattlePyramidMap
+thumb_func 0x8087748 InitTrainerHillMap
+thumb_func 0x8087778 InitMapLayoutData
+thumb_func 0x80877d4 InitBackupMapLayoutData
+thumb_func 0x808782c InitBackupMapLayoutConnections
 thumb_func 0x80878b8
-thumb_func 0x808791c
-thumb_func 0x8087984
-thumb_func 0x80879e4
-thumb_func 0x8087a44
-thumb_func 0x8087aa8
-thumb_func 0x8087b14
-thumb_func 0x8087b88
+thumb_func 0x808791c FillSouthConnection
+thumb_func 0x8087984 FillNorthConnection
+thumb_func 0x80879e4 FillWestConnection
+thumb_func 0x8087a44 FillEastConnection
+thumb_func 0x8087aa8 MapGridGetZCoordAt
+thumb_func 0x8087b14 MapGridIsImpassableAt
+thumb_func 0x8087b88 MapGridGetMetatileIdAt
 thumb_func 0x8087c20 MapGridGetMetatileBehaviorAt
 thumb_func 0x8087c38 MapGridGetMetatileLayerTypeAt
 thumb_func 0x8087c54 MapGridSetMetatileIdAt
 thumb_func 0x8087c9c MapGridSetMetatileEntryAt
-thumb_func 0x8087cd4
+thumb_func 0x8087cd4 GetBehaviorByMetatileId
 thumb_func 0x8087d28 save_serialize_map
-thumb_func 0x8087d9c
-thumb_func 0x8087dd8
+thumb_func 0x8087d9c SavedMapViewIsEmpty
+thumb_func 0x8087dd8 ClearSavedMapView
 thumb_func 0x8087e00
 thumb_func 0x8087f28
-thumb_func 0x8088000
+thumb_func 0x8088000 GetMapBorderIdAt
 thumb_func 0x80880ec GetPostCameraMoveMapBorderId
-thumb_func 0x8088114
+thumb_func 0x8088114 CanCameraMoveInDirection
 thumb_func 0x808815c
-thumb_func 0x80881e0
+thumb_func 0x80881e0 CameraMove
 thumb_func 0x80882b4
 thumb_func 0x808830c
 thumb_func 0x8088370
@@ -3459,25 +3459,25 @@ thumb_func 0x808839c
 thumb_func 0x80883b0
 thumb_func 0x80883f0
 thumb_func 0x80884a0
-thumb_func 0x80884bc
-thumb_func 0x80884d4
-thumb_func 0x80884e4
+thumb_func 0x80884bc GetCameraFocusCoords
+thumb_func 0x80884d4 SetPlayerCoords
+thumb_func 0x80884e4 GetCameraCoords
 thumb_func 0x80884f8
-thumb_func 0x8088554
+thumb_func 0x8088554 SkipCopyingMetatileFromSavedMap
 thumb_func 0x8088598
 thumb_func 0x80885dc
 thumb_func 0x8088620 nullsub_13
 thumb_func 0x8088624 nullsub_45
-thumb_func 0x8088628
-thumb_func 0x80886b4
-thumb_func 0x80886c8
-thumb_func 0x80886dc
-thumb_func 0x80886f0
-thumb_func 0x8088700
+thumb_func 0x8088628 apply_map_tileset_palette
+thumb_func 0x80886b4 copy_map_tileset1_to_vram
+thumb_func 0x80886c8 copy_map_tileset2_to_vram
+thumb_func 0x80886dc copy_map_tileset2_to_vram_2
+thumb_func 0x80886f0 apply_map_tileset1_palette
+thumb_func 0x8088700 apply_map_tileset2_palette
 thumb_func 0x8088710 copy_map_tileset1_tileset2_to_vram
 thumb_func 0x8088738 apply_map_tileset1_tileset2_palette
 thumb_func 0x8088750
-thumb_func 0x8088754
+thumb_func 0x8088754 MetatileBehavior_IsEncounterTile
 thumb_func 0x8088778 MetatileBehavior_IsJumpEast
 thumb_func 0x808878c MetatileBehavior_IsJumpWest
 thumb_func 0x80887a0 MetatileBehavior_IsJumpNorth
@@ -3494,7 +3494,7 @@ thumb_func 0x8088894 Unref_MetatileBehavior_IsUnused04
 thumb_func 0x80888a8 MetatileBehavior_IsLadder
 thumb_func 0x80888bc MetatileBehavior_IsNonAnimDoor
 thumb_func 0x80888d8 MetatileBehavior_IsDeepSouthWarp
-thumb_func 0x80888ec
+thumb_func 0x80888ec MetatileBehavior_IsSurfableWaterOrUnderwater
 thumb_func 0x8088910 MetatileBehavior_IsEastArrowWarp
 thumb_func 0x8088924 MetatileBehavior_IsWestArrowWarp
 thumb_func 0x8088938 MetatileBehavior_IsNorthArrowWarp
@@ -3531,7 +3531,7 @@ thumb_func 0x8088c28 MetatileBehavior_IsBlockDecoration
 thumb_func 0x8088c3c MetatileBehavior_IsSecretBaseImpassable
 thumb_func 0x8088c50 MetatileBehavior_IsMB_C6
 thumb_func 0x8088c64 MetatileBehavior_IsSecretBasePoster
-thumb_func 0x8088c78
+thumb_func 0x8088c78 MetatileBehavior_IsNormal
 thumb_func 0x8088c8c MetatileBehavior_IsSecretBaseNorthWall
 thumb_func 0x8088ca0
 thumb_func 0x8088cb4 MetatileBehavior_HoldsSmallDecoration
@@ -3620,11 +3620,11 @@ thumb_func 0x808946c MetatileBehavior_IsQuestionnaire
 thumb_func 0x8089480
 thumb_func 0x8089494 MetatileBehavior_IsLongGrassSouthEdge
 thumb_func 0x80894a8 MetatileBehavior_IsTrainerHillTimer
-thumb_func 0x80894bc
+thumb_func 0x80894bc move_tilemap_camera_to_upper_left_corner_
 thumb_func 0x80894cc tilemap_move_something
-thumb_func 0x80894e8
-thumb_func 0x80894f8
-thumb_func 0x8089508
+thumb_func 0x80894e8 coords8_add
+thumb_func 0x80894f8 move_tilemap_camera_to_upper_left_corner
+thumb_func 0x8089508 FieldUpdateBgTilemapScroll
 thumb_func 0x808956c
 thumb_func 0x8089598 DrawWholeMapView
 thumb_func 0x80895c4 DrawWholeMapViewInternal
@@ -3636,139 +3636,139 @@ thumb_func 0x8089798 RedrawMapSliceWest
 thumb_func 0x8089804 CurrentMapDrawMetatileAt
 thumb_func 0x8089840 DrawDoorMetatileAt
 thumb_func 0x8089874 DrawMetatileAt
-thumb_func 0x80898dc
-thumb_func 0x8089a10
+thumb_func 0x80898dc DrawMetatile
+thumb_func 0x8089a10 MapPosToBgTilemapOffset
 thumb_func 0x8089a58 CameraUpdateCallback
-thumb_func 0x8089a80
-thumb_func 0x8089a98
-thumb_func 0x8089ad8
-thumb_func 0x8089be8
+thumb_func 0x8089a80 ResetCameraUpdateInfo
+thumb_func 0x8089a98 InitCameraUpdateCallback
+thumb_func 0x8089ad8 CameraUpdate
+thumb_func 0x8089be8 MoveCameraAndRedrawMap
 thumb_func 0x8089c24
-thumb_func 0x8089c30
+thumb_func 0x8089c30 SetCameraPanning
 thumb_func 0x8089c48 InstallCameraPanAheadCallback
-thumb_func 0x8089c78
-thumb_func 0x8089cc4
-thumb_func 0x8089d64
+thumb_func 0x8089c78 UpdateCameraPanning
+thumb_func 0x8089cc4 CameraPanningCB_PanAhead
+thumb_func 0x8089d64 CopyDoorTilesToVram
 thumb_func 0x8089d9c door_build_blockdef
 thumb_func 0x8089ddc DrawCurrentDoorAnimFrame
 thumb_func 0x8089e94 DrawClosedDoorTiles
-thumb_func 0x8089ecc
+thumb_func 0x8089ecc DrawDoor
 thumb_func 0x8089f54
-thumb_func 0x8089fb8
+thumb_func 0x8089fb8 Task_AnimateDoor
 thumb_func 0x8089ff0 GetLastDoorFrame
 thumb_func 0x808a004 GetDoorGraphics
-thumb_func 0x808a028
-thumb_func 0x808a08c
+thumb_func 0x808a028 StartDoorAnimationTask
+thumb_func 0x808a08c DrawClosedDoor
 thumb_func 0x808a098 DrawOpenedDoor
-thumb_func 0x808a0d8
-thumb_func 0x808a130
+thumb_func 0x808a0d8 StartDoorOpenAnimation
+thumb_func 0x808a130 StartDoorCloseAnimation
 thumb_func 0x808a170 cur_mapdata_get_door_x2_at
-thumb_func 0x808a1a0
+thumb_func 0x808a1a0 unref_sub_808A83C
 thumb_func 0x808a1b8 FieldSetDoorOpened
 thumb_func 0x808a1e4 FieldSetDoorClosed
-thumb_func 0x808a210
-thumb_func 0x808a248
-thumb_func 0x808a280
-thumb_func 0x808a294
+thumb_func 0x808a210 FieldAnimateDoorClose
+thumb_func 0x808a248 FieldAnimateDoorOpen
+thumb_func 0x808a280 FieldIsDoorAnimationRunning
+thumb_func 0x808a294 GetDoorSoundEffect
 thumb_func 0x808a2c8
-thumb_func 0x808a2fc
+thumb_func 0x808a2fc MovementType_Player
 thumb_func 0x808a320
-thumb_func 0x808a324
-thumb_func 0x808a39c
+thumb_func 0x808a324 player_step
+thumb_func 0x808a39c TryInterruptEventObjectSpecialAnim
 thumb_func 0x808a400 npc_clear_strange_bits
-thumb_func 0x808a424
+thumb_func 0x808a424 MovePlayerAvatarUsingKeypadInput
 thumb_func 0x808a45c PlayerAllowForcedMovementIfMovingSameDirection
-thumb_func 0x808a478
+thumb_func 0x808a478 TryDoMetatileBehaviorForcedMovement
 thumb_func 0x808a48c
-thumb_func 0x808a49c
-thumb_func 0x808a4f8
-thumb_func 0x808a544
+thumb_func 0x808a49c GetForcedMovementByMetatileBehavior
+thumb_func 0x808a4f8 ForcedMovement_None
+thumb_func 0x808a544 DoForcedMovement
 thumb_func 0x808a5bc DoForcedMovementInCurrentDirection
 thumb_func 0x808a5f0
-thumb_func 0x808a604
-thumb_func 0x808a61c
-thumb_func 0x808a634
-thumb_func 0x808a64c
-thumb_func 0x808a664
-thumb_func 0x808a67c
-thumb_func 0x808a694
-thumb_func 0x808a6ac
+thumb_func 0x808a604 ForcedMovement_WalkSouth
+thumb_func 0x808a61c ForcedMovement_WalkNorth
+thumb_func 0x808a634 ForcedMovement_WalkWest
+thumb_func 0x808a64c ForcedMovement_WalkEast
+thumb_func 0x808a664 ForcedMovement_PushedSouthByCurrent
+thumb_func 0x808a67c ForcedMovement_PushedNorthByCurrent
+thumb_func 0x808a694 ForcedMovement_PushedWestByCurrent
+thumb_func 0x808a6ac ForcedMovement_PushedEastByCurrent
 thumb_func 0x808a6c4 ForcedMovement_Slide
-thumb_func 0x808a6fc
-thumb_func 0x808a714
-thumb_func 0x808a72c
-thumb_func 0x808a744
-thumb_func 0x808a75c
-thumb_func 0x808a768
-thumb_func 0x808a774
-thumb_func 0x808a7cc
+thumb_func 0x808a6fc ForcedMovement_SlideSouth
+thumb_func 0x808a714 ForcedMovement_SlideNorth
+thumb_func 0x808a72c ForcedMovement_SlideWest
+thumb_func 0x808a744 ForcedMovement_SlideEast
+thumb_func 0x808a75c ForcedMovement_0xBB
+thumb_func 0x808a768 ForcedMovement_0xBC
+thumb_func 0x808a774 ForcedMovement_MuddySlope
+thumb_func 0x808a7cc MovePlayerNotOnBike
 thumb_func 0x808a7f4
-thumb_func 0x808a7fc
-thumb_func 0x808a840
-thumb_func 0x808a854
-thumb_func 0x808a864
-thumb_func 0x808a920
+thumb_func 0x808a7fc CheckMovementInputNotOnBike
+thumb_func 0x808a840 PlayerNotOnBikeNotMoving
+thumb_func 0x808a854 PlayerNotOnBikeTurningInPlace
+thumb_func 0x808a864 PlayerNotOnBikeMoving
+thumb_func 0x808a920 CheckForPlayerAvatarCollision
 thumb_func 0x808a98c
-thumb_func 0x808a9f8
+thumb_func 0x808a9f8 CheckForEventObjectCollision
 thumb_func 0x808aac8
 thumb_func 0x808ab20
-thumb_func 0x808ab78
+thumb_func 0x808ab78 ShouldJumpLedge
 thumb_func 0x808ab9c
-thumb_func 0x808ac48
-thumb_func 0x808ac88
+thumb_func 0x808ac48 check_acro_bike_metatile
+thumb_func 0x808ac88 IsPlayerCollidingWithFarawayIslandMew
 thumb_func 0x808ad30 SetPlayerAvatarTransitionFlags
-thumb_func 0x808ad4c
+thumb_func 0x808ad4c DoPlayerAvatarTransition
 thumb_func 0x808ada0 nullsub_44
-thumb_func 0x808ada4
-thumb_func 0x808add0
-thumb_func 0x808ae04
-thumb_func 0x808ae3c
-thumb_func 0x808ae98
-thumb_func 0x808aecc
+thumb_func 0x808ada4 PlayerAvatarTransition_Normal
+thumb_func 0x808add0 PlayerAvatarTransition_MachBike
+thumb_func 0x808ae04 PlayerAvatarTransition_AcroBike
+thumb_func 0x808ae3c PlayerAvatarTransition_Surfing
+thumb_func 0x808ae98 PlayerAvatarTransition_Underwater
+thumb_func 0x808aecc PlayerAvatarTransition_ReturnToField
 thumb_func 0x808aedc
-thumb_func 0x808af20
+thumb_func 0x808af20 player_is_anim_in_certain_ranges
 thumb_func 0x808af7c
 thumb_func 0x808afa0
 thumb_func 0x808afc4
 thumb_func 0x808afe8 PlayerSetCopyableMovement
 thumb_func 0x808b004 PlayerGetCopyableMovement
 thumb_func 0x808b020
-thumb_func 0x808b048
-thumb_func 0x808b084
-thumb_func 0x808b09c
-thumb_func 0x808b0b4
-thumb_func 0x808b0cc
-thumb_func 0x808b0e4
-thumb_func 0x808b0fc
-thumb_func 0x808b120
-thumb_func 0x808b138
-thumb_func 0x808b15c
+thumb_func 0x808b048 PlayerSetAnimId
+thumb_func 0x808b084 PlayerGoSpeed1
+thumb_func 0x808b09c PlayerGoSpeed2
+thumb_func 0x808b0b4 pokemonanimfunc_49
+thumb_func 0x808b0cc PlayerGoSpeed4
+thumb_func 0x808b0e4 PlayerRun
+thumb_func 0x808b0fc PlayerOnBikeCollide
+thumb_func 0x808b120 PlayerOnBikeCollideWithFarawayIslandMew
+thumb_func 0x808b138 PlayerNotOnBikeCollide
+thumb_func 0x808b15c PlayerNotOnBikeCollideWithFarawayIslandMew
 thumb_func 0x808b174
-thumb_func 0x808b18c
+thumb_func 0x808b18c PlayerTurnInPlace
 thumb_func 0x808b1a4
 thumb_func 0x808b1c8
-thumb_func 0x808b20c
-thumb_func 0x808b224
+thumb_func 0x808b20c PlayerIdleWheelie
+thumb_func 0x808b224 PlayerStartWheelie
 thumb_func 0x808b23c
 thumb_func 0x808b254
-thumb_func 0x808b278
-thumb_func 0x808b29c
-thumb_func 0x808b2c0
-thumb_func 0x808b2e4
+thumb_func 0x808b278 PlayerMovingHoppingWheelie
+thumb_func 0x808b29c PlayerLedgeHoppingWheelie
+thumb_func 0x808b2c0 PlayerAcroTurnJump
+thumb_func 0x808b2e4 PlayerStandingHoppingWheelie
 thumb_func 0x808b308
 thumb_func 0x808b320
 thumb_func 0x808b338
-thumb_func 0x808b350
-thumb_func 0x808b3cc
+thumb_func 0x808b350 PlayCollisionSoundIfNotFacingWarp
+thumb_func 0x808b3cc GetXYCoordsOneStepInFrontOfPlayer
 thumb_func 0x808b410 PlayerGetDestCoords
-thumb_func 0x808b440
+thumb_func 0x808b440 player_get_pos_including_state_based_drift
 thumb_func 0x808b59c GetPlayerFacingDirection
 thumb_func 0x808b5bc GetPlayerMovementDirection
 thumb_func 0x808b5d8 PlayerGetZCoord
 thumb_func 0x808b5f4
-thumb_func 0x808b624
+thumb_func 0x808b624 TestPlayerAvatarFlags
 thumb_func 0x808b634
-thumb_func 0x808b640
+thumb_func 0x808b640 GetPlayerAvatarObjectId
 thumb_func 0x808b64c
 thumb_func 0x808b658
 thumb_func 0x808b6a0
@@ -3778,148 +3778,148 @@ thumb_func 0x808b6e0
 thumb_func 0x808b6f0 GetPlayerAvatarGraphicsIdByStateId
 thumb_func 0x808b70c unref_GetRivalAvatarGenderByGraphicsId
 thumb_func 0x808b738 GetPlayerAvatarGenderByGraphicsId
-thumb_func 0x808b764
+thumb_func 0x808b764 PartyHasMonWithSurf
 thumb_func 0x808b7b4 IsPlayerSurfingNorth
-thumb_func 0x808b7d8
-thumb_func 0x808b864
-thumb_func 0x808b878
-thumb_func 0x808b890
-thumb_func 0x808b8d0
+thumb_func 0x808b7d8 IsPlayerFacingSurfableFishableWater
+thumb_func 0x808b864 ClearPlayerAvatarInfo
+thumb_func 0x808b878 SetPlayerAvatarStateMask
+thumb_func 0x808b890 GetPlayerAvatarStateTransitionByGraphicsId
+thumb_func 0x808b8d0 GetPlayerAvatarGraphicsIdByCurrentState
 thumb_func 0x808b914 SetPlayerAvatarExtraStateTransition
-thumb_func 0x808b944
+thumb_func 0x808b944 InitPlayerAvatar
 thumb_func 0x808ba0c
 thumb_func 0x808ba78
 thumb_func 0x808bac0
 thumb_func 0x808bb18
 thumb_func 0x808bb8c
 thumb_func 0x808bbe4
-thumb_func 0x808bc74
-thumb_func 0x808bcb0
+thumb_func 0x808bc74 StartStrengthAnim
+thumb_func 0x808bcb0 Task_BumpBoulder
 thumb_func 0x808bd08
-thumb_func 0x808bd28
+thumb_func 0x808bd28 do_boulder_dust
 thumb_func 0x808bde8
 thumb_func 0x808be3c
 thumb_func 0x808be5c
 thumb_func 0x808be8c
-thumb_func 0x808bea8
+thumb_func 0x808bea8 PlayerAvatar_DoSecretBaseMatJump
 thumb_func 0x808bf14
 thumb_func 0x808bf34
 thumb_func 0x808bf64
-thumb_func 0x808bf80
-thumb_func 0x808bfa8
-thumb_func 0x808c020
-thumb_func 0x808c060
+thumb_func 0x808bf80 PlayerAvatar_SecretBaseMatSpinStep0
+thumb_func 0x808bfa8 PlayerAvatar_SecretBaseMatSpinStep1
+thumb_func 0x808c020 PlayerAvatar_SecretBaseMatSpinStep2
+thumb_func 0x808c060 PlayerAvatar_SecretBaseMatSpinStep3
 thumb_func 0x808c0b4
-thumb_func 0x808c10c
+thumb_func 0x808c10c taskFF_0805D1D4
 thumb_func 0x808c178
-thumb_func 0x808c1f0
+thumb_func 0x808c1f0 StartFishing
 thumb_func 0x808c224
 thumb_func 0x808c25c
-thumb_func 0x808c27c
-thumb_func 0x808c314
-thumb_func 0x808c338
+thumb_func 0x808c27c Fishing2
+thumb_func 0x808c314 Fishing3
+thumb_func 0x808c338 Fishing4
 thumb_func 0x808c384
-thumb_func 0x808c424
+thumb_func 0x808c424 Fishing6
 thumb_func 0x808c4d4
-thumb_func 0x808c514
-thumb_func 0x808c56c
-thumb_func 0x808c5d4
-thumb_func 0x808c618
-thumb_func 0x808c704
-thumb_func 0x808c774
+thumb_func 0x808c514 Fishing8
+thumb_func 0x808c56c Fishing9
+thumb_func 0x808c5d4 Fishing10
+thumb_func 0x808c618 Fishing11
+thumb_func 0x808c704 Fishing12
+thumb_func 0x808c774 Fishing13
 thumb_func 0x808c7e4 Fishing14
-thumb_func 0x808c7fc
-thumb_func 0x808c89c
-thumb_func 0x808c8e8
+thumb_func 0x808c7fc Fishing15
+thumb_func 0x808c89c Fishing16
+thumb_func 0x808c8e8 AlignFishingAnimationFrames
 thumb_func 0x808c9e4
 thumb_func 0x808c9f0
 thumb_func 0x808ca04
 thumb_func 0x808cb04
-thumb_func 0x808cb24
+thumb_func 0x808cb24 RunOnLoadMapScript
 thumb_func 0x808cb38
 thumb_func 0x808cb58
 thumb_func 0x808cb6c
 thumb_func 0x808ccfc
-thumb_func 0x808cd60
+thumb_func 0x808cd60 ClearEventObject
 thumb_func 0x808cd80 ClearAllEventObjects
-thumb_func 0x808cda8
-thumb_func 0x808cdc0
-thumb_func 0x808ce64
+thumb_func 0x808cda8 ResetEventObjects
+thumb_func 0x808cdc0 CreateReflectionEffectSprites
+thumb_func 0x808ce64 GetFirstInactiveEventObjectId
 thumb_func 0x808ce94 GetEventObjectIdByLocalIdAndMap
 thumb_func 0x808ceb8 TryGetEventObjectIdByLocalIdAndMap
 thumb_func 0x808cee4 GetEventObjectIdByXY
-thumb_func 0x808cf28
-thumb_func 0x808cf78
+thumb_func 0x808cf28 GetEventObjectIdByLocalIdAndMapInternal
+thumb_func 0x808cf78 GetEventObjectIdByLocalId
 thumb_func 0x808cfb4 InitEventObjectStateFromTemplate
-thumb_func 0x808d0ec
-thumb_func 0x808d180
+thumb_func 0x808d0ec Unref_TryInitLocalEventObject
+thumb_func 0x808d180 GetAvailableEventObjectId
 thumb_func 0x808d220 RemoveEventObject
-thumb_func 0x808d234
-thumb_func 0x808d27c
+thumb_func 0x808d234 RemoveEventObjectByLocalIdAndMap
+thumb_func 0x808d27c RemoveEventObjectInternal
 thumb_func 0x808d2c8 RemoveAllEventObjectsExceptPlayer
-thumb_func 0x808d2fc
-thumb_func 0x808d4b0
+thumb_func 0x808d2fc TrySetupEventObjectSprite
+thumb_func 0x808d4b0 TrySpawnEventObjectTemplate
 thumb_func 0x808d578 SpawnSpecialEventObject
 thumb_func 0x808d5b4 SpawnSpecialEventObjectParameterized
 thumb_func 0x808d61c TrySpawnEventObject
 thumb_func 0x808d66c MakeObjectTemplateFromEventObjectGraphicsInfo
 thumb_func 0x808d6a0 MakeObjectTemplateFromEventObjectGraphicsInfoWithCallbackIndex
 thumb_func 0x808d6c0 MakeObjectTemplateFromEventObjectTemplate
-thumb_func 0x808d6d8
-thumb_func 0x808d77c
-thumb_func 0x808d8f0
+thumb_func 0x808d6d8 AddPseudoEventObject
+thumb_func 0x808d77c sprite_new
+thumb_func 0x808d8f0 TrySpawnEventObjects
 thumb_func 0x808d9fc RemoveEventObjectsOutsideView
 thumb_func 0x808da5c RemoveEventObjectIfOutsideView
 thumb_func 0x808dadc
 thumb_func 0x808db28
 thumb_func 0x808dcfc
-thumb_func 0x808dd34
-thumb_func 0x808dd68
+thumb_func 0x808dd34 SetPlayerAvatarEventObjectIdAndObjectId
+thumb_func 0x808dd68 EventObjectSetGraphicsId
 thumb_func 0x808de74 EventObjectSetGraphicsIdByLocalIdAndMap
-thumb_func 0x808deb4
+thumb_func 0x808deb4 EventObjectTurn
 thumb_func 0x808df04 EventObjectTurnByLocalIdAndMap
 thumb_func 0x808df44 PlayerObjectTurn
-thumb_func 0x808df64
-thumb_func 0x808e004
-thumb_func 0x808e04c
+thumb_func 0x808df64 get_berry_tree_graphics
+thumb_func 0x808e004 GetEventObjectGraphicsInfo
+thumb_func 0x808e04c SetEventObjectDynamicGraphicsId
 thumb_func 0x808e068 npc_by_local_id_and_map_set_field_1_bit_x20
 thumb_func 0x808e0b8 EventObjectGetLocalIdAndMap
 thumb_func 0x808e0cc
 thumb_func 0x808e0fc
 thumb_func 0x808e154
 thumb_func 0x808e19c
-thumb_func 0x808e1f0
+thumb_func 0x808e1f0 UpdateShoalTideFlag
 thumb_func 0x808e204 LoadEventObjectPalette
 thumb_func 0x808e230 Unused_LoadEventObjectPaletteSet
 thumb_func 0x808e264
-thumb_func 0x808e28c
+thumb_func 0x808e28c PatchObjectPalette
 thumb_func 0x808e2c4 PatchObjectPaletteRange
-thumb_func 0x808e2f0
-thumb_func 0x808e338
-thumb_func 0x808e3a8
+thumb_func 0x808e2f0 FindEventObjectPaletteIndexByTag
+thumb_func 0x808e338 LoadPlayerObjectReflectionPalette
+thumb_func 0x808e3a8 LoadSpecialObjectReflectionPalette
 thumb_func 0x808e420
 thumb_func 0x808e434 unref_sub_808EAC4
-thumb_func 0x808e454
-thumb_func 0x808e464
+thumb_func 0x808e454 ShiftEventObjectCoords
+thumb_func 0x808e464 SetEventObjectCoords
 thumb_func 0x808e478 MoveEventObjectToMapCoords
 thumb_func 0x808e518 TryMoveEventObjectToMapCoords
-thumb_func 0x808e56c
+thumb_func 0x808e56c ShiftStillEventObjectCoords
 thumb_func 0x808e580 UpdateEventObjectCoordsForCameraUpdate
-thumb_func 0x808e5e8
+thumb_func 0x808e5e8 GetEventObjectIdByXYZ
 thumb_func 0x808e650 EventObjectDoesZCoordMatch
 thumb_func 0x808e678 UpdateEventObjectsForCameraUpdate
-thumb_func 0x808e6a4
-thumb_func 0x808e6e8
+thumb_func 0x808e6a4 AddCameraObject
+thumb_func 0x808e6e8 ObjectCB_CameraObject
 thumb_func 0x808e710 CameraObject_0
 thumb_func 0x808e74c CameraObject_1
 thumb_func 0x808e784 CameraObject_2
-thumb_func 0x808e7b4
-thumb_func 0x808e7fc
+thumb_func 0x808e7b4 FindCameraObject
+thumb_func 0x808e7fc CameraObjectReset1
 thumb_func 0x808e818 CameraObjectSetFollowedObjectId
 thumb_func 0x808e834 CameraObjectGetFollowedObjectId
-thumb_func 0x808e84c
-thumb_func 0x808e85c
-thumb_func 0x808e8c0
+thumb_func 0x808e84c CameraObjectReset2
+thumb_func 0x808e85c CopySprite
+thumb_func 0x808e8c0 CreateCopySpriteAt
 thumb_func 0x808e930 SetEventObjectDirection
 thumb_func 0x808e974 GetEventObjectScriptPointerByLocalIdAndMap
 thumb_func 0x808e98c GetEventObjectScriptPointerByEventObjectId
@@ -3928,33 +3928,33 @@ thumb_func 0x808e9c8 GetEventObjectFlagIdByEventObjectId
 thumb_func 0x808e9f0
 thumb_func 0x808ea2c
 thumb_func 0x808ea44
-thumb_func 0x808ea80
-thumb_func 0x808ea98
+thumb_func 0x808ea80 EventObjectGetBerryTreeId
+thumb_func 0x808ea98 GetEventObjectTemplateByLocalIdAndMap
 thumb_func 0x808eaec FindEventObjectTemplateByLocalId
-thumb_func 0x808eb24
+thumb_func 0x808eb24 GetBaseTemplateForEventObject
 thumb_func 0x808eb78 OverrideTemplateCoordsForEventObject
 thumb_func 0x808eb98 OverrideEventObjectTemplateScript
 thumb_func 0x808ebac TryOverrideTemplateCoordsForEventObject
 thumb_func 0x808ebc4 TryOverrideEventObjectTemplateCoords
-thumb_func 0x808ebfc
+thumb_func 0x808ebfc OverrideSecretBaseDecorationSpriteScript
 thumb_func 0x808ec68
-thumb_func 0x808ecd0
+thumb_func 0x808ecd0 GetObjectPaletteTag
 thumb_func 0x808ed50 MovementType_None
 thumb_func 0x808ed74
 thumb_func 0x808ed78 MovementType_WanderAround
 thumb_func 0x808ed9c
 thumb_func 0x808edb0
-thumb_func 0x808edbc
+thumb_func 0x808edbc MovementType_WanderAround_Step0
 thumb_func 0x808edd0 MovementType_WanderAround_Step1
-thumb_func 0x808edfc
+thumb_func 0x808edfc MovementType_WanderAround_Step2
 thumb_func 0x808ee38 MovementType_WanderAround_Step3
-thumb_func 0x808ee58
+thumb_func 0x808ee58 MovementType_WanderAround_Step4
 thumb_func 0x808eea4 MovementType_WanderAround_Step5
 thumb_func 0x808eed4 MovementType_WanderAround_Step6
-thumb_func 0x808eefc
+thumb_func 0x808eefc EventObjectIsTrainerAndCloseToPlayer
 thumb_func 0x808ef78 GetVectorDirection
-thumb_func 0x808efa8
-thumb_func 0x808efb8
+thumb_func 0x808efa8 GetLimitedVectorDirection_SouthNorth
+thumb_func 0x808efb8 GetLimitedVectorDirection_WestEast
 thumb_func 0x808efcc GetLimitedVectorDirection_WestNorth
 thumb_func 0x808f028 GetLimitedVectorDirection_EastNorth
 thumb_func 0x808f084 GetLimitedVectorDirection_WestSouth
@@ -3963,33 +3963,33 @@ thumb_func 0x808f13c GetLimitedVectorDirection_SouthNorthWest
 thumb_func 0x808f178 GetLimitedVectorDirection_SouthNorthEast
 thumb_func 0x808f1b4 GetLimitedVectorDirection_NorthWestEast
 thumb_func 0x808f1f0 GetLimitedVectorDirection_SouthWestEast
-thumb_func 0x808f22c
+thumb_func 0x808f22c TryGetTrainerEncounterDirection
 thumb_func 0x808f2b4 MovementType_LookAround
 thumb_func 0x808f2d8
 thumb_func 0x808f2ec
-thumb_func 0x808f2f8
+thumb_func 0x808f2f8 MovementType_LookAround_Step0
 thumb_func 0x808f30c MovementType_LookAround_Step1
-thumb_func 0x808f338
+thumb_func 0x808f338 MovementType_LookAround_Step2
 thumb_func 0x808f37c MovementType_LookAround_Step3
-thumb_func 0x808f3ac
+thumb_func 0x808f3ac MovementType_LookAround_Step4
 thumb_func 0x808f3f4 MovementType_WanderUpAndDown
 thumb_func 0x808f418
 thumb_func 0x808f42c
-thumb_func 0x808f438
+thumb_func 0x808f438 MovementType_WanderUpAndDown_Step0
 thumb_func 0x808f44c MovementType_WanderUpAndDown_Step1
-thumb_func 0x808f478
+thumb_func 0x808f478 MovementType_WanderUpAndDown_Step2
 thumb_func 0x808f4b4 MovementType_WanderUpAndDown_Step3
-thumb_func 0x808f4d4
+thumb_func 0x808f4d4 MovementType_WanderUpAndDown_Step4
 thumb_func 0x808f520 MovementType_WanderUpAndDown_Step5
 thumb_func 0x808f550 MovementType_WanderUpAndDown_Step6
 thumb_func 0x808f578 MovementType_WanderLeftAndRight
 thumb_func 0x808f59c
 thumb_func 0x808f5b0
-thumb_func 0x808f5bc
+thumb_func 0x808f5bc MovementType_WanderLeftAndRight_Step0
 thumb_func 0x808f5d0 MovementType_WanderLeftAndRight_Step1
-thumb_func 0x808f5fc
+thumb_func 0x808f5fc MovementType_WanderLeftAndRight_Step2
 thumb_func 0x808f638 MovementType_WanderLeftAndRight_Step3
-thumb_func 0x808f658
+thumb_func 0x808f658 MovementType_WanderLeftAndRight_Step4
 thumb_func 0x808f6a4 MovementType_WanderLeftAndRight_Step5
 thumb_func 0x808f6d4 MovementType_WanderLeftAndRight_Step6
 thumb_func 0x808f6fc MovementType_FaceDirection
@@ -4001,237 +4001,237 @@ thumb_func 0x808f78c
 thumb_func 0x808f79c MovementType_BerryTreeGrowth
 thumb_func 0x808f7e0
 thumb_func 0x808f7f4
-thumb_func 0x808f800
+thumb_func 0x808f800 MovementType_BerryTreeGrowth_Step0
 thumb_func 0x808f8b8 MovementType_BerryTreeGrowth_Step1
-thumb_func 0x808f8d8
+thumb_func 0x808f8d8 MovementType_BerryTreeGrowth_Step2
 thumb_func 0x808f924 MovementType_BerryTreeGrowth_Step3
 thumb_func 0x808f974 MovementType_BerryTreeGrowth_Step4
 thumb_func 0x808f9c0 MovementType_FaceDownAndUp
 thumb_func 0x808f9e4
 thumb_func 0x808f9f8
-thumb_func 0x808fa04
+thumb_func 0x808fa04 MovementType_FaceDownAndUp_Step0
 thumb_func 0x808fa18 MovementType_FaceDownAndUp_Step1
-thumb_func 0x808fa44
+thumb_func 0x808fa44 MovementType_FaceDownAndUp_Step2
 thumb_func 0x808fa88 MovementType_FaceDownAndUp_Step3
-thumb_func 0x808fab8
+thumb_func 0x808fab8 MovementType_FaceDownAndUp_Step4
 thumb_func 0x808fb00 MovementType_FaceLeftAndRight
 thumb_func 0x808fb24
 thumb_func 0x808fb38
-thumb_func 0x808fb44
+thumb_func 0x808fb44 MovementType_FaceLeftAndRight_Step0
 thumb_func 0x808fb58 MovementType_FaceLeftAndRight_Step1
-thumb_func 0x808fb84
+thumb_func 0x808fb84 MovementType_FaceLeftAndRight_Step2
 thumb_func 0x808fbc8 MovementType_FaceLeftAndRight_Step3
-thumb_func 0x808fbf8
+thumb_func 0x808fbf8 MovementType_FaceLeftAndRight_Step4
 thumb_func 0x808fc40 MovementType_FaceUpAndLeft
 thumb_func 0x808fc64
 thumb_func 0x808fc78
-thumb_func 0x808fc84
+thumb_func 0x808fc84 MovementType_FaceUpAndLeft_Step0
 thumb_func 0x808fc98 MovementType_FaceUpAndLeft_Step1
-thumb_func 0x808fcc4
+thumb_func 0x808fcc4 MovementType_FaceUpAndLeft_Step2
 thumb_func 0x808fd08 MovementType_FaceUpAndLeft_Step3
-thumb_func 0x808fd38
+thumb_func 0x808fd38 MovementType_FaceUpAndLeft_Step4
 thumb_func 0x808fd80 MovementType_FaceUpAndRight
 thumb_func 0x808fda4
 thumb_func 0x808fdb8
-thumb_func 0x808fdc4
+thumb_func 0x808fdc4 MovementType_FaceUpAndRight_Step0
 thumb_func 0x808fdd8 MovementType_FaceUpAndRight_Step1
-thumb_func 0x808fe04
+thumb_func 0x808fe04 MovementType_FaceUpAndRight_Step2
 thumb_func 0x808fe48 MovementType_FaceUpAndRight_Step3
-thumb_func 0x808fe78
+thumb_func 0x808fe78 MovementType_FaceUpAndRight_Step4
 thumb_func 0x808fec0 MovementType_FaceDownAndLeft
 thumb_func 0x808fee4
 thumb_func 0x808fef8
-thumb_func 0x808ff04
+thumb_func 0x808ff04 MovementType_FaceDownAndLeft_Step0
 thumb_func 0x808ff18 MovementType_FaceDownAndLeft_Step1
-thumb_func 0x808ff44
+thumb_func 0x808ff44 MovementType_FaceDownAndLeft_Step2
 thumb_func 0x808ff88 MovementType_FaceDownAndLeft_Step3
-thumb_func 0x808ffb8
+thumb_func 0x808ffb8 MovementType_FaceDownAndLeft_Step4
 thumb_func 0x8090000 MovementType_FaceDownAndRight
 thumb_func 0x8090024
 thumb_func 0x8090038
-thumb_func 0x8090044
+thumb_func 0x8090044 MovementType_FaceDownAndRight_Step0
 thumb_func 0x8090058 MovementType_FaceDownAndRight_Step1
-thumb_func 0x8090084
+thumb_func 0x8090084 MovementType_FaceDownAndRight_Step2
 thumb_func 0x80900c8 MovementType_FaceDownAndRight_Step3
-thumb_func 0x80900f8
+thumb_func 0x80900f8 MovementType_FaceDownAndRight_Step4
 thumb_func 0x8090140 MovementType_FaceDownUpAndLeft
 thumb_func 0x8090164
 thumb_func 0x8090178
-thumb_func 0x8090184
+thumb_func 0x8090184 MovementType_FaceDownUpAndLeft_Step0
 thumb_func 0x8090198 MovementType_FaceDownUpAndLeft_Step1
-thumb_func 0x80901c4
+thumb_func 0x80901c4 MovementType_FaceDownUpAndLeft_Step2
 thumb_func 0x8090208 MovementType_FaceDownUpAndLeft_Step3
-thumb_func 0x8090238
+thumb_func 0x8090238 MovementType_FaceDownUpAndLeft_Step4
 thumb_func 0x8090280 MovementType_FaceDownUpAndRight
 thumb_func 0x80902a4
 thumb_func 0x80902b8
-thumb_func 0x80902c4
+thumb_func 0x80902c4 MovementType_FaceDownUpAndRight_Step0
 thumb_func 0x80902d8 MovementType_FaceDownUpAndRight_Step1
-thumb_func 0x8090304
+thumb_func 0x8090304 MovementType_FaceDownUpAndRight_Step2
 thumb_func 0x8090348 MovementType_FaceDownUpAndRight_Step3
-thumb_func 0x8090378
+thumb_func 0x8090378 MovementType_FaceDownUpAndRight_Step4
 thumb_func 0x80903c0 MovementType_FaceUpRightAndLeft
 thumb_func 0x80903e4
 thumb_func 0x80903f8
-thumb_func 0x8090404
+thumb_func 0x8090404 MovementType_FaceUpLeftAndRight_Step0
 thumb_func 0x8090418 MovementType_FaceUpLeftAndRight_Step1
-thumb_func 0x8090444
+thumb_func 0x8090444 MovementType_FaceUpLeftAndRight_Step2
 thumb_func 0x8090488 MovementType_FaceUpLeftAndRight_Step3
-thumb_func 0x80904b8
+thumb_func 0x80904b8 MovementType_FaceUpLeftAndRight_Step4
 thumb_func 0x8090500 MovementType_FaceDownRightAndLeft
 thumb_func 0x8090524
 thumb_func 0x8090538
-thumb_func 0x8090544
+thumb_func 0x8090544 MovementType_FaceDownLeftAndRight_Step0
 thumb_func 0x8090558 MovementType_FaceDownLeftAndRight_Step1
-thumb_func 0x8090584
+thumb_func 0x8090584 MovementType_FaceDownLeftAndRight_Step2
 thumb_func 0x80905c8 MovementType_FaceDownLeftAndRight_Step3
-thumb_func 0x80905f8
+thumb_func 0x80905f8 MovementType_FaceDownLeftAndRight_Step4
 thumb_func 0x8090640 MovementType_RotateCounterclockwise
 thumb_func 0x8090664
 thumb_func 0x8090678
 thumb_func 0x8090684 MovementType_RotateCounterclockwise_Step0
 thumb_func 0x80906b0 MovementType_RotateCounterclockwise_Step1
 thumb_func 0x80906d4 MovementType_RotateCounterclockwise_Step2
-thumb_func 0x8090700
+thumb_func 0x8090700 MovementType_RotateCounterclockwise_Step3
 thumb_func 0x8090744 MovementType_RotateClockwise
 thumb_func 0x8090768
 thumb_func 0x809077c
 thumb_func 0x8090788 MovementType_RotateClockwise_Step0
 thumb_func 0x80907b4 MovementType_RotateClockwise_Step1
 thumb_func 0x80907d8 MovementType_RotateClockwise_Step2
-thumb_func 0x8090804
+thumb_func 0x8090804 MovementType_RotateClockwise_Step3
 thumb_func 0x8090848 MovementType_WalkBackAndForth
 thumb_func 0x809086c
 thumb_func 0x8090880
-thumb_func 0x809088c
+thumb_func 0x809088c MovementType_WalkBackAndForth_Step0
 thumb_func 0x80908a0 MovementType_WalkBackAndForth_Step1
 thumb_func 0x80908d8 MovementType_WalkBackAndForth_Step2
 thumb_func 0x8090990 MovementType_WalkBackAndForth_Step3
-thumb_func 0x80909b8
+thumb_func 0x80909b8 MovementType_WalkSequence_Step0
 thumb_func 0x80909cc MoveNextDirectionInSequence
 thumb_func 0x8090a80 MovementType_WalkSequence_Step2
 thumb_func 0x8090aa8 MovementType_WalkSequenceUpRightLeftDown
 thumb_func 0x8090acc
 thumb_func 0x8090ae0
-thumb_func 0x8090aec
+thumb_func 0x8090aec MovementType_WalkSequenceUpRightLeftDown_Step1
 thumb_func 0x8090b34 MovementType_WalkSequenceRightLeftDownUp
 thumb_func 0x8090b58
 thumb_func 0x8090b6c
-thumb_func 0x8090b78
+thumb_func 0x8090b78 MovementType_WalkSequenceRightLeftDownUp_Step1
 thumb_func 0x8090bc0 MovementType_WalkSequenceDownUpRightLeft
 thumb_func 0x8090be4
 thumb_func 0x8090bf8
-thumb_func 0x8090c04
+thumb_func 0x8090c04 MovementType_WalkSequenceDownUpRightLeft_Step1
 thumb_func 0x8090c4c MovementType_WalkSequenceLeftDownUpRight
 thumb_func 0x8090c70
 thumb_func 0x8090c84
-thumb_func 0x8090c90
+thumb_func 0x8090c90 MovementType_WalkSequenceLeftDownUpRight_Step1
 thumb_func 0x8090cd8 MovementType_WalkSequenceUpLeftRightDown
 thumb_func 0x8090cfc
 thumb_func 0x8090d10
-thumb_func 0x8090d1c
+thumb_func 0x8090d1c MovementType_WalkSequenceUpLeftRightDown_Step1
 thumb_func 0x8090d64 MovementType_WalkSequenceLeftRightDownUp
 thumb_func 0x8090d88
 thumb_func 0x8090d9c
-thumb_func 0x8090da8
+thumb_func 0x8090da8 MovementType_WalkSequenceLeftRightDownUp_Step1
 thumb_func 0x8090df0 MovementType_WalkSequenceDownUpLeftRight
 thumb_func 0x8090e14
 thumb_func 0x8090e28
-thumb_func 0x8090e34
+thumb_func 0x8090e34 MovementType_WalkSequenceDownUpLeftRight_Step1
 thumb_func 0x8090e7c MovementType_WalkSequenceRightDownUpLeft
 thumb_func 0x8090ea0
 thumb_func 0x8090eb4
-thumb_func 0x8090ec0
+thumb_func 0x8090ec0 MovementType_WalkSequenceRightDownUpLeft_Step1
 thumb_func 0x8090f08 MovementType_WalkSequenceLeftUpDownRight
 thumb_func 0x8090f2c
 thumb_func 0x8090f40
-thumb_func 0x8090f4c
+thumb_func 0x8090f4c MovementType_WalkSequenceLeftUpDownRight_Step1
 thumb_func 0x8090f94 MovementType_WalkSequenceUpDownRightLeft
 thumb_func 0x8090fb8
 thumb_func 0x8090fcc
-thumb_func 0x8090fd8
+thumb_func 0x8090fd8 MovementType_WalkSequenceUpDownRightLeft_Step1
 thumb_func 0x8091020 MovementType_WalkSequenceRightLeftUpDown
 thumb_func 0x8091044
 thumb_func 0x8091058
-thumb_func 0x8091064
+thumb_func 0x8091064 MovementType_WalkSequenceRightLeftUpDown_Step1
 thumb_func 0x80910ac MovementType_WalkSequenceDownRightLeftUp
 thumb_func 0x80910d0
 thumb_func 0x80910e4
-thumb_func 0x80910f0
+thumb_func 0x80910f0 MovementType_WalkSequenceDownRightLeftUp_Step1
 thumb_func 0x8091138 MovementType_WalkSequenceRightUpDownLeft
 thumb_func 0x809115c
 thumb_func 0x8091170
-thumb_func 0x809117c
+thumb_func 0x809117c MovementType_WalkSequenceRightUpDownLeft_Step1
 thumb_func 0x80911c4 MovementType_WalkSequenceUpDownLeftRight
 thumb_func 0x80911e8
 thumb_func 0x80911fc
-thumb_func 0x8091208
+thumb_func 0x8091208 MovementType_WalkSequenceUpDownLeftRight_Step1
 thumb_func 0x8091250 MovementType_WalkSequenceLeftRightUpDown
 thumb_func 0x8091274
 thumb_func 0x8091288
-thumb_func 0x8091294
+thumb_func 0x8091294 MovementType_WalkSequenceLeftRightUpDown_Step1
 thumb_func 0x80912dc MovementType_WalkSequenceDownLeftRightUp
 thumb_func 0x8091300
 thumb_func 0x8091314
-thumb_func 0x8091320
+thumb_func 0x8091320 MovementType_WalkSequenceDownLeftRightUp_Step1
 thumb_func 0x8091368 MovementType_WalkSequenceUpLeftDownRight
 thumb_func 0x809138c
 thumb_func 0x80913a0
-thumb_func 0x80913ac
+thumb_func 0x80913ac MovementType_WalkSequenceUpLeftDownRight_Step1
 thumb_func 0x80913f4 MovementType_WalkSequenceDownRightUpLeft
 thumb_func 0x8091418
 thumb_func 0x809142c
-thumb_func 0x8091438
+thumb_func 0x8091438 MovementType_WalkSequenceDownRightUpLeft_Step1
 thumb_func 0x8091480 MovementType_WalkSequenceLeftDownRightUp
 thumb_func 0x80914a4
 thumb_func 0x80914b8
-thumb_func 0x80914c4
+thumb_func 0x80914c4 MovementType_WalkSequenceLeftDownRightUp_Step1
 thumb_func 0x809150c MovementType_WalkSequenceRightUpLeftDown
 thumb_func 0x8091530
 thumb_func 0x8091544
-thumb_func 0x8091550
+thumb_func 0x8091550 MovementType_WalkSequenceRightUpLeftDown_Step1
 thumb_func 0x8091598 MovementType_WalkSequenceUpRightDownLeft
 thumb_func 0x80915bc
 thumb_func 0x80915d0
-thumb_func 0x80915dc
+thumb_func 0x80915dc MovementType_WalkSequenceUpRightDownLeft_Step1
 thumb_func 0x8091624 MovementType_WalkSequenceDownLeftUpRight
 thumb_func 0x8091648
 thumb_func 0x809165c
-thumb_func 0x8091668
+thumb_func 0x8091668 MovementType_WalkSequenceDownLeftUpRight_Step1
 thumb_func 0x80916b0 MovementType_WalkSequenceLeftUpRightDown
 thumb_func 0x80916d4
 thumb_func 0x80916e8
-thumb_func 0x80916f4
+thumb_func 0x80916f4 MovementType_WalkSequenceLeftUpRightDown_Step1
 thumb_func 0x809173c MovementType_WalkSequenceRightDownLeftUp
 thumb_func 0x8091760
 thumb_func 0x8091774
-thumb_func 0x8091780
+thumb_func 0x8091780 MovementType_WalkSequenceRightDownLeftUp_Step1
 thumb_func 0x80917c8 MovementType_CopyPlayer
 thumb_func 0x80917ec
 thumb_func 0x8091800
-thumb_func 0x809180c
+thumb_func 0x809180c MovementType_CopyPlayer_Step0
 thumb_func 0x8091830
 thumb_func 0x8091890 MovementType_CopyPlayer_Step2
 thumb_func 0x80918b8
 thumb_func 0x80918bc CopyablePlayerMovement_FaceDirection
-thumb_func 0x8091904
-thumb_func 0x8091a14
-thumb_func 0x8091acc
-thumb_func 0x8091b84
+thumb_func 0x8091904 CopyablePlayerMovement_GoSpeed0
+thumb_func 0x8091a14 CopyablePlayerMovement_GoSpeed1
+thumb_func 0x8091acc CopyablePlayerMovement_GoSpeed2
+thumb_func 0x8091b84 CopyablePlayerMovement_Slide
 thumb_func 0x8091c3c cph_IM_DIFFERENT
-thumb_func 0x8091c84
-thumb_func 0x8091d3c
+thumb_func 0x8091c84 CopyablePlayerMovement_GoSpeed4
+thumb_func 0x8091d3c CopyablePlayerMovement_Jump
 thumb_func 0x8091e04 MovementType_CopyPlayerInGrass
 thumb_func 0x8091e28
 thumb_func 0x8091e3c
-thumb_func 0x8091e48
-thumb_func 0x8091eac
-thumb_func 0x8091f1c
-thumb_func 0x8091f28
+thumb_func 0x8091e48 MovementType_CopyPlayerInGrass_Step1
+thumb_func 0x8091eac MovementType_TreeDisguise
+thumb_func 0x8091f1c MovementType_Disguise_Callback
+thumb_func 0x8091f28 MovementType_MountainDisguise
 thumb_func 0x8091f98 MovementType_Hidden
 thumb_func 0x8091ffc
 thumb_func 0x8092010
-thumb_func 0x809201c
+thumb_func 0x809201c MovementType_Hidden_Step0
 thumb_func 0x8092028 MovementType_MoveInPlace_Step1
 thumb_func 0x8092044 MovementType_WalkInPlace
 thumb_func 0x8092068
@@ -4272,18 +4272,18 @@ thumb_func 0x809238c
 thumb_func 0x809239c
 thumb_func 0x80923ac
 thumb_func 0x80923bc
-thumb_func 0x80923e0
-thumb_func 0x8092428
+thumb_func 0x80923e0 npc_apply_anim_looping
+thumb_func 0x8092428 obj_npc_animation_step
 thumb_func 0x8092468 GetDirectionToFace
 thumb_func 0x809249c SetTrainerMovementType
 thumb_func 0x80924e8
 thumb_func 0x80924f8 GetCollisionInDirection
-thumb_func 0x8092538
-thumb_func 0x80925fc
+thumb_func 0x8092538 GetCollisionAtCoords
+thumb_func 0x80925fc GetCollisionFlagsAtCoords
 thumb_func 0x80926c8 IsCoordOutsideEventObjectMovementRange
 thumb_func 0x8092738
-thumb_func 0x8092790
-thumb_func 0x809280c
+thumb_func 0x8092790 DoesObjectCollideWithObjectAt
+thumb_func 0x809280c IsBerryTreeSparkling
 thumb_func 0x8092860
 thumb_func 0x80928ac MoveCoords
 thumb_func 0x80928d0
@@ -4295,14 +4295,14 @@ thumb_func 0x8092a9c GetEventObjectMovingCameraOffset
 thumb_func 0x8092adc EventObjectMoveDestCoords
 thumb_func 0x8092afc EventObjectIsMovementOverridden
 thumb_func 0x8092b14 EventObjectIsHeldMovementActive
-thumb_func 0x8092b30
+thumb_func 0x8092b30 EventObjectSetHeldMovement
 thumb_func 0x8092b78 EventObjectForceSetHeldMovement
 thumb_func 0x8092b94 EventObjectClearHeldMovementIfActive
 thumb_func 0x8092bac EventObjectClearHeldMovement
 thumb_func 0x8092be0 EventObjectCheckHeldMovementStatus
 thumb_func 0x8092bf4 EventObjectClearHeldMovementIfFinished
 thumb_func 0x8092c18 EventObjectGetHeldMovementActionId
-thumb_func 0x8092c30
+thumb_func 0x8092c30 UpdateEventObjectCurrentMovement
 thumb_func 0x8092ca0
 thumb_func 0x8092ccc
 thumb_func 0x8092cf8
@@ -4321,31 +4321,31 @@ thumb_func 0x8092f08
 thumb_func 0x8092f34
 thumb_func 0x8092f60
 thumb_func 0x8092f8c EventObjectFaceOppositeDirection
-thumb_func 0x8092fb8
+thumb_func 0x8092fb8 HallOfFame_PrintWelcomeText
 thumb_func 0x8092fe4
 thumb_func 0x8093010
 thumb_func 0x809303c
-thumb_func 0x8093068
+thumb_func 0x8093068 MovementType_FaceUpAndRight_callback
 thumb_func 0x8093094
 thumb_func 0x80930c0
 thumb_func 0x80930ec
 thumb_func 0x8093118
 thumb_func 0x8093144
-thumb_func 0x8093170
+thumb_func 0x8093170 GetOppositeDirection
 thumb_func 0x80931a4 zffu_offset_calc
 thumb_func 0x80931bc state_to_direction
-thumb_func 0x80931fc
+thumb_func 0x80931fc EventObjectExecHeldMovementAction
 thumb_func 0x809321c
-thumb_func 0x8093234
+thumb_func 0x8093234 EventObjectExecSingleMovementAction
 thumb_func 0x8093258
-thumb_func 0x8093274
+thumb_func 0x8093274 EventObjectSetSingleMovement
 thumb_func 0x809327c FaceDirection
-thumb_func 0x80932c0
-thumb_func 0x80932d0
-thumb_func 0x80932e0
-thumb_func 0x80932f0
-thumb_func 0x8093300
-thumb_func 0x809339c
+thumb_func 0x80932c0 MovementAction_FaceDown_Step0
+thumb_func 0x80932d0 MovementAction_FaceUp_Step0
+thumb_func 0x80932e0 MovementAction_FaceLeft_Step0
+thumb_func 0x80932f0 MovementAction_FaceRight_Step0
+thumb_func 0x8093300 npc_apply_direction
+thumb_func 0x809339c do_go_anim
 thumb_func 0x80933f8 StartRunningAnim
 thumb_func 0x8093428 npc_obj_ministep_stop_on_arrival
 thumb_func 0x8093460
@@ -4384,7 +4384,7 @@ thumb_func 0x80938d4 MovementAction_WalkNormalLeft_Step1
 thumb_func 0x80938f4 MovementAction_WalkNormalRight_Step0
 thumb_func 0x8093914 MovementAction_WalkNormalRight_Step1
 thumb_func 0x8093934
-thumb_func 0x80939f0
+thumb_func 0x80939f0 maybe_shadow_1
 thumb_func 0x8093a34
 thumb_func 0x8093af8
 thumb_func 0x8093b0c
@@ -4479,8 +4479,8 @@ thumb_func 0x8094860 MovementAction_JumpSpecialRight_Step0
 thumb_func 0x8094880 MovementAction_JumpSpecialRight_Step1
 thumb_func 0x80948a8 MovementAction_FacePlayer_Step0
 thumb_func 0x8094904 MovementAction_FaceAwayPlayer_Step0
-thumb_func 0x8094968
-thumb_func 0x8094978
+thumb_func 0x8094968 MovementAction_LockFacingDirection_Step0
+thumb_func 0x8094978 MovementAction_UnlockFacingDirection_Step0
 thumb_func 0x8094988 MovementAction_JumpDown_Step0
 thumb_func 0x80949b4 MovementAction_JumpDown_Step1
 thumb_func 0x80949e0 MovementAction_JumpUp_Step0
@@ -4506,43 +4506,43 @@ thumb_func 0x8094d24 MovementAction_JumpInPlaceLeftRight_Step1
 thumb_func 0x8094d50 MovementAction_JumpInPlaceRightLeft_Step0
 thumb_func 0x8094d7c MovementAction_JumpInPlaceRightLeft_Step1
 thumb_func 0x8094da8 MovementAction_FaceOriginalDirection_Step0
-thumb_func 0x8094dc0
-thumb_func 0x8094dd0
-thumb_func 0x8094de0
-thumb_func 0x8094df0
+thumb_func 0x8094dc0 MovementAction_NurseJoyBowDown_Step0
+thumb_func 0x8094dd0 MovementAction_EnableJumpLandingGroundEffect_Step0
+thumb_func 0x8094de0 MovementAction_DisableJumpLandingGroundEffect_Step0
+thumb_func 0x8094df0 MovementAction_DisableAnimation_Step0
 thumb_func 0x8094e00 MovementAction_RestoreAnimation_Step0
-thumb_func 0x8094e2c
-thumb_func 0x8094e3c
-thumb_func 0x8094e4c
-thumb_func 0x8094e70
-thumb_func 0x8094e94
-thumb_func 0x8094eb8
-thumb_func 0x8094efc
+thumb_func 0x8094e2c MovementAction_SetInvisible_Step0
+thumb_func 0x8094e3c MovementAction_SetVisible_Step0
+thumb_func 0x8094e4c MovementAction_EmoteExclamationMark_Step0
+thumb_func 0x8094e70 MovementAction_EmoteQuestionMark_Step0
+thumb_func 0x8094e94 MovementAction_EmoteHeart_Step0
+thumb_func 0x8094eb8 MovementAction_RevealTrainer_Step0
+thumb_func 0x8094efc MovementAction_RevealTrainer_Step1
 thumb_func 0x8094f1c MovementAction_RockSmashBreak_Step0
 thumb_func 0x8094f38 MovementAction_RockSmashBreak_Step1
 thumb_func 0x8094f5c MovementAction_RockSmashBreak_Step2
 thumb_func 0x8094f98 MovementAction_CutTree_Step0
 thumb_func 0x8094fb4 MovementAction_CutTree_Step1
 thumb_func 0x8094fd8 MovementAction_CutTree_Step2
-thumb_func 0x8095014
-thumb_func 0x8095024
-thumb_func 0x8095034
-thumb_func 0x8095064
-thumb_func 0x8095094
-thumb_func 0x80950a0
-thumb_func 0x80950b0
+thumb_func 0x8095014 MovementAction_SetFixedPriority_Step0
+thumb_func 0x8095024 MovementAction_ClearFixedPriority_Step0
+thumb_func 0x8095034 MovementAction_InitAffineAnim_Step0
+thumb_func 0x8095064 MovementAction_ClearAffineAnim_Step0
+thumb_func 0x8095094 MovementAction_Unknown1_Step0
+thumb_func 0x80950a0 MovementAction_Unknown2_Step0
+thumb_func 0x80950b0 MovementAction_WalkDownStartAffine_Step0
 thumb_func 0x80950e4 MovementAction_WalkDownStartAffine_Step1
-thumb_func 0x8095110
+thumb_func 0x8095110 MovementAction_WalkDownAffine_Step0
 thumb_func 0x8095144 MovementAction_WalkDownAffine_Step1
-thumb_func 0x8095170
+thumb_func 0x8095170 MovementAction_WalkLeftAffine_Step0
 thumb_func 0x80951a4 MovementAction_WalkLeftAffine_Step1
-thumb_func 0x80951d0
+thumb_func 0x80951d0 MovementAction_WalkRightAffine_Step0
 thumb_func 0x8095204 MovementAction_WalkRightAffine_Step1
 thumb_func 0x8095230
-thumb_func 0x8095270
-thumb_func 0x8095280
-thumb_func 0x8095290
-thumb_func 0x80952a0
+thumb_func 0x8095270 MovementAction_AcroWheelieFaceDown_Step0
+thumb_func 0x8095280 MovementAction_AcroWheelieFaceUp_Step0
+thumb_func 0x8095290 MovementAction_AcroWheelieFaceLeft_Step0
+thumb_func 0x80952a0 MovementAction_AcroWheelieFaceRight_Step0
 thumb_func 0x80952b0 MovementAction_AcroPopWheelieDown_Step0
 thumb_func 0x80952d4 MovementAction_AcroPopWheelieUp_Step0
 thumb_func 0x80952f8 MovementAction_AcroPopWheelieLeft_Step0
@@ -4615,11 +4615,11 @@ thumb_func 0x8095d58
 thumb_func 0x8095d78 MovementAction_AcroEndWheelieMoveLeft_Step1
 thumb_func 0x8095d98
 thumb_func 0x8095db8 MovementAction_AcroEndWheelieMoveRight_Step1
-thumb_func 0x8095dd8
-thumb_func 0x8095dec
-thumb_func 0x8095e04
+thumb_func 0x8095dd8 MovementAction_Levitate_Step0
+thumb_func 0x8095dec MovementAction_StopLevitate_Step0
+thumb_func 0x8095e04 MovementAction_DestroyExtraTaskIfAtTop_Step0
 thumb_func 0x8095e28
-thumb_func 0x8095e2c
+thumb_func 0x8095e2c MovementAction_PauseSpriteAnim
 thumb_func 0x8095e3c UpdateEventObjectSpriteAnimPause
 thumb_func 0x8095e58 TryEnableEventObjectAnim
 thumb_func 0x8095e88 UpdateEventObjectVisibility
@@ -4628,63 +4628,63 @@ thumb_func 0x8095f80 UpdateEventObjSpriteVisibility
 thumb_func 0x8095fa8 GetAllGroundEffectFlags_OnSpawn
 thumb_func 0x8095ff0 GetAllGroundEffectFlags_OnBeginStep
 thumb_func 0x8096048 GetAllGroundEffectFlags_OnFinishStep
-thumb_func 0x8096098
-thumb_func 0x80960c0
-thumb_func 0x809611c
-thumb_func 0x809613c
+thumb_func 0x8096098 EventObjectUpdateMetatileBehaviors
+thumb_func 0x80960c0 GetGroundEffectFlags_Reflection
+thumb_func 0x809611c GetGroundEffectFlags_TallGrassOnSpawn
+thumb_func 0x809613c GetGroundEffectFlags_LongGrassOnSpawn
 thumb_func 0x809615c
-thumb_func 0x809617c
-thumb_func 0x809619c
-thumb_func 0x80961dc
-thumb_func 0x809622c
-thumb_func 0x8096290
+thumb_func 0x809617c GetGroundEffectFlags_LongGrassOnBeginStep
+thumb_func 0x809619c GetGroundEffectFlags_Tracks
+thumb_func 0x80961dc GetGroundEffectFlags_SandHeap
+thumb_func 0x809622c GetGroundEffectFlags_ShallowFlowingWater
+thumb_func 0x8096290 GetGroundEffectFlags_Puddle
 thumb_func 0x80962c0
-thumb_func 0x80962e0
-thumb_func 0x8096330
-thumb_func 0x8096380
-thumb_func 0x80963a0
-thumb_func 0x80963fc
-thumb_func 0x809654c
-thumb_func 0x809657c
-thumb_func 0x80965d8
-thumb_func 0x8096634
+thumb_func 0x80962e0 GetGroundEffectFlags_ShortGrass
+thumb_func 0x8096330 GetGroundEffectFlags_HotSprings
+thumb_func 0x8096380 GetGroundEffectFlags_Seaweed
+thumb_func 0x80963a0 GetGroundEffectFlags_JumpLanding
+thumb_func 0x80963fc EventObjectCheckForReflectiveSurface
+thumb_func 0x809654c GetReflectionTypeByMetatileBehavior
+thumb_func 0x809657c GetLedgeJumpDirection
+thumb_func 0x80965d8 SetEventObjectSpriteOamTableForLongGrass
+thumb_func 0x8096634 IsZCoordMismatchAt
 thumb_func 0x8096670 UpdateEventObjectZCoordAndPriority
 thumb_func 0x80966cc InitObjectPriorityByZCoord
 thumb_func 0x8096718
-thumb_func 0x8096728
+thumb_func 0x8096728 EventObjectUpdateZCoord
 thumb_func 0x809677c SetObjectSubpriorityByZCoord
 thumb_func 0x80967c4 EventObjectUpdateSubpriority
 thumb_func 0x80967e0 AreZCoordsCompatible
-thumb_func 0x8096800
-thumb_func 0x809684c
-thumb_func 0x8096898
-thumb_func 0x80968e4
-thumb_func 0x8096930
-thumb_func 0x809693c
-thumb_func 0x8096948
-thumb_func 0x8096958
+thumb_func 0x8096800 GroundEffect_SpawnOnTallGrass
+thumb_func 0x809684c GroundEffect_StepOnTallGrass
+thumb_func 0x8096898 GroundEffect_SpawnOnLongGrass
+thumb_func 0x80968e4 GroundEffect_StepOnLongGrass
+thumb_func 0x8096930 GroundEffect_WaterReflection
+thumb_func 0x809693c GroundEffect_IceReflection
+thumb_func 0x8096948 GroundEffect_FlowingWater
+thumb_func 0x8096958 GroundEffect_SandTracks
 thumb_func 0x8096984
 thumb_func 0x80969b0 nullsub_47
-thumb_func 0x80969b4
-thumb_func 0x8096a04
+thumb_func 0x80969b4 DoTracksGroundEffect_Footprints
+thumb_func 0x8096a04 DoTracksGroundEffect_BikeTireTracks
 thumb_func 0x8096a54
-thumb_func 0x8096a60
-thumb_func 0x8096a70
-thumb_func 0x8096a80
-thumb_func 0x8096ad8
-thumb_func 0x8096b00
-thumb_func 0x8096b30
-thumb_func 0x8096b60
-thumb_func 0x8096b90
-thumb_func 0x8096ba0
-thumb_func 0x8096bb0
-thumb_func 0x8096bd0
+thumb_func 0x8096a60 GroundEffect_StepOnPuddle
+thumb_func 0x8096a70 GroundEffect_SandHeap
+thumb_func 0x8096a80 GroundEffect_JumpOnTallGrass
+thumb_func 0x8096ad8 GroundEffect_JumpOnLongGrass
+thumb_func 0x8096b00 GroundEffect_JumpOnShallowWater
+thumb_func 0x8096b30 GroundEffect_JumpOnWater
+thumb_func 0x8096b60 GroundEffect_JumpLandingDust
+thumb_func 0x8096b90 GroundEffect_ShortGrass
+thumb_func 0x8096ba0 GroundEffect_HotSprings
+thumb_func 0x8096bb0 GroundEffect_Seaweed
+thumb_func 0x8096bd0 DoFlaggedGroundEffects
 thumb_func 0x8096c2c filters_out_some_ground_effects
 thumb_func 0x8096c64 FilterOutStepOnPuddleGroundEffectIfJumping
 thumb_func 0x8096c80 DoGroundEffects_OnSpawn
 thumb_func 0x8096ccc DoGroundEffects_OnBeginStep
 thumb_func 0x8096d20 DoGroundEffects_OnFinishStep
-thumb_func 0x8096d74
+thumb_func 0x8096d74 FreezeEventObject
 thumb_func 0x8096e04 FreezeEventObjects
 thumb_func 0x8096e40 FreezeEventObjectsExceptOne
 thumb_func 0x8096e84 UnfreezeEventObject
@@ -4694,8 +4694,8 @@ thumb_func 0x8096f3c Step2
 thumb_func 0x8096f60 Step3
 thumb_func 0x8096f88 Step4
 thumb_func 0x8096fac Step8
-thumb_func 0x8096fd0
-thumb_func 0x8096fe4
+thumb_func 0x8096fd0 oamt_npc_ministep_reset
+thumb_func 0x8096fe4 obj_npc_ministep
 thumb_func 0x809704c
 thumb_func 0x809705c
 thumb_func 0x8097098
@@ -4708,9 +4708,9 @@ thumb_func 0x80971cc
 thumb_func 0x8097254
 thumb_func 0x80972e8
 thumb_func 0x80972ec WaitForMovementDelay
-thumb_func 0x8097304
+thumb_func 0x8097304 SetAndStartSpriteAnim
 thumb_func 0x809732c SpriteAnimEnded
-thumb_func 0x8097344
+thumb_func 0x8097344 UpdateEventObjectSpriteVisibility
 thumb_func 0x8097438 UpdateEventObjectSpriteSubpriorityAndVisibility
 thumb_func 0x8097460
 thumb_func 0x809749c
@@ -4725,71 +4725,71 @@ thumb_func 0x80976d8
 thumb_func 0x8097724
 thumb_func 0x8097758
 thumb_func 0x8097780 DoShadowFieldEffect
-thumb_func 0x809779c
-thumb_func 0x80977d8
-thumb_func 0x8097878
-thumb_func 0x8097900
-thumb_func 0x809792c
-thumb_func 0x809796c
-thumb_func 0x80979cc
+thumb_func 0x809779c DoRippleFieldEffect
+thumb_func 0x80977d8 MovementAction_StoreAndLockAnim_Step0
+thumb_func 0x8097878 MovementAction_FreeAndUnlockAnim_Step0
+thumb_func 0x8097900 FindLockedEventObjectIndex
+thumb_func 0x809792c CreateLevitateMovementTask
+thumb_func 0x809796c ApplyLevitateMovement
+thumb_func 0x80979cc DestroyExtraMovementTask
 thumb_func 0x80979fc
-thumb_func 0x8097a48
+thumb_func 0x8097a48 MovementAction_FlyUp_Step0
 thumb_func 0x8097a58 MovementAction_FlyUp_Step1
-thumb_func 0x8097a7c
+thumb_func 0x8097a7c MovementAction_FlyDown_Step0
 thumb_func 0x8097a90 MovementAction_FlyDown_Step1
 thumb_func 0x8097aac
 thumb_func 0x8097ab0 InitFieldMessageBox
 thumb_func 0x8097adc
-thumb_func 0x8097b44
-thumb_func 0x8097b58
-thumb_func 0x8097b74
+thumb_func 0x8097b44 task_add_textbox
+thumb_func 0x8097b58 task_del_textbox
+thumb_func 0x8097b74 ShowFieldMessage
 thumb_func 0x8097b9c
 thumb_func 0x8097bc0
-thumb_func 0x8097c00
+thumb_func 0x8097c00 ShowFieldAutoScrollMessage
 thumb_func 0x8097c28
 thumb_func 0x8097c40
-thumb_func 0x8097c64
+thumb_func 0x8097c64 textbox_fdecode_auto_and_task_add
 thumb_func 0x8097c8c
-thumb_func 0x8097c9c
+thumb_func 0x8097c9c HideFieldMessageBox
 thumb_func 0x8097cb8
 thumb_func 0x8097cc4
 thumb_func 0x8097ce0
 thumb_func 0x8097cfc
-thumb_func 0x8097d10
+thumb_func 0x8097d10 walkrun_is_standing_still
 thumb_func 0x8097d2c
 thumb_func 0x8097d4c
-thumb_func 0x8097d70
+thumb_func 0x8097d70 ScriptFreezeEventObjects
 thumb_func 0x8097d88
 thumb_func 0x8097e04
-thumb_func 0x8097e28
-thumb_func 0x8097e7c
+thumb_func 0x8097e28 LockSelectedEventObject
+thumb_func 0x8097e7c ScriptUnfreezeEventObjects
 thumb_func 0x8097eac
 thumb_func 0x8097efc
 thumb_func 0x8097f24
 thumb_func 0x8097f44
 thumb_func 0x8097fb8
 thumb_func 0x80980bc
-thumb_func 0x80980e0
-thumb_func 0x8098104
+thumb_func 0x80980e0 GetWindowFrameTilesPal
+thumb_func 0x8098104 LoadMessageBoxGfx
 thumb_func 0x8098144 LoadUserWindowBorderGfx_
-thumb_func 0x809815c
+thumb_func 0x809815c LoadWindowGfx
 thumb_func 0x80981b4 LoadUserWindowBorderGfx
-thumb_func 0x80981e0
-thumb_func 0x8098368
-thumb_func 0x8098504
-thumb_func 0x80985a0
+thumb_func 0x80981e0 DrawTextBorderOuter
+thumb_func 0x8098368 DrawTextBorderInner
+thumb_func 0x8098504 rbox_fill_rectangle
+thumb_func 0x80985a0 stdpal_get
 thumb_func 0x80985ec
 thumb_func 0x80985f4
 thumb_func 0x8098640 InitScriptContext
-thumb_func 0x809867c
-thumb_func 0x8098688
-thumb_func 0x8098690
-thumb_func 0x8098698
+thumb_func 0x809867c SetupBytecodeScript
+thumb_func 0x8098688 SetupNativeScript
+thumb_func 0x8098690 StopScript
+thumb_func 0x8098698 RunScriptCommand
 thumb_func 0x8098720 ScriptPush
 thumb_func 0x8098748 ScriptPop
 thumb_func 0x809876c
 thumb_func 0x8098770 ScriptCall
-thumb_func 0x8098784
+thumb_func 0x8098784 ScriptReturn
 thumb_func 0x8098794 ScriptReadHalfword
 thumb_func 0x80987ac ScriptReadWord
 thumb_func 0x80987dc
@@ -4800,38 +4800,38 @@ thumb_func 0x809881c ScriptContext1_Init
 thumb_func 0x8098844 ScriptContext2_RunScript
 thumb_func 0x8098880 ScriptContext1_SetupScript
 thumb_func 0x80988b8
-thumb_func 0x80988c4
+thumb_func 0x80988c4 EnableBothScriptContexts
 thumb_func 0x80988d8 ScriptContext2_RunNewScript
-thumb_func 0x8098910
+thumb_func 0x8098910 MapHeaderGetScriptTable
 thumb_func 0x8098950 MapHeaderRunScriptType
-thumb_func 0x8098968
+thumb_func 0x8098968 MapHeaderCheckScriptTable
 thumb_func 0x80989c8
-thumb_func 0x80989d4
-thumb_func 0x80989e0
-thumb_func 0x80989ec
-thumb_func 0x80989f8
+thumb_func 0x80989d4 RunOnTransitionMapScript
+thumb_func 0x80989e0 RunOnResumeMapScript
+thumb_func 0x80989ec RunOnReturnToFieldMapScript
+thumb_func 0x80989f8 RunOnDiveWarpMapScript
 thumb_func 0x8098a04 TryRunOnFrameMapScript
 thumb_func 0x8098a20 TryRunOnWarpIntoMapScript
-thumb_func 0x8098a34
+thumb_func 0x8098a34 CalculateRamScriptChecksum
 thumb_func 0x8098a58
-thumb_func 0x8098a84
-thumb_func 0x8098b10
-thumb_func 0x8098b80
-thumb_func 0x8098bcc
+thumb_func 0x8098a84 InitRamScript
+thumb_func 0x8098b10 GetRamScript
+thumb_func 0x8098b80 ValidateSavedRamScript
+thumb_func 0x8098bcc GetSavedRamScriptIfValid
 thumb_func 0x8098c28 InitRamScript_NoEventObject
 thumb_func 0x8098c54
 thumb_func 0x8098c58 nullsub_48
-thumb_func 0x8098c5c
+thumb_func 0x8098c5c ScrCmd_end
 thumb_func 0x8098c68 ScrCmd_gotonative
-thumb_func 0x8098c80
+thumb_func 0x8098c80 ScrCmd_special
 thumb_func 0x8098c94
-thumb_func 0x8098ca0
+thumb_func 0x8098ca0 ScrCmd_specialvar
 thumb_func 0x8098cc8
 thumb_func 0x8098cd4
 thumb_func 0x8098ce0
-thumb_func 0x8098ce4
+thumb_func 0x8098ce4 ScrCmd_waitstate
 thumb_func 0x8098cf0 ScrCmd_goto
-thumb_func 0x8098d08
+thumb_func 0x8098d08 ScrCmd_return
 thumb_func 0x8098d14 ScrCmd_call
 thumb_func 0x8098d2c ScrCmd_goto_if
 thumb_func 0x8098d68 ScrCmd_call_if
@@ -4844,9 +4844,9 @@ thumb_func 0x8098e90 ScrCmd_gotostd
 thumb_func 0x8098ec0 ScrCmd_callstd
 thumb_func 0x8098ef0 ScrCmd_gotostd_if
 thumb_func 0x8098f3c ScrCmd_callstd_if
-thumb_func 0x8098f88
+thumb_func 0x8098f88 ScrCmd_returnram
 thumb_func 0x8098f9c ScrCmd_killscript
-thumb_func 0x8098fb4
+thumb_func 0x8098fb4 ScrCmd_setmysteryeventstatus
 thumb_func 0x8098fcc ScrCmd_loadword
 thumb_func 0x8098ff0 ScrCmd_loadbytefromaddr
 thumb_func 0x8099014 ScrCmd_writebytetoaddr
@@ -4854,9 +4854,9 @@ thumb_func 0x809902c ScrCmd_loadbyte
 thumb_func 0x8099048 ScrCmd_setptrbyte
 thumb_func 0x809906c ScrCmd_copylocal
 thumb_func 0x809908c ScrCmd_copybyte
-thumb_func 0x80990a8
-thumb_func 0x80990cc
-thumb_func 0x80990f8
+thumb_func 0x80990a8 ScrCmd_setvar
+thumb_func 0x80990cc ScrCmd_copyvar
+thumb_func 0x80990f8 ScrCmd_setorcopyvar
 thumb_func 0x8099124 compare_012
 thumb_func 0x8099144 ScrCmd_compare_local_to_local
 thumb_func 0x8099174 ScrCmd_compare_local_to_value
@@ -4864,329 +4864,329 @@ thumb_func 0x809919c ScrCmd_compare_local_to_addr
 thumb_func 0x80991c8 ScrCmd_compare_addr_to_local
 thumb_func 0x80991f4 ScrCmd_compare_addr_to_value
 thumb_func 0x8099214 ScrCmd_compare_addr_to_addr
-thumb_func 0x8099238
-thumb_func 0x8099268
-thumb_func 0x809929c
-thumb_func 0x80992c4
-thumb_func 0x80992f4
-thumb_func 0x8099328
-thumb_func 0x809936c
-thumb_func 0x80993b0
-thumb_func 0x80993f4
-thumb_func 0x8099438
-thumb_func 0x8099464
-thumb_func 0x80994a8
-thumb_func 0x80994ec
-thumb_func 0x8099518
-thumb_func 0x8099544
-thumb_func 0x8099570
-thumb_func 0x809959c
-thumb_func 0x80995b0
-thumb_func 0x80995c4
+thumb_func 0x8099238 ScrCmd_compare_var_to_value
+thumb_func 0x8099268 ScrCmd_compare_var_to_var
+thumb_func 0x809929c ScrCmd_addvar
+thumb_func 0x80992c4 ScrCmd_subvar
+thumb_func 0x80992f4 ScrCmd_random
+thumb_func 0x8099328 ScrCmd_giveitem
+thumb_func 0x809936c ScrCmd_takeitem
+thumb_func 0x80993b0 ScrCmd_checkitemspace
+thumb_func 0x80993f4 ScrCmd_checkitem
+thumb_func 0x8099438 ScrCmd_checkitemtype
+thumb_func 0x8099464 ScrCmd_givepcitem
+thumb_func 0x80994a8 ScrCmd_checkpcitem
+thumb_func 0x80994ec ScrCmd_givedecoration
+thumb_func 0x8099518 ScrCmd_takedecoration
+thumb_func 0x8099544 ScrCmd_checkdecorspace
+thumb_func 0x8099570 ScrCmd_checkdecor
+thumb_func 0x809959c ScrCmd_setflag
+thumb_func 0x80995b0 ScrCmd_clearflag
+thumb_func 0x80995c4 ScrCmd_checkflag
 thumb_func 0x80995e0 ScrCmd_incrementgamestat
-thumb_func 0x80995f8
-thumb_func 0x8099614
-thumb_func 0x8099630
-thumb_func 0x8099650
-thumb_func 0x8099678
-thumb_func 0x80996a8
-thumb_func 0x809971c
+thumb_func 0x80995f8 ScrCmd_animateflash
+thumb_func 0x8099614 ScrCmd_setflashradius
+thumb_func 0x8099630 IsPaletteNotActive
+thumb_func 0x8099650 ScrCmd_fadescreen
+thumb_func 0x8099678 ScrCmd_fadescreenspeed
+thumb_func 0x80996a8 ScrCmd_fadescreenswapbuffers
+thumb_func 0x809971c RunPauseTimer
 thumb_func 0x809973c ScrCmd_delay
-thumb_func 0x8099760
-thumb_func 0x8099798
-thumb_func 0x80997a4
-thumb_func 0x80997dc
+thumb_func 0x8099760 ScrCmd_initclock
+thumb_func 0x8099798 ScrCmd_dotimebasedevents
+thumb_func 0x80997a4 ScrCmd_gettime
+thumb_func 0x80997dc ScrCmd_setweather
 thumb_func 0x80997f8
 thumb_func 0x8099804
-thumb_func 0x8099810
-thumb_func 0x8099828
-thumb_func 0x8099844
-thumb_func 0x80998cc
+thumb_func 0x8099810 ScrCmd_setstepcallback
+thumb_func 0x8099828 ScrCmd_setmaplayoutindex
+thumb_func 0x8099844 ScrCmd_warp
+thumb_func 0x80998cc ScrCmd_warpsilent
 thumb_func 0x8099954
-thumb_func 0x80999dc
-thumb_func 0x8099a50
+thumb_func 0x80999dc ScrCmd_warphole
+thumb_func 0x8099a50 ScrCmd_warpteleport
 thumb_func 0x8099ad8
-thumb_func 0x8099b60
-thumb_func 0x8099be0
-thumb_func 0x8099c64
-thumb_func 0x8099ce4
-thumb_func 0x8099d64
-thumb_func 0x8099de4
-thumb_func 0x8099e20
-thumb_func 0x8099e3c
-thumb_func 0x8099e50
-thumb_func 0x8099e68
-thumb_func 0x8099e7c
-thumb_func 0x8099e90
-thumb_func 0x8099ea0
-thumb_func 0x8099eb4
-thumb_func 0x8099ee4
-thumb_func 0x8099ef8
-thumb_func 0x8099f04
-thumb_func 0x8099f18
-thumb_func 0x8099f4c
-thumb_func 0x8099f70
-thumb_func 0x8099fb4
-thumb_func 0x8099ff8
-thumb_func 0x809a020
-thumb_func 0x809a074
+thumb_func 0x8099b60 ScrCmd_setwarp
+thumb_func 0x8099be0 ScrCmd_setdynamicwarp
+thumb_func 0x8099c64 ScrCmd_setdivewarp
+thumb_func 0x8099ce4 ScrCmd_setholewarp
+thumb_func 0x8099d64 ScrCmd_setescapewarp
+thumb_func 0x8099de4 ScrCmd_getplayerxy
+thumb_func 0x8099e20 ScrCmd_getpartysize
+thumb_func 0x8099e3c ScrCmd_playse
+thumb_func 0x8099e50 WaitForSoundEffectFinish
+thumb_func 0x8099e68 ScrCmd_waitse
+thumb_func 0x8099e7c ScrCmd_playfanfare
+thumb_func 0x8099e90 WaitForFanfareFinish
+thumb_func 0x8099ea0 ScrCmd_waitfanfare
+thumb_func 0x8099eb4 ScrCmd_playbgm
+thumb_func 0x8099ee4 ScrCmd_savebgm
+thumb_func 0x8099ef8 ScrCmd_fadedefaultbgm
+thumb_func 0x8099f04 ScrCmd_fadenewbgm
+thumb_func 0x8099f18 ScrCmd_fadeoutbgm
+thumb_func 0x8099f4c ScrCmd_fadeinbgm
+thumb_func 0x8099f70 ScrCmd_setobjectpriority
+thumb_func 0x8099fb4 ScrCmd_applymovement_at
+thumb_func 0x8099ff8 WaitForMovementFinish
+thumb_func 0x809a020 ScrCmd_waitmovement
+thumb_func 0x809a074 ScrCmd_waitmovement_at
 thumb_func 0x809a0c8
-thumb_func 0x809a0f0
-thumb_func 0x809a120
-thumb_func 0x809a148
-thumb_func 0x809a178
-thumb_func 0x809a1e0
-thumb_func 0x809a238
-thumb_func 0x809a260
-thumb_func 0x809a290
+thumb_func 0x809a0f0 ScrCmd_removeobject_at
+thumb_func 0x809a120 ScrCmd_addobject
+thumb_func 0x809a148 ScrCmd_addobject_at
+thumb_func 0x809a178 ScrCmd_setobjectxy
+thumb_func 0x809a1e0 ScrCmd_setobjectxyperm
+thumb_func 0x809a238 ScrCmd_moveobjectoffscreen
+thumb_func 0x809a260 ScrCmd_showobject_at
+thumb_func 0x809a290 ScrCmd_hideobject_at
 thumb_func 0x809a2c0
-thumb_func 0x809a2fc
-thumb_func 0x809a32c
-thumb_func 0x809a364
-thumb_func 0x809a398
-thumb_func 0x809a3c0
-thumb_func 0x809a430
-thumb_func 0x809a44c
-thumb_func 0x809a474
-thumb_func 0x809a4cc
-thumb_func 0x809a504
+thumb_func 0x809a2fc ScrCmd_resetobjectpriority
+thumb_func 0x809a32c ScrCmd_faceplayer
+thumb_func 0x809a364 ScrCmd_turnobject
+thumb_func 0x809a398 ScrCmd_setobjectmovementtype
+thumb_func 0x809a3c0 ScrCmd_createvobject
+thumb_func 0x809a430 ScrCmd_turnvobject
+thumb_func 0x809a44c ScrCmd_lockall
+thumb_func 0x809a474 ScrCmd_lock
+thumb_func 0x809a4cc ScrCmd_releaseall
+thumb_func 0x809a504 ScrCmd_release
 thumb_func 0x809a55c ScrCmd_message
 thumb_func 0x809a578 ScrCmd_pokenavcall
 thumb_func 0x809a594 ScrCmd_messageautoscroll
-thumb_func 0x809a5c4
-thumb_func 0x809a600
-thumb_func 0x809a614
-thumb_func 0x809a620
-thumb_func 0x809a648
-thumb_func 0x809a65c
-thumb_func 0x809a688
+thumb_func 0x809a5c4 ScrCmd_cmdDB
+thumb_func 0x809a600 ScrCmd_waitmessage
+thumb_func 0x809a614 ScrCmd_closemessage
+thumb_func 0x809a620 WaitForAorBPress
+thumb_func 0x809a648 ScrCmd_waitbuttonpress
+thumb_func 0x809a65c ScrCmd_yesnobox
+thumb_func 0x809a688 ScrCmd_multichoice
 thumb_func 0x809a6c4
 thumb_func 0x809a714
-thumb_func 0x809a718
+thumb_func 0x809a718 ScrCmd_multichoicegrid
 thumb_func 0x809a768
 thumb_func 0x809a774
 thumb_func 0x809a780
-thumb_func 0x809a7b0
-thumb_func 0x809a7d0
+thumb_func 0x809a7b0 ScrCmd_hidemonpic
+thumb_func 0x809a7d0 ScrCmd_showcontestwinner
 thumb_func 0x809a7f4
 thumb_func 0x809a8e4
-thumb_func 0x809a8f0
+thumb_func 0x809a8f0 ScrCmd_vmessage
 thumb_func 0x809a90c
-thumb_func 0x809a950
-thumb_func 0x809a9a0
-thumb_func 0x809a9e8
+thumb_func 0x809a950 ScrCmd_bufferleadmonspeciesname
+thumb_func 0x809a9a0 ScrCmd_bufferpartymonnick
+thumb_func 0x809a9e8 ScrCmd_bufferitemname
 thumb_func 0x809aa1c
-thumb_func 0x809aa60
-thumb_func 0x809aa9c
-thumb_func 0x809aae0
-thumb_func 0x809ab20
-thumb_func 0x809ab48
-thumb_func 0x809ab6c
-thumb_func 0x809aba0
-thumb_func 0x809abdc
+thumb_func 0x809aa60 ScrCmd_bufferdecorationname
+thumb_func 0x809aa9c ScrCmd_buffernumberstring
+thumb_func 0x809aae0 ScrCmd_bufferstdstring
+thumb_func 0x809ab20 ScrCmd_bufferstring
+thumb_func 0x809ab48 ScrCmd_vloadword
+thumb_func 0x809ab6c ScrCmd_vbufferstring
+thumb_func 0x809aba0 ScrCmd_bufferboxname
+thumb_func 0x809abdc ScrCmd_givemon
 thumb_func 0x809ac5c
-thumb_func 0x809ac88
-thumb_func 0x809acb4
+thumb_func 0x809ac88 ScrCmd_setmonmove
+thumb_func 0x809acb4 ScrCmd_checkpartymove
 thumb_func 0x809ad30
 thumb_func 0x809ad64
-thumb_func 0x809ad98
-thumb_func 0x809add8
+thumb_func 0x809ad98 ScrCmd_checkmoney
+thumb_func 0x809add8 ScrCmd_showmoneybox
 thumb_func 0x809ae14
-thumb_func 0x809ae20
-thumb_func 0x809ae50
-thumb_func 0x809ae78
-thumb_func 0x809ae8c
-thumb_func 0x809aea8
-thumb_func 0x809aebc
+thumb_func 0x809ae20 ScrCmd_updatemoneybox
+thumb_func 0x809ae50 ScrCmd_showcoinsbox
+thumb_func 0x809ae78 ScrCmd_hidecoinsbox
+thumb_func 0x809ae8c ScrCmd_updatecoinsbox
+thumb_func 0x809aea8 ScrCmd_trainerbattle
+thumb_func 0x809aebc ScrCmd_dotrainerbattle
 thumb_func 0x809aec8
 thumb_func 0x809aedc
-thumb_func 0x809aef0
-thumb_func 0x809af14
-thumb_func 0x809af30
-thumb_func 0x809af4c
-thumb_func 0x809af80
+thumb_func 0x809aef0 ScrCmd_checktrainerflag
+thumb_func 0x809af14 ScrCmd_settrainerflag
+thumb_func 0x809af30 HideSaveInfoWindow
+thumb_func 0x809af4c ScrCmd_setwildbattle
+thumb_func 0x809af80 ScrCmd_dowildbattle
 thumb_func 0x809af90
 thumb_func 0x809afa4
 thumb_func 0x809afb8
-thumb_func 0x809afcc
-thumb_func 0x809aff4
-thumb_func 0x809b030
+thumb_func 0x809afcc ScrCmd_playslotmachine
+thumb_func 0x809aff4 ScrCmd_setberrytree
+thumb_func 0x809b030 ScrCmd_getpricereduction
 thumb_func 0x809b05c
 thumb_func 0x809b06c
-thumb_func 0x809b07c
+thumb_func 0x809b07c IsPokerusInParty
 thumb_func 0x809b08c
-thumb_func 0x809b0a4
-thumb_func 0x809b0cc
-thumb_func 0x809b0fc
-thumb_func 0x809b11c
-thumb_func 0x809b148
-thumb_func 0x809b164
-thumb_func 0x809b17c
+thumb_func 0x809b0a4 ScrCmd_dofieldeffect
+thumb_func 0x809b0cc ScrCmd_setfieldeffectarg
+thumb_func 0x809b0fc WaitForFieldEffectFinish
+thumb_func 0x809b11c ScrCmd_waitfieldeffect
+thumb_func 0x809b148 ScrCmd_setrespawn
+thumb_func 0x809b164 ScrCmd_checkplayergender
+thumb_func 0x809b17c ScrCmd_playmoncry
 thumb_func 0x809b1b4
-thumb_func 0x809b1c8
-thumb_func 0x809b248
-thumb_func 0x809b2a0
-thumb_func 0x809b2e4
+thumb_func 0x809b1c8 ScrCmd_setmetatile
+thumb_func 0x809b248 ScrCmd_opendoor
+thumb_func 0x809b2a0 ScrCmd_closedoor
+thumb_func 0x809b2e4 IsDoorAnimationStopped
 thumb_func 0x809b2fc
-thumb_func 0x809b310
+thumb_func 0x809b310 ScrCmd_setdooropen
 thumb_func 0x809b354
-thumb_func 0x809b398
+thumb_func 0x809b398 ScrCmd_addelevmenuitem
 thumb_func 0x809b3d4
-thumb_func 0x809b3d8
-thumb_func 0x809b3f8
-thumb_func 0x809b430
+thumb_func 0x809b3d8 ScrCmd_checkcoins
+thumb_func 0x809b3f8 ScrCmd_givecoins
+thumb_func 0x809b430 ScrCmd_takecoins
 thumb_func 0x809b468
 thumb_func 0x809b48c
-thumb_func 0x809b498
+thumb_func 0x809b498 ScrCmd_mossdeepgym3
 thumb_func 0x809b4b4
-thumb_func 0x809b4c0
-thumb_func 0x809b4d4
-thumb_func 0x809b51c
-thumb_func 0x809b554
-thumb_func 0x809b58c
-thumb_func 0x809b5b4
-thumb_func 0x809b648
+thumb_func 0x809b4c0 ScrCmd_cmdD8
+thumb_func 0x809b4d4 ScrCmd_cmdD9
+thumb_func 0x809b51c ScrCmd_setmonobedient
+thumb_func 0x809b554 ScrCmd_checkmonobedience
+thumb_func 0x809b58c ScrCmd_gotoram
+thumb_func 0x809b5b4 ScrCmd_warpD1
+thumb_func 0x809b648 ScrCmd_setmonmetlocation
 thumb_func 0x809b68c
-thumb_func 0x809b6a8
+thumb_func 0x809b6a8 ScrCmd_buffertrainerclassname
 thumb_func 0x809b6e4
 thumb_func 0x809b720
-thumb_func 0x809b72c
+thumb_func 0x809b72c ScrCmd_warpE0
 thumb_func 0x809b7b4 FieldClearPlayerInput
-thumb_func 0x809b7e0
-thumb_func 0x809b8ec
-thumb_func 0x809ba54
-thumb_func 0x809ba6c
-thumb_func 0x809baa8
-thumb_func 0x809bad4
+thumb_func 0x809b7e0 FieldGetPlayerInput
+thumb_func 0x809b8ec ProcessPlayerFieldInput
+thumb_func 0x809ba54 GetPlayerPosition
+thumb_func 0x809ba6c GetInFrontOfPlayerPosition
+thumb_func 0x809baa8 GetPlayerCurMetatileBehavior
+thumb_func 0x809bad4 TryStartInteractionScript
 thumb_func 0x809bb48 GetInteractionScript
-thumb_func 0x809bba0
-thumb_func 0x809bc5c
-thumb_func 0x809bd30
-thumb_func 0x809be10
-thumb_func 0x809c0c4
+thumb_func 0x809bba0 GetInteractedLinkPlayerScript
+thumb_func 0x809bc5c GetInteractedEventObjectScript
+thumb_func 0x809bd30 GetInteractedBackgroundEventScript
+thumb_func 0x809be10 GetInteractedMetatileScript
+thumb_func 0x809c0c4 GetInteractedWaterScript
 thumb_func 0x809c140
-thumb_func 0x809c174
-thumb_func 0x809c1b4
-thumb_func 0x809c210
-thumb_func 0x809c244
-thumb_func 0x809c2cc
-thumb_func 0x809c408
-thumb_func 0x809c41c
-thumb_func 0x809c458
-thumb_func 0x809c46c
+thumb_func 0x809c174 TrySetupDiveEmergeScript
+thumb_func 0x809c1b4 TryStartStepBasedScript
+thumb_func 0x809c210 TryStartCoordEventScript
+thumb_func 0x809c244 TryStartMiscWalkingScripts
+thumb_func 0x809c2cc TryStartStepCountScript
+thumb_func 0x809c408 Unref_ClearHappinessStepCounter
+thumb_func 0x809c41c UpdateHappinessStepCounter
+thumb_func 0x809c458 ClearPoisonStepCounter
+thumb_func 0x809c46c UpdatePoisonStepCounter
 thumb_func 0x809c4b4
-thumb_func 0x809c4c0
-thumb_func 0x809c510
-thumb_func 0x809c574
-thumb_func 0x809c66c
+thumb_func 0x809c4c0 CheckStandardWildEncounter
+thumb_func 0x809c510 TryArrowWarp
+thumb_func 0x809c574 TryStartWarpEventScript
+thumb_func 0x809c66c IsWarpMetatileBehavior
 thumb_func 0x809c70c
 thumb_func 0x809c764 GetWarpEventAtMapPosition
-thumb_func 0x809c788
-thumb_func 0x809c850
+thumb_func 0x809c788 SetupWarp
+thumb_func 0x809c850 TryDoorWarp
 thumb_func 0x809c8dc GetWarpEventAtPosition
-thumb_func 0x809c924
+thumb_func 0x809c924 TryRunCoordEventScript
 thumb_func 0x809c964 GetCoordEventScriptAtPosition
 thumb_func 0x809c9cc GetCoordEventScriptAtMapPosition
 thumb_func 0x809c9f4 GetBackgroundEventAtPosition
-thumb_func 0x809ca44
-thumb_func 0x809cac0
-thumb_func 0x809cb58
-thumb_func 0x809cb94
-thumb_func 0x809cbd8
-thumb_func 0x809cc1c
-thumb_func 0x809cc78
+thumb_func 0x809ca44 dive_warp
+thumb_func 0x809cac0 TrySetDiveWarp
+thumb_func 0x809cb58 GetEventObjectScriptPointerPlayerFacing
+thumb_func 0x809cb94 SetCableClubWarp
+thumb_func 0x809cbd8 InitEventData
+thumb_func 0x809cc1c ClearTempFieldEventData
+thumb_func 0x809cc78 ClearDailyFlags
 thumb_func 0x809cc98 DisableNationalPokedex
-thumb_func 0x809ccc0
-thumb_func 0x809cd04
-thumb_func 0x809cd48
-thumb_func 0x809cd58
-thumb_func 0x809cd68
-thumb_func 0x809cd7c
-thumb_func 0x809cd8c
-thumb_func 0x809cd9c
+thumb_func 0x809ccc0 EnableNationalPokedex
+thumb_func 0x809cd04 IsNationalPokedexEnabled
+thumb_func 0x809cd48 DisableMysteryEvent
+thumb_func 0x809cd58 EnableMysteryEvent
+thumb_func 0x809cd68 IsMysteryEventEnabled
+thumb_func 0x809cd7c DisableMysteryGift
+thumb_func 0x809cd8c EnableMysteryGift
+thumb_func 0x809cd9c IsMysteryGiftEnabled
 thumb_func 0x809cdb0
 thumb_func 0x809ce48
 thumb_func 0x809ceb0 DisableResetRTC
 thumb_func 0x809cecc EnableResetRTC
 thumb_func 0x809ceec CanResetRTC
-thumb_func 0x809cf20
+thumb_func 0x809cf20 GetVarPointer
 thumb_func 0x809cf6c VarGet
 thumb_func 0x809cf88 VarSet
 thumb_func 0x809cfa8 VarGetEventObjectGraphicsId
-thumb_func 0x809cfc4
+thumb_func 0x809cfc4 GetFlagPointer
 thumb_func 0x809d018 FlagSet
 thumb_func 0x809d040 FlagClear
 thumb_func 0x809d068 FlagGet
 thumb_func 0x809d094
-thumb_func 0x809d0a0
+thumb_func 0x809d0a0 CoordEventWeather_Sunny
 thumb_func 0x809d0ac
 thumb_func 0x809d0b8
-thumb_func 0x809d0c4
-thumb_func 0x809d0d0
-thumb_func 0x809d0dc
-thumb_func 0x809d0e8
-thumb_func 0x809d0f4
-thumb_func 0x809d100
-thumb_func 0x809d10c
-thumb_func 0x809d118
-thumb_func 0x809d124
-thumb_func 0x809d130
-thumb_func 0x809d164
-thumb_func 0x809d190
-thumb_func 0x809d1e0
-thumb_func 0x809d214
-thumb_func 0x809d280
-thumb_func 0x809d2c8
+thumb_func 0x809d0c4 CoordEventWeather_Thunderstorm
+thumb_func 0x809d0d0 CoordEventWeather_LightRain
+thumb_func 0x809d0dc CoordEventWeather_Snow
+thumb_func 0x809d0e8 CoordEventWeather_Ash
+thumb_func 0x809d0f4 CoordEventWeather_Fog
+thumb_func 0x809d100 CoordEventWeather_DiagonalFog
+thumb_func 0x809d10c CoordEventWeather_Drought
+thumb_func 0x809d118 CoordEventWeather_Route119Cycle
+thumb_func 0x809d124 CoordEventWeather_Route123Cycle
+thumb_func 0x809d130 DoCoordEventWeather
+thumb_func 0x809d164 Task_RunPerStepCallback
+thumb_func 0x809d190 RunTimeBasedEvents
+thumb_func 0x809d1e0 Task_RunTimeBasedEvents
+thumb_func 0x809d214 SetUpFieldTasks
+thumb_func 0x809d280 ActivatePerStepCallback
+thumb_func 0x809d2c8 ResetFieldTasksArgs
 thumb_func 0x809d304 nullsub_49
-thumb_func 0x809d308
-thumb_func 0x809d360
+thumb_func 0x809d308 GetPacifidlogBridgeMetatileOffsets
+thumb_func 0x809d360 SetPacifidlogBridgeMetatiles
 thumb_func 0x809d3e8 UpdateHalfSubmergedBridgeMetatiles
 thumb_func 0x809d40c UpdateFullySubmergedBridgeMetatiles
 thumb_func 0x809d430 UpdateFloatingBridgeMetatiles
-thumb_func 0x809d454
-thumb_func 0x809d4f0
-thumb_func 0x809d58c
-thumb_func 0x809d700
-thumb_func 0x809d764
-thumb_func 0x809d7c8
-thumb_func 0x809d9e0
+thumb_func 0x809d454 StandingOnNewPacifidlogBridge
+thumb_func 0x809d4f0 StandingOnSamePacifidlogBridge
+thumb_func 0x809d58c PacifidlogBridgePerStepCallback
+thumb_func 0x809d700 SetLoweredForetreeBridgeMetatile
+thumb_func 0x809d764 SetNormalFortreeBridgeMetatile
+thumb_func 0x809d7c8 FortreeBridgePerStepCallback
+thumb_func 0x809d9e0 CoordInIcePuzzleRegion
 thumb_func 0x809da24 MarkIcePuzzleCoordVisited
-thumb_func 0x809da5c
-thumb_func 0x809daa0
-thumb_func 0x809dafc
-thumb_func 0x809dc8c
-thumb_func 0x809dd68
+thumb_func 0x809da5c IsIcePuzzleCoordVisited
+thumb_func 0x809daa0 SetSootopolisGymCrackedIceMetatiles
+thumb_func 0x809dafc SootopolisGymIcePerStepCallback
+thumb_func 0x809dc8c AshGrassPerStepCallback
+thumb_func 0x809dd68 SetCrackedFloorHoleMetatile
 thumb_func 0x809dda4
-thumb_func 0x809deb4
-thumb_func 0x809df10
-thumb_func 0x809e050
-thumb_func 0x809e088
-thumb_func 0x809e0c0
-thumb_func 0x809e130
-thumb_func 0x809e18c
+thumb_func 0x809deb4 SetMuddySlopeMetatile
+thumb_func 0x809df10 Task_MuddySlope
+thumb_func 0x809e050 InitTimeBasedEvents
+thumb_func 0x809e088 DoTimeBasedEvents
+thumb_func 0x809e0c0 UpdatePerDay
+thumb_func 0x809e130 UpdatePerMinute
+thumb_func 0x809e18c ReturnFromStartWallClock
 thumb_func 0x809e1a0
-thumb_func 0x809e1c0
-thumb_func 0x809e2dc
-thumb_func 0x809e3dc
+thumb_func 0x809e1c0 SpriteCB_ResetRtcCursor0
+thumb_func 0x809e2dc SpriteCB_ResetRtcCursor1
+thumb_func 0x809e3dc CreateCursor
 thumb_func 0x809e464
-thumb_func 0x809e478
-thumb_func 0x809e49c
-thumb_func 0x809e58c
+thumb_func 0x809e478 HideChooseTimeWindow
+thumb_func 0x809e49c PrintTime
+thumb_func 0x809e58c ShowChooseTimeWindow
 thumb_func 0x809e610 MoveTimeUpDown
 thumb_func 0x809e678 Task_ResetRtc_3
 thumb_func 0x809e690 Task_ResetRtc_2
-thumb_func 0x809e6c0
-thumb_func 0x809e7d8
-thumb_func 0x809e860
+thumb_func 0x809e6c0 Task_ResetRtc_1
+thumb_func 0x809e7d8 Task_ResetRtc_0
+thumb_func 0x809e860 CB2_InitResetRtcScreen
 thumb_func 0x809e920
-thumb_func 0x809e968
+thumb_func 0x809e968 CB2_ResetRtcScreen
 thumb_func 0x809e984
-thumb_func 0x809e998
-thumb_func 0x809e9d0
-thumb_func 0x809ead8
+thumb_func 0x809e998 ShowMessage
+thumb_func 0x809e9d0 Task_ShowResetRtcPrompt
+thumb_func 0x809ead8 Task_ResetRtcScreen
 thumb_func 0x809ecf4 SetDexPokemonPokenavFlags
-thumb_func 0x809ed18
-thumb_func 0x809ed88
+thumb_func 0x809ed18 BuildStartMenuActions
+thumb_func 0x809ed88 AddStartMenuAction
 thumb_func 0x809eda4 BuildNormalStartMenu
 thumb_func 0x809ee10 BuildSafariZoneStartMenu
 thumb_func 0x809ee40 BuildLinkModeStartMenu
@@ -5194,84 +5194,84 @@ thumb_func 0x809ee7c BuildUnionRoomStartMenu
 thumb_func 0x809eeb8 BuildBattlePikeStartMenu
 thumb_func 0x809eedc BuildBattlePyramidStartMenu
 thumb_func 0x809ef0c BuildMultiBattleRoomStartMenu
-thumb_func 0x809ef2c
-thumb_func 0x809efa0
-thumb_func 0x809f04c
-thumb_func 0x809f098
-thumb_func 0x809f16c
+thumb_func 0x809ef2c ShowSafariBallsWindow
+thumb_func 0x809efa0 ShowPyramidFloorWindow
+thumb_func 0x809f04c RemoveExtraStartMenuWindows
+thumb_func 0x809f098 PrintStartMenuActions
+thumb_func 0x809f16c InitStartMenuStep
 thumb_func 0x809f270 InitStartMenu
-thumb_func 0x809f28c
-thumb_func 0x809f2a8
+thumb_func 0x809f28c StartMenuTask
+thumb_func 0x809f2a8 CreateStartMenuTask
 thumb_func 0x809f2d8
 thumb_func 0x809f2f0
 thumb_func 0x809f30c
-thumb_func 0x809f374
-thumb_func 0x809f39c
-thumb_func 0x809f48c
-thumb_func 0x809f4c8
+thumb_func 0x809f374 ShowStartMenu
+thumb_func 0x809f39c HandleStartMenuInput
+thumb_func 0x809f48c StartMenuPokedexCallback
+thumb_func 0x809f4c8 StartMenuPokemonCallback
 thumb_func 0x809f4fc
 thumb_func 0x809f530
-thumb_func 0x809f564
-thumb_func 0x809f5d4
-thumb_func 0x809f5f8
-thumb_func 0x809f63c
-thumb_func 0x809f64c
+thumb_func 0x809f564 StartMenuPlayerNameCallback
+thumb_func 0x809f5d4 StartMenuSaveCallback
+thumb_func 0x809f5f8 StartMenuOptionCallback
+thumb_func 0x809f63c StartMenuExitCallback
+thumb_func 0x809f64c StartMenuSafariZoneRetireCallback
 thumb_func 0x809f660
-thumb_func 0x809f698
-thumb_func 0x809f6ac
-thumb_func 0x809f6cc
-thumb_func 0x809f700
-thumb_func 0x809f71c
-thumb_func 0x809f774
-thumb_func 0x809f790
-thumb_func 0x809f7ac
-thumb_func 0x809f800
+thumb_func 0x809f698 StartMenuBattlePyramidRetireCallback
+thumb_func 0x809f6ac CableCarMainCallback_Run
+thumb_func 0x809f6cc StartMenuBattlePyramidBagCallback
+thumb_func 0x809f700 SaveStartCallback
+thumb_func 0x809f71c SaveCallback
+thumb_func 0x809f774 BattlePyramidRetireStartCallback
+thumb_func 0x809f790 BattlePyramidRetireReturnCallback
+thumb_func 0x809f7ac BattlePyramidRetireCallback
+thumb_func 0x809f800 InitSave
 thumb_func 0x809f824
-thumb_func 0x809f858
-thumb_func 0x809f870
-thumb_func 0x809f8a8
+thumb_func 0x809f858 SaveGame
+thumb_func 0x809f870 ShowSaveMessage
+thumb_func 0x809f8a8 SaveGameTask
 thumb_func 0x809f8ec
 thumb_func 0x809f8fc
-thumb_func 0x809f908
-thumb_func 0x809f914
-thumb_func 0x809f948
-thumb_func 0x809f978
+thumb_func 0x809f908 SaveStartTimer
+thumb_func 0x809f914 SaveSuccesTimer
+thumb_func 0x809f948 SaveErrorTimer
+thumb_func 0x809f978 SaveConfirmSaveCallback
 thumb_func 0x809f9c4
-thumb_func 0x809f9e0
-thumb_func 0x809fa54
+thumb_func 0x809f9e0 SaveConfirmInputCallback
+thumb_func 0x809fa54 SaveFileExistsCallback
 thumb_func 0x809fa8c
 thumb_func 0x809faa8
-thumb_func 0x809fac4
-thumb_func 0x809fb0c
-thumb_func 0x809fb24
+thumb_func 0x809fac4 SaveOverwriteInputCallback
+thumb_func 0x809fb0c SaveSavingMessageCallback
+thumb_func 0x809fb24 SaveDoSaveCallback
 thumb_func 0x809fb88
-thumb_func 0x809fbb0
-thumb_func 0x809fbd4
+thumb_func 0x809fbb0 SaveReturnSuccessCallback
+thumb_func 0x809fbd4 SaveErrorCallback
 thumb_func 0x809fbfc SaveReturnErrorCallback
-thumb_func 0x809fc18
-thumb_func 0x809fc34
+thumb_func 0x809fc18 InitBattlePyramidRetire
+thumb_func 0x809fc34 BattlePyramidConfirmRetireCallback
 thumb_func 0x809fc60
-thumb_func 0x809fc7c
+thumb_func 0x809fc7c BattlePyramidRetireInputCallback
 thumb_func 0x809fcb0
 thumb_func 0x809fcbc
 thumb_func 0x809fdec
 thumb_func 0x809fe18
 thumb_func 0x809fe28
-thumb_func 0x809ff8c
+thumb_func 0x809ff8c ShowSaveInfoWindow
 thumb_func 0x80a0150
 thumb_func 0x80a016c
 thumb_func 0x80a0194
-thumb_func 0x80a01dc
-thumb_func 0x80a01fc
-thumb_func 0x80a020c
-thumb_func 0x80a021c
+thumb_func 0x80a01dc HideStartMenuWindow
+thumb_func 0x80a01fc HideStartMenu
+thumb_func 0x80a020c AppendToList
+thumb_func 0x80a021c ResetTilesetAnimBuffer
 thumb_func 0x80a0248 AppendTilesetAnimToBuffer
 thumb_func 0x80a0298 TransferTilesetAnimsBuffer
-thumb_func 0x80a02e0
-thumb_func 0x80a02f4
-thumb_func 0x80a0300
-thumb_func 0x80a0370
-thumb_func 0x80a03ac
+thumb_func 0x80a02e0 InitTilesetAnimations
+thumb_func 0x80a02f4 InitSecondaryTilesetAnimation
+thumb_func 0x80a0300 UpdateTilesetAnimations
+thumb_func 0x80a0370 _InitPrimaryTilesetAnimation
+thumb_func 0x80a03ac _InitSecondaryTilesetAnimation
 thumb_func 0x80a03e8
 thumb_func 0x80a0410
 thumb_func 0x80a0438 TilesetAnim_General
@@ -5320,7 +5320,7 @@ thumb_func 0x80a0b9c QueueAnimTiles_Lavaridge_Steam
 thumb_func 0x80a0be4 QueueAnimTiles_Pacifidlog_LogBridges
 thumb_func 0x80a0c0c QueueAnimTiles_Underwater_Seaweed
 thumb_func 0x80a0c34 QueueAnimTiles_Pacifidlog_WaterCurrents
-thumb_func 0x80a0c5c
+thumb_func 0x80a0c5c QueueAnimTiles_Mauville_Flowers
 thumb_func 0x80a0cfc QueueAnimTiles_Rustboro_WindyWater
 thumb_func 0x80a0d38 QueueAnimTiles_Rustboro_Fountain
 thumb_func 0x80a0d60 QueueAnimTiles_Lavaridge_Lava
@@ -5338,47 +5338,47 @@ thumb_func 0x80a0efc TilesetAnim_BattlePyramid
 thumb_func 0x80a0f20 TilesetAnim_BattleDome
 thumb_func 0x80a0f38 TilesetAnim_BattleDome2
 thumb_func 0x80a0f50 QueueAnimTiles_Building_TVTurnedOn
-thumb_func 0x80a0f78
+thumb_func 0x80a0f78 QueueAnimTiles_SootopolisGym_Waterfalls
 thumb_func 0x80a0fc0 QueueAnimTiles_EliteFour_WallLights
 thumb_func 0x80a0fe8 QueueAnimTiles_EliteFour_GroundLights
 thumb_func 0x80a1010 QueueAnimTiles_MauvilleGym_ElectricGates
 thumb_func 0x80a1038 QueueAnimTiles_BikeShop_BlinkingLights
 thumb_func 0x80a1060 QueueAnimTiles_Sootopolis_StormyWater
-thumb_func 0x80a1088
+thumb_func 0x80a1088 QueueAnimTiles_BattlePyramid_Torch
 thumb_func 0x80a10b4
-thumb_func 0x80a10e0
-thumb_func 0x80a114c
-thumb_func 0x80a11bc
-thumb_func 0x80a1200
-thumb_func 0x80a1238
+thumb_func 0x80a10e0 BlendAnimPalette_BattleDome_FloorLights
+thumb_func 0x80a114c BlendAnimPalette_BattleDome_FloorLightsNoBlend
+thumb_func 0x80a11bc LoadCompressedPalette
+thumb_func 0x80a1200 LoadPalette
+thumb_func 0x80a1238 FillPalette
 thumb_func 0x80a1288 TransferPlttBuffer
-thumb_func 0x80a12e4
+thumb_func 0x80a12e4 UpdatePaletteFade
 thumb_func 0x80a133c ResetPaletteFade
 thumb_func 0x80a135c ReadPlttIntoBuffers
-thumb_func 0x80a139c
+thumb_func 0x80a139c BeginNormalPaletteFade
 thumb_func 0x80a14e4 unref_sub_80A1C1C
-thumb_func 0x80a152c
-thumb_func 0x80a15a4
-thumb_func 0x80a1708
+thumb_func 0x80a152c unref_sub_80A1C64
+thumb_func 0x80a15a4 unused_sub_80A1CDC
+thumb_func 0x80a1708 unused_sub_80A1E40
 thumb_func 0x80a17c8 unused_sub_80A1F00
 thumb_func 0x80a1820 ResetPaletteStructByUid
 thumb_func 0x80a183c ResetPaletteStruct
 thumb_func 0x80a1898 ResetPaletteFadeControl
 thumb_func 0x80a1910 unref_sub_80A2048
 thumb_func 0x80a193c unref_sub_80A2074
-thumb_func 0x80a196c
-thumb_func 0x80a19a0
+thumb_func 0x80a196c GetPaletteNumByUid
+thumb_func 0x80a19a0 UpdateNormalPaletteFade
 thumb_func 0x80a1ae0 InvertPlttBuffer
 thumb_func 0x80a1b28 TintPlttBuffer
 thumb_func 0x80a1bfc UnfadePlttBuffer
 thumb_func 0x80a1c58 BeginFastPaletteFade
-thumb_func 0x80a1c7c
+thumb_func 0x80a1c7c BeginFastPaletteFadeInternal
 thumb_func 0x80a1d00
-thumb_func 0x80a2078
-thumb_func 0x80a2114
-thumb_func 0x80a2230
-thumb_func 0x80a2284
-thumb_func 0x80a22e8
+thumb_func 0x80a2078 BeginHardwarePaletteFade
+thumb_func 0x80a2114 UpdateHardwarePaletteFade
+thumb_func 0x80a2230 UpdateBlendRegisters
+thumb_func 0x80a2284 IsSoftwarePaletteFadeFinishing
+thumb_func 0x80a22e8 BlendPalettes
 thumb_func 0x80a2324 BlendPalettesUnfaded
 thumb_func 0x80a2358 TintPalette_GrayScale
 thumb_func 0x80a23a8 TintPalette_GrayScale2
@@ -5389,68 +5389,68 @@ thumb_func 0x80a25c0
 thumb_func 0x80a25fc
 thumb_func 0x80a2604
 thumb_func 0x80a261c
-thumb_func 0x80a269c
-thumb_func 0x80a26b0
+thumb_func 0x80a269c InitMapMusic
+thumb_func 0x80a26b0 MapMusicMain
 thumb_func 0x80a27a8 ResetMapMusic
 thumb_func 0x80a27cc
-thumb_func 0x80a27d8
-thumb_func 0x80a27f8
+thumb_func 0x80a27d8 PlayNewMapMusic
+thumb_func 0x80a27f8 StopMapMusic
 thumb_func 0x80a2818 FadeOutMapMusic
 thumb_func 0x80a2850 FadeOutAndPlayNewMapMusic
 thumb_func 0x80a2884 FadeOutAndFadeInNewMapMusic
 thumb_func 0x80a28c8 FadeInNewMapMusic
 thumb_func 0x80a2904 IsNotWaitingForBGMStop
-thumb_func 0x80a2928
-thumb_func 0x80a295c
-thumb_func 0x80a2994
-thumb_func 0x80a29ac
-thumb_func 0x80a29e8
-thumb_func 0x80a2a08
+thumb_func 0x80a2928 PlayFanfareByFanfareNum
+thumb_func 0x80a295c WaitFanfare
+thumb_func 0x80a2994 StopFanfareByFanfareNum
+thumb_func 0x80a29ac PlayFanfare
+thumb_func 0x80a29e8 IsFanfareTaskInactive
+thumb_func 0x80a2a08 Task_Fanfare
 thumb_func 0x80a2a38 CreateFanfareTask
-thumb_func 0x80a2a5c
-thumb_func 0x80a2ab0
-thumb_func 0x80a2ac8
+thumb_func 0x80a2a5c FadeInNewBGM
+thumb_func 0x80a2ab0 PlayBattleBGM
+thumb_func 0x80a2ac8 IsBGMPausedOrStopped
 thumb_func 0x80a2af0
 thumb_func 0x80a2b08
-thumb_func 0x80a2b20
-thumb_func 0x80a2b3c
+thumb_func 0x80a2b20 IsBGMStopped
+thumb_func 0x80a2b3c PlayCry1
 thumb_func 0x80a2b88 PlayCry2
-thumb_func 0x80a2bac
-thumb_func 0x80a2c0c
-thumb_func 0x80a2c70
-thumb_func 0x80a2ccc
-thumb_func 0x80a2d14
-thumb_func 0x80a2f40
+thumb_func 0x80a2bac PlayCry3
+thumb_func 0x80a2c0c PlayCry4
+thumb_func 0x80a2c70 PlayCry6
+thumb_func 0x80a2ccc PlayCry5
+thumb_func 0x80a2d14 PlayCryInternal
+thumb_func 0x80a2f40 IsCryFinished
 thumb_func 0x80a2f64
 thumb_func 0x80a2f7c
-thumb_func 0x80a2f90
-thumb_func 0x80a2fb4
-thumb_func 0x80a2fd4
+thumb_func 0x80a2f90 IsCryPlayingOrClearCrySongs
+thumb_func 0x80a2fb4 IsCryPlaying
+thumb_func 0x80a2fd4 Task_DuckBGMForPokemonCry
 thumb_func 0x80a301c RestoreBGMVolumeAfterPokemonCry
-thumb_func 0x80a3040
+thumb_func 0x80a3040 PlayBGM
 thumb_func 0x80a306c
-thumb_func 0x80a307c
+thumb_func 0x80a307c PlaySE12WithPanning
 thumb_func 0x80a30d0
 thumb_func 0x80a3104
-thumb_func 0x80a3138
-thumb_func 0x80a3168
+thumb_func 0x80a3138 SE12PanpotControl
+thumb_func 0x80a3168 IsSEPlaying
 thumb_func 0x80a31ac
 thumb_func 0x80a31d4
 thumb_func 0x80a31fc ClearBattleAnimationVars
 thumb_func 0x80a32d8 DoMoveAnim
-thumb_func 0x80a3310
-thumb_func 0x80a34c4
+thumb_func 0x80a3310 LaunchBattleAnimation
+thumb_func 0x80a34c4 DestroyAnimSprite
 thumb_func 0x80a34e4 DestroyAnimVisualTask
 thumb_func 0x80a3500 DestroyAnimSoundTask
-thumb_func 0x80a351c
-thumb_func 0x80a354c
-thumb_func 0x80a3580
-thumb_func 0x80a35ac
+thumb_func 0x80a351c AddSpriteIndex
+thumb_func 0x80a354c ClearSpriteIndex
+thumb_func 0x80a3580 WaitAnimFrameCount
+thumb_func 0x80a35ac RunAnimScriptCommand
 thumb_func 0x80a35c0
-thumb_func 0x80a35ec
-thumb_func 0x80a3654
-thumb_func 0x80a36a0
-thumb_func 0x80a3794
+thumb_func 0x80a35ec ScriptCmd_loadspritegfx
+thumb_func 0x80a3654 ScriptCmd_unloadspritegfx
+thumb_func 0x80a36a0 ScriptCmd_createsprite
+thumb_func 0x80a3794 ScriptCmd_createvisualtask
 thumb_func 0x80a3810 ScriptCmd_delay
 thumb_func 0x80a3850
 thumb_func 0x80a3884 nullsub_501
@@ -5458,121 +5458,121 @@ thumb_func 0x80a3888 nullsub_51
 thumb_func 0x80a388c
 thumb_func 0x80a3994 ScriptCmd_playse
 thumb_func 0x80a39bc
-thumb_func 0x80a3aa0
-thumb_func 0x80a3bd8
-thumb_func 0x80a3c54
+thumb_func 0x80a3aa0 ScriptCmd_monbg
+thumb_func 0x80a3bd8 IsBattlerSpriteVisible
+thumb_func 0x80a3c54 MoveBattlerSpriteToBG
 thumb_func 0x80a3f68
 thumb_func 0x80a3fe8
 thumb_func 0x80a4044
-thumb_func 0x80a40a0
-thumb_func 0x80a4178
+thumb_func 0x80a40a0 task_pA_ma0A_obj_to_bg_pal
+thumb_func 0x80a4178 ScriptCmd_clearmonbg
 thumb_func 0x80a4248
-thumb_func 0x80a42e0
-thumb_func 0x80a43a4
+thumb_func 0x80a42e0 ScriptCmd_monbg_22
+thumb_func 0x80a43a4 ScriptCmd_clearmonbg_23
 thumb_func 0x80a4478
-thumb_func 0x80a4510
-thumb_func 0x80a4548
-thumb_func 0x80a4570
+thumb_func 0x80a4510 ScriptCmd_setalpha
+thumb_func 0x80a4548 ScriptCmd_setbldcnt
+thumb_func 0x80a4570 ScriptCmd_blendoff
 thumb_func 0x80a4594 ScriptCmd_call
-thumb_func 0x80a45c8
+thumb_func 0x80a45c8 ScriptCmd_return
 thumb_func 0x80a45dc ScriptCmd_setarg
 thumb_func 0x80a4610 ScriptCmd_choosetwoturnanim
-thumb_func 0x80a4650
+thumb_func 0x80a4650 ScriptCmd_jumpifmoveturn
 thumb_func 0x80a4694 ScriptCmd_goto
-thumb_func 0x80a46b8
+thumb_func 0x80a46b8 IsContest
 thumb_func 0x80a46e0 ScriptCmd_fadetobg
-thumb_func 0x80a4724
-thumb_func 0x80a47bc
-thumb_func 0x80a4890
-thumb_func 0x80a4958
+thumb_func 0x80a4724 ScriptCmd_fadetobgfromset
+thumb_func 0x80a47bc Task_FadeToBg
+thumb_func 0x80a4890 LoadMoveBg
+thumb_func 0x80a4958 LoadDefaultBg
 thumb_func 0x80a4974 ScriptCmd_restorebg
-thumb_func 0x80a49b8
+thumb_func 0x80a49b8 ScriptCmd_waitbgfadeout
 thumb_func 0x80a49ec
 thumb_func 0x80a4a20 ScriptCmd_changebg
-thumb_func 0x80a4a40
-thumb_func 0x80a4b40
+thumb_func 0x80a4a40 BattleAnimAdjustPanning
+thumb_func 0x80a4b40 BattleAnimAdjustPanning2
 thumb_func 0x80a4bb4 KeepPanInRange
 thumb_func 0x80a4bdc CalculatePanIncrement
 thumb_func 0x80a4c1c ScriptCmd_playsewithpan
 thumb_func 0x80a4c54 ScriptCmd_setpan
 thumb_func 0x80a4c80 ScriptCmd_panse_1B
-thumb_func 0x80a4d40
+thumb_func 0x80a4d40 Task_PanFromInitialToTarget
 thumb_func 0x80a4dd0 ScriptCmd_panse_26
 thumb_func 0x80a4e64 ScriptCmd_panse_27
-thumb_func 0x80a4f24
+thumb_func 0x80a4f24 ScriptCmd_loopsewithpan
 thumb_func 0x80a4fac Task_LoopAndPlaySE
 thumb_func 0x80a5008 ScriptCmd_waitplaysewithpan
 thumb_func 0x80a507c Task_WaitAndPlaySE
-thumb_func 0x80a50c0
-thumb_func 0x80a5134
-thumb_func 0x80a51b8
-thumb_func 0x80a520c
-thumb_func 0x80a524c
-thumb_func 0x80a52a4
-thumb_func 0x80a52d4
+thumb_func 0x80a50c0 ScriptCmd_createsoundtask
+thumb_func 0x80a5134 ScriptCmd_waitsound
+thumb_func 0x80a51b8 ScriptCmd_jumpargeq
+thumb_func 0x80a520c ScriptCmd_jumpifcontest
+thumb_func 0x80a524c ScriptCmd_monbgprio_28
+thumb_func 0x80a52a4 ScriptCmd_monbgprio_29
+thumb_func 0x80a52d4 ScriptCmd_monbgprio_2A
 thumb_func 0x80a5348 ScriptCmd_invisible
 thumb_func 0x80a5384 ScriptCmd_visible
-thumb_func 0x80a53c4
-thumb_func 0x80a5474
+thumb_func 0x80a53c4 ScriptCmd_doublebattle_2D
+thumb_func 0x80a5474 ScriptCmd_doublebattle_2E
 thumb_func 0x80a550c
-thumb_func 0x80a5534
-thumb_func 0x80a5680
-thumb_func 0x80a5868
+thumb_func 0x80a5534 GetBattlerSpriteCoord
+thumb_func 0x80a5680 GetBattlerYDelta
+thumb_func 0x80a5868 GetBattlerElevation
 thumb_func 0x80a58d4 GetBattlerSpriteFinal_Y
-thumb_func 0x80a5974
+thumb_func 0x80a5974 GetBattlerSpriteCoord2
 thumb_func 0x80a5a00 GetBattlerSpriteDefault_Y
 thumb_func 0x80a5a14 GetSubstituteSpriteDefault_Y
-thumb_func 0x80a5a58
-thumb_func 0x80a5b08
-thumb_func 0x80a5b9c
-thumb_func 0x80a5ba4
-thumb_func 0x80a5bb4
-thumb_func 0x80a5c14
+thumb_func 0x80a5a58 GetBattlerYCoordWithElevation
+thumb_func 0x80a5b08 GetAnimBattlerSpriteId
+thumb_func 0x80a5b9c StoreSpriteCallbackInData6
+thumb_func 0x80a5ba4 SetCallbackToStoredInData6
+thumb_func 0x80a5bb4 TranslateSpriteInCircleOverDuration
+thumb_func 0x80a5c14 TranslateSpriteInGrowingCircleOverDuration
 thumb_func 0x80a5c90
-thumb_func 0x80a5d18
+thumb_func 0x80a5d18 TranslateSpriteInEllipseOverDuration
 thumb_func 0x80a5d78 WaitAnimForDuration
 thumb_func 0x80a5d98
 thumb_func 0x80a5db4
 thumb_func 0x80a5e04 TranslateSpriteLinear
 thumb_func 0x80a5e34 TranslateSpriteLinearFixedPoint
-thumb_func 0x80a5e70
+thumb_func 0x80a5e70 TranslateSpriteLinearFixedPointIconFrame
 thumb_func 0x80a5eb4
-thumb_func 0x80a5ef8
-thumb_func 0x80a5f48
-thumb_func 0x80a5fa4
-thumb_func 0x80a6014
+thumb_func 0x80a5ef8 TranslateMonSpriteLinear
+thumb_func 0x80a5f48 TranslateMonSpriteLinearFixedPoint
+thumb_func 0x80a5fa4 TranslateSpriteLinearAndFlicker
+thumb_func 0x80a6014 DestroySpriteAndMatrix
 thumb_func 0x80a6028
 thumb_func 0x80a606c
 thumb_func 0x80a6084 RunStoredCallbackWhenAffineAnimEnds
 thumb_func 0x80a60a0 RunStoredCallbackWhenAnimEnds
 thumb_func 0x80a60bc
-thumb_func 0x80a60dc
+thumb_func 0x80a60dc DestroyAnimVisualTaskAndDisableBlend
 thumb_func 0x80a6100 SetSpriteCoordsToAnimAttackerCoords
-thumb_func 0x80a612c
-thumb_func 0x80a619c
-thumb_func 0x80a61c8
-thumb_func 0x80a61fc
+thumb_func 0x80a612c SetAnimSpriteInitialXOffset
+thumb_func 0x80a619c InitAnimArcTranslation
+thumb_func 0x80a61c8 TranslateAnimHorizontalArc
+thumb_func 0x80a61fc TranslateAnimVerticalArc
 thumb_func 0x80a6230 SetSpritePrimaryCoordsFromSecondaryCoords
 thumb_func 0x80a6248 InitSpritePosToAnimTarget
-thumb_func 0x80a6294
-thumb_func 0x80a62f8
+thumb_func 0x80a6294 InitSpritePosToAnimAttacker
+thumb_func 0x80a62f8 GetBattlerSide
 thumb_func 0x80a630c
 thumb_func 0x80a631c GetBattlerAtPosition
-thumb_func 0x80a6358
-thumb_func 0x80a63e8
+thumb_func 0x80a6358 IsBattlerSpritePresent
+thumb_func 0x80a63e8 IsDoubleBattle
 thumb_func 0x80a63f8
 thumb_func 0x80a6458
 thumb_func 0x80a64c4
 thumb_func 0x80a6530
-thumb_func 0x80a6588
-thumb_func 0x80a65d8
-thumb_func 0x80a6610
+thumb_func 0x80a6588 AnimLoadCompressedBgGfx
+thumb_func 0x80a65d8 InitAnimBgTilemapBuffer
+thumb_func 0x80a6610 AnimLoadCompressedBgTilemap
 thumb_func 0x80a6628
 thumb_func 0x80a665c
 thumb_func 0x80a6674
 thumb_func 0x80a66b4
-thumb_func 0x80a66dc
-thumb_func 0x80a671c
+thumb_func 0x80a66dc InitSpriteDataForLinearTranslation
+thumb_func 0x80a671c InitAnimLinearTranslation
 thumb_func 0x80a67b4
 thumb_func 0x80a67dc
 thumb_func 0x80a6804 AnimTranslateLinear
@@ -5580,57 +5580,57 @@ thumb_func 0x80a6860
 thumb_func 0x80a687c
 thumb_func 0x80a689c
 thumb_func 0x80a68c8
-thumb_func 0x80a68f0
+thumb_func 0x80a68f0 InitAnimFastLinearTranslation
 thumb_func 0x80a6988
 thumb_func 0x80a69b0 AnimFastTranslateLinear
 thumb_func 0x80a6a0c
-thumb_func 0x80a6a28
+thumb_func 0x80a6a28 InitAnimFastLinearTranslationWithSpeed
 thumb_func 0x80a6a54
-thumb_func 0x80a6a7c
+thumb_func 0x80a6a7c SetSpriteRotScale
 thumb_func 0x80a6b00
-thumb_func 0x80a6b38
-thumb_func 0x80a6c0c
+thumb_func 0x80a6b38 PrepareBattlerSpriteForRotScale
+thumb_func 0x80a6c0c ResetSpriteRotScale
 thumb_func 0x80a6c68 SetBattlerSpriteYOffsetFromRotation
-thumb_func 0x80a6ca8
+thumb_func 0x80a6ca8 TrySetSpriteRotScale
 thumb_func 0x80a6d64
-thumb_func 0x80a6da4
+thumb_func 0x80a6da4 ArcTan2_
 thumb_func 0x80a6dbc ArcTan2Neg
-thumb_func 0x80a6dd4
+thumb_func 0x80a6dd4 SetGreyscaleOrOriginalPalette
 thumb_func 0x80a6e74
 thumb_func 0x80a6f8c
 thumb_func 0x80a7074
-thumb_func 0x80a707c
+thumb_func 0x80a707c GetBattlerAtPosition_
 thumb_func 0x80a7090
 thumb_func 0x80a70e8 TranslateAnimSpriteToTargetMonLocation
 thumb_func 0x80a7174
 thumb_func 0x80a71e4
 thumb_func 0x80a7200
-thumb_func 0x80a72b0
-thumb_func 0x80a7324
+thumb_func 0x80a72b0 CloneBattlerSpriteWithBlend
+thumb_func 0x80a7324 obj_delete_but_dont_free_vram
 thumb_func 0x80a733c
 thumb_func 0x80a73c4
-thumb_func 0x80a7460
+thumb_func 0x80a7460 AnimTask_BlendMonInAndOut
 thumb_func 0x80a74bc AnimTask_BlendMonInAndOutSetup
-thumb_func 0x80a74e4
+thumb_func 0x80a74e4 AnimTask_BlendMonInAndOutStep
 thumb_func 0x80a757c
 thumb_func 0x80a75c4 PrepareAffineAnimInTaskData
-thumb_func 0x80a75fc
-thumb_func 0x80a7734
-thumb_func 0x80a7788
-thumb_func 0x80a77e0
-thumb_func 0x80a7910
-thumb_func 0x80a7918
+thumb_func 0x80a75fc RunAffineAnimFromTaskData
+thumb_func 0x80a7734 SetBattlerSpriteYOffsetFromYScale
+thumb_func 0x80a7788 SetBattlerSpriteYOffsetFromOtherYScale
+thumb_func 0x80a77e0 GetBattlerYDeltaFromSpriteId
+thumb_func 0x80a7910 StorePointerInVars
+thumb_func 0x80a7918 LoadPointerFromVars
 thumb_func 0x80a7924
 thumb_func 0x80a7990
 thumb_func 0x80a7a08 AnimTask_GetFrustrationPowerLevel
 thumb_func 0x80a7a3c
 thumb_func 0x80a7b40
 thumb_func 0x80a7bac GetBattlerSpriteSubpriority
-thumb_func 0x80a7bf0
+thumb_func 0x80a7bf0 GetBattlerSpriteBGPriority
 thumb_func 0x80a7c2c GetBattlerSpriteBGPriorityRank
 thumb_func 0x80a7c5c
-thumb_func 0x80a7ed8
-thumb_func 0x80a7ee4
+thumb_func 0x80a7ed8 DestroySpriteAndFreeResources_
+thumb_func 0x80a7ee4 GetBattlerSpriteCoordAttr
 thumb_func 0x80a81ec SetAverageBattlerPositions
 thumb_func 0x80a8290
 thumb_func 0x80a8334
@@ -5643,27 +5643,27 @@ thumb_func 0x80a86c4
 thumb_func 0x80a86f8
 thumb_func 0x80a8750
 thumb_func 0x80a87ac
-thumb_func 0x80a8818
-thumb_func 0x80a8878
-thumb_func 0x80a88cc
-thumb_func 0x80a8964
-thumb_func 0x80a89d4
+thumb_func 0x80a8818 ResetTasks
+thumb_func 0x80a8878 CreateTask
+thumb_func 0x80a88cc InsertTask
+thumb_func 0x80a8964 DestroyTask
+thumb_func 0x80a89d4 RunTasks
 thumb_func 0x80a8a04 FindFirstActiveTask
 thumb_func 0x80a8a40 nullsub_50
 thumb_func 0x80a8a44 SetTaskFuncWithFollowupFunc
 thumb_func 0x80a8a78 SwitchTaskToFollowupFunc
-thumb_func 0x80a8aac
-thumb_func 0x80a8ae4
+thumb_func 0x80a8aac FuncIsActiveTask
+thumb_func 0x80a8ae4 FindTaskIdByFunc
 thumb_func 0x80a8b14 GetTaskCount
 thumb_func 0x80a8b44 SetWordTaskArg
 thumb_func 0x80a8b7c GetWordTaskArg
 thumb_func 0x80a8bbc nullsub_10
-thumb_func 0x80a8bc0
-thumb_func 0x80a8c04
+thumb_func 0x80a8bc0 ReshowBattleScreenAfterMenu
+thumb_func 0x80a8c04 CB2_ReshowBattleScreenAfterMenu
 thumb_func 0x80a8ebc
-thumb_func 0x80a8edc
-thumb_func 0x80a8fd0
-thumb_func 0x80a93a4
+thumb_func 0x80a8edc LoadBattlerSpriteGfx
+thumb_func 0x80a8fd0 CreateBattlerSprite
+thumb_func 0x80a93a4 CreateHealthboxSprite
 thumb_func 0x80a9538
 thumb_func 0x80a967c
 thumb_func 0x80a970c
@@ -5673,224 +5673,224 @@ thumb_func 0x80a9898
 thumb_func 0x80a98e8
 thumb_func 0x80a9998
 thumb_func 0x80a99ec
-thumb_func 0x80a9a54
+thumb_func 0x80a9a54 AnimTask_StatsChange
 thumb_func 0x80a9c2c LaunchStatusAnimation
 thumb_func 0x80a9c7c
 thumb_func 0x80a9c8c
-thumb_func 0x80a9cd4
-thumb_func 0x80a9d3c
+thumb_func 0x80a9cd4 SpriteCB_VersionBannerLeft
+thumb_func 0x80a9d3c SpriteCB_VersionBannerRight
 thumb_func 0x80a9d7c SpriteCB_PressStartCopyrightBanner
-thumb_func 0x80a9db4
-thumb_func 0x80a9e10
-thumb_func 0x80a9e6c
-thumb_func 0x80a9f1c
-thumb_func 0x80a9f44
-thumb_func 0x80aa048
+thumb_func 0x80a9db4 CreatePressStartBanner
+thumb_func 0x80a9e10 CreateCopyrightBanner
+thumb_func 0x80a9e6c SpriteCB_PokemonLogoShine
+thumb_func 0x80a9f1c SpriteCB_PokemonLogoShine2
+thumb_func 0x80a9f44 StartPokemonLogoShine
+thumb_func 0x80aa048 StopCryAndClearCrySongs
 thumb_func 0x80aa06c
 thumb_func 0x80aa400
 thumb_func 0x80aa418
-thumb_func 0x80aa528
-thumb_func 0x80aa650
+thumb_func 0x80aa528 Task_TitleScreenPhase2
+thumb_func 0x80aa650 Task_TitleScreenPhase3
 thumb_func 0x80aa7b4
 thumb_func 0x80aa7d0
 thumb_func 0x80aa7ec
 thumb_func 0x80aa808
-thumb_func 0x80aa824
-thumb_func 0x80aa844
-thumb_func 0x80aa8a0
-thumb_func 0x80aa994
+thumb_func 0x80aa824 CB2_GoToBerryFixScreen
+thumb_func 0x80aa844 UsePokeblockOnField
+thumb_func 0x80aa8a0 StartWeather
+thumb_func 0x80aa994 SetNextWeather
 thumb_func 0x80aaa00 SetCurrentAndNextWeather
 thumb_func 0x80aaa2c SetCurrentAndNextWeatherNoDelay
-thumb_func 0x80aaa5c
-thumb_func 0x80aaaac
+thumb_func 0x80aaa5c Task_WeatherInit
+thumb_func 0x80aaaac Task_WeatherMain
 thumb_func 0x80aab4c
-thumb_func 0x80aab68
+thumb_func 0x80aab68 None_Init
 thumb_func 0x80aab88 nullsub_53
 thumb_func 0x80aab8c
-thumb_func 0x80aab90
-thumb_func 0x80aaca4
-thumb_func 0x80aad30
-thumb_func 0x80aae48
-thumb_func 0x80aaea8
-thumb_func 0x80aaf00
+thumb_func 0x80aab90 BuildGammaShiftTables
+thumb_func 0x80aaca4 UpdateWeatherGammaShift
+thumb_func 0x80aad30 FadeInScreenWithWeather
+thumb_func 0x80aae48 FadeInScreen_RainShowShade
+thumb_func 0x80aaea8 FadeInScreen_Drought
+thumb_func 0x80aaf00 FadeInScreen_Fog1
 thumb_func 0x80aaf3c nullsub_19
-thumb_func 0x80aaf40
-thumb_func 0x80ab144
-thumb_func 0x80ab28c
-thumb_func 0x80ab3ac
+thumb_func 0x80aaf40 ApplyGammaShift
+thumb_func 0x80ab144 ApplyGammaShiftWithBlend
+thumb_func 0x80ab28c ApplyDroughtGammaShiftWithBlend
+thumb_func 0x80ab3ac ApplyFogBlend
 thumb_func 0x80ab4c8 MarkFogSpritePalToLighten
-thumb_func 0x80ab4fc
+thumb_func 0x80ab4fc LightenSpritePaletteInFog
 thumb_func 0x80ab544
 thumb_func 0x80ab578
-thumb_func 0x80ab5cc
+thumb_func 0x80ab5cc FadeScreen
 thumb_func 0x80ab6f8 IsWeatherNotFadingIn
-thumb_func 0x80ab714
+thumb_func 0x80ab714 UpdateSpritePaletteWithWeather
 thumb_func 0x80ab7fc ApplyWeatherGammaShiftToPal
 thumb_func 0x80ab81c
-thumb_func 0x80ab848
-thumb_func 0x80ab878
-thumb_func 0x80ab880
-thumb_func 0x80ab8a0
+thumb_func 0x80ab848 LoadCustomWeatherSpritePalette
+thumb_func 0x80ab878 LoadDroughtWeatherPalette
+thumb_func 0x80ab880 ResetDroughtWeatherPaletteLoading
+thumb_func 0x80ab8a0 LoadDroughtWeatherPalettes
 thumb_func 0x80ab8dc
 thumb_func 0x80ab8ec
 thumb_func 0x80ab918
-thumb_func 0x80aba20
+thumb_func 0x80aba20 Weather_SetBlendCoeffs
 thumb_func 0x80aba60 Weather_SetTargetBlendCoeffs
-thumb_func 0x80abaa4
+thumb_func 0x80abaa4 Weather_UpdateBlend
 thumb_func 0x80abb70
-thumb_func 0x80abc08
+thumb_func 0x80abc08 GetCurrentWeather
 thumb_func 0x80abc18
-thumb_func 0x80abc74
+thumb_func 0x80abc74 PlayRainStoppingSoundEffect
 thumb_func 0x80abcb8
 thumb_func 0x80abccc
 thumb_func 0x80abce0
-thumb_func 0x80abcf4
+thumb_func 0x80abcf4 PreservePaletteInWeather
 thumb_func 0x80abd24
 thumb_func 0x80abd34 Clouds_InitVars
 thumb_func 0x80abd80 Clouds_InitAll
-thumb_func 0x80abdb0
-thumb_func 0x80abe10
+thumb_func 0x80abdb0 Clouds_Main
+thumb_func 0x80abe10 Clouds_Finish
 thumb_func 0x80abe58 Sunny_InitVars
-thumb_func 0x80abe7c
+thumb_func 0x80abe7c Sunny_InitAll
 thumb_func 0x80abe88 nullsub_541
 thumb_func 0x80abe8c
-thumb_func 0x80abe90
-thumb_func 0x80abf5c
+thumb_func 0x80abe90 CreateCloudSprites
+thumb_func 0x80abf5c DestroyCloudSprites
 thumb_func 0x80abfb0 UpdateCloudSprite
 thumb_func 0x80abfcc Drought_InitVars
 thumb_func 0x80ac000 Drought_InitAll
-thumb_func 0x80ac030
+thumb_func 0x80ac030 Drought_Main
 thumb_func 0x80ac114
-thumb_func 0x80ac118
-thumb_func 0x80ac12c
+thumb_func 0x80ac118 StartDroughtWeatherBlend
+thumb_func 0x80ac12c UpdateDroughtBlend
 thumb_func 0x80ac224 LightRain_InitVars
 thumb_func 0x80ac290
-thumb_func 0x80ac2c0
-thumb_func 0x80ac320
-thumb_func 0x80ac3ac
-thumb_func 0x80ac480
-thumb_func 0x80ac584
-thumb_func 0x80ac5b0
+thumb_func 0x80ac2c0 LightRain_Main
+thumb_func 0x80ac320 LightRain_Finish
+thumb_func 0x80ac3ac StartRainSpriteFall
+thumb_func 0x80ac480 UpdateRainSprite
+thumb_func 0x80ac584 WaitRainSprite
+thumb_func 0x80ac5b0 InitRainSpriteMovement
 thumb_func 0x80ac664
-thumb_func 0x80ac674
-thumb_func 0x80ac7a8
-thumb_func 0x80ac834
+thumb_func 0x80ac674 CreateRainSprite
+thumb_func 0x80ac7a8 UpdateVisibleRainSprites
+thumb_func 0x80ac834 DestroyRainSprites
 thumb_func 0x80ac888 Snow_InitVars
 thumb_func 0x80ac8d8 Snow_InitAll
 thumb_func 0x80ac944 Snow_Main
-thumb_func 0x80ac980
-thumb_func 0x80ac9e4
-thumb_func 0x80aca60
-thumb_func 0x80acacc
-thumb_func 0x80acb00
+thumb_func 0x80ac980 Snow_Finish
+thumb_func 0x80ac9e4 UpdateVisibleSnowflakeSprites
+thumb_func 0x80aca60 CreateSnowflakeSprite
+thumb_func 0x80acacc DestroySnowflakeSprite
+thumb_func 0x80acb00 InitSnowflakeSpriteMovement
 thumb_func 0x80acbac WaitSnowflakeSprite
-thumb_func 0x80acc08
+thumb_func 0x80acc08 UpdateSnowflakeSprite
 thumb_func 0x80acd40 MedRain_InitVars
 thumb_func 0x80acdb4 MedRain_InitAll
 thumb_func 0x80acde4 HeavyRain_InitVars
 thumb_func 0x80ace50
 thumb_func 0x80ace80
-thumb_func 0x80ad20c
-thumb_func 0x80ad2b8
-thumb_func 0x80ad2f4
+thumb_func 0x80ad20c Rain_Finish
+thumb_func 0x80ad2b8 SetThunderCounter
+thumb_func 0x80ad2f4 UpdateThunderSound
 thumb_func 0x80ad35c Fog1_InitVars
 thumb_func 0x80ad3bc Fog1_InitAll
-thumb_func 0x80ad3ec
-thumb_func 0x80ad4ac
+thumb_func 0x80ad3ec Fog1_Main
+thumb_func 0x80ad4ac Fog1_Finish
 thumb_func 0x80ad548 Fog1SpriteCallback
-thumb_func 0x80ad5a8
+thumb_func 0x80ad5a8 CreateFog1Sprites
 thumb_func 0x80ad664
-thumb_func 0x80ad6b8
+thumb_func 0x80ad6b8 Ash_InitVars
 thumb_func 0x80ad714 Ash_InitAll
-thumb_func 0x80ad744
-thumb_func 0x80ad7f0
-thumb_func 0x80ad858
-thumb_func 0x80ad868
-thumb_func 0x80ad910
+thumb_func 0x80ad744 Ash_Main
+thumb_func 0x80ad7f0 Ash_Finish
+thumb_func 0x80ad858 LoadAshSpriteSheet
+thumb_func 0x80ad868 CreateAshSprites
+thumb_func 0x80ad910 DestroyAshSprites
 thumb_func 0x80ad964 UpdateAshSprite
 thumb_func 0x80ad9e0 Fog2_InitVars
 thumb_func 0x80ada64 Fog2_InitAll
-thumb_func 0x80ada94
-thumb_func 0x80adaf8
+thumb_func 0x80ada94 Fog2_Main
+thumb_func 0x80adaf8 Fog2_Finish
 thumb_func 0x80adb58 UpdateFog2Movement
-thumb_func 0x80adbec
-thumb_func 0x80adca4
+thumb_func 0x80adbec CreateFog2Sprites
+thumb_func 0x80adca4 DestroyFog2Sprites
 thumb_func 0x80adcf8 UpdateFog2Sprite
 thumb_func 0x80add58 Sandstorm_InitVars
 thumb_func 0x80addd8 Sandstorm_InitAll
-thumb_func 0x80ade08
-thumb_func 0x80ade84
+thumb_func 0x80ade08 Sandstorm_Main
+thumb_func 0x80ade84 Sandstorm_Finish
 thumb_func 0x80adee8 UpdateSandstormWaveIndex
 thumb_func 0x80adf20 UpdateSandstormMovement
-thumb_func 0x80adfa0
-thumb_func 0x80ae034
-thumb_func 0x80ae0f4
+thumb_func 0x80adfa0 DestroySandstormSprites
+thumb_func 0x80ae034 CreateSandstormSprites
+thumb_func 0x80ae0f4 CreateSwirlSandstormSprites
 thumb_func 0x80ae1f4 UpdateSandstormSprite
 thumb_func 0x80ae254 WaitSandSwirlSpriteEntrance
 thumb_func 0x80ae278 UpdateSandstormSwirlSprite
 thumb_func 0x80ae2ec Shade_InitVars
-thumb_func 0x80ae31c
+thumb_func 0x80ae31c Shade_InitAll
 thumb_func 0x80ae328 nullsub_55
 thumb_func 0x80ae32c
-thumb_func 0x80ae330
+thumb_func 0x80ae330 Bubbles_InitVars
 thumb_func 0x80ae384 Bubbles_InitAll
 thumb_func 0x80ae3b4 Bubbles_Main
 thumb_func 0x80ae428 Bubbles_Finish
-thumb_func 0x80ae444
-thumb_func 0x80ae4cc
-thumb_func 0x80ae530
-thumb_func 0x80ae590
-thumb_func 0x80ae5a4
-thumb_func 0x80ae624
+thumb_func 0x80ae444 CreateBubbleSprite
+thumb_func 0x80ae4cc DestroyBubbleSprites
+thumb_func 0x80ae530 UpdateBubbleSprite
+thumb_func 0x80ae590 UnusedSetCurrentAlternatingWeather
+thumb_func 0x80ae5a4 Task_DoAlternatingWeather
+thumb_func 0x80ae624 CreateAlternatingWeatherTask
 thumb_func 0x80ae678 SetSav1Weather
-thumb_func 0x80ae6a8
+thumb_func 0x80ae6a8 GetSav1Weather
 thumb_func 0x80ae6b8 SetSav1WeatherFromCurrMapHeader
 thumb_func 0x80ae6ec SetWeather
 thumb_func 0x80ae704 SetWeather_Unused
-thumb_func 0x80ae71c
-thumb_func 0x80ae780
-thumb_func 0x80ae7e4
+thumb_func 0x80ae71c DoCurrentWeather
+thumb_func 0x80ae780 ResumePausedWeather
+thumb_func 0x80ae7e4 TranslateWeatherNum
 thumb_func 0x80ae8b8 UpdateWeatherPerDay
-thumb_func 0x80ae8d8
-thumb_func 0x80ae8f8
+thumb_func 0x80ae8d8 UpdateRainCounter
+thumb_func 0x80ae8f8 palette_bg_faded_fill_white
 thumb_func 0x80ae91c
-thumb_func 0x80ae93c
+thumb_func 0x80ae93c pal_fill_for_maplights
 thumb_func 0x80ae988
-thumb_func 0x80ae99c
-thumb_func 0x80ae9b0
+thumb_func 0x80ae99c pal_fill_black
+thumb_func 0x80ae9b0 WarpFadeScreen
 thumb_func 0x80ae9f0
-thumb_func 0x80aea08
+thumb_func 0x80aea08 task0A_nop_for_a_while
 thumb_func 0x80aea24
-thumb_func 0x80aea44
-thumb_func 0x80aea64
+thumb_func 0x80aea44 task0A_asap_script_env_2_enable_and_set_ctx_running
+thumb_func 0x80aea64 FieldCallback_ReturnToEventScript2
 thumb_func 0x80aea84
-thumb_func 0x80aeaa0
+thumb_func 0x80aeaa0 task_mpl_807DD60
 thumb_func 0x80aeb10
 thumb_func 0x80aeb30
 thumb_func 0x80aebb0
 thumb_func 0x80aec10
 thumb_func 0x80aec30
-thumb_func 0x80aec94
+thumb_func 0x80aec94 mapldr_default
 thumb_func 0x80aecac
 thumb_func 0x80aecc4
 thumb_func 0x80aece4
 thumb_func 0x80aed08
 thumb_func 0x80aed34
-thumb_func 0x80aee4c
-thumb_func 0x80aef0c
+thumb_func 0x80aee4c task_map_chg_seq_0807E20C
+thumb_func 0x80aef0c task_map_chg_seq_0807E2CC
 thumb_func 0x80aef5c
 thumb_func 0x80aef84
 thumb_func 0x80aefa0
-thumb_func 0x80aefac
+thumb_func 0x80aefac task_mpl_807E3C8
 thumb_func 0x80aefd0
 thumb_func 0x80aefec
 thumb_func 0x80af00c
 thumb_func 0x80af018 WaitForWeatherFadeIn
-thumb_func 0x80af030
-thumb_func 0x80af068
-thumb_func 0x80af098
-thumb_func 0x80af0cc
-thumb_func 0x80af0f0
+thumb_func 0x80af030 DoWarp
+thumb_func 0x80af068 DoDiveWarp
+thumb_func 0x80af098 ScrCmd_pokemartdecoration2
+thumb_func 0x80af0cc DoDoorWarp
+thumb_func 0x80af0f0 DoFallWarp
 thumb_func 0x80af108
 thumb_func 0x80af124
 thumb_func 0x80af134
@@ -5899,26 +5899,26 @@ thumb_func 0x80af178
 thumb_func 0x80af1b4
 thumb_func 0x80af1dc
 thumb_func 0x80af244
-thumb_func 0x80af268
+thumb_func 0x80af268 Task_ReturnToWorldFromLinkRoom
 thumb_func 0x80af2f4
 thumb_func 0x80af308
 thumb_func 0x80af384
-thumb_func 0x80af4f0
+thumb_func 0x80af4f0 task0A_fade_n_map_maybe
 thumb_func 0x80af55c
 thumb_func 0x80af594 SetFlashScanlineEffectWindowBoundary
 thumb_func 0x80af5c0
 thumb_func 0x80af64c SetFlash2ScanlineEffectWindowBoundary
 thumb_func 0x80af678
-thumb_func 0x80af704
-thumb_func 0x80af7c8
+thumb_func 0x80af704 UpdateFlashLevelEffect
+thumb_func 0x80af7c8 UpdateFlash2LevelEffect
 thumb_func 0x80af88c
 thumb_func 0x80af8b4
 thumb_func 0x80af8d8
 thumb_func 0x80af938
 thumb_func 0x80af998
-thumb_func 0x80af9e4
-thumb_func 0x80afa20
-thumb_func 0x80afa5c
+thumb_func 0x80af9e4 WriteFlashScanlineEffectBuffer
+thumb_func 0x80afa20 WriteBattlePyramidViewScanlineEffectBuffer
+thumb_func 0x80afa5c task0A_mpl_807E31C
 thumb_func 0x80afab8
 thumb_func 0x80afb40
 thumb_func 0x80afb64
@@ -5928,105 +5928,105 @@ thumb_func 0x80afc14
 thumb_func 0x80afe30
 thumb_func 0x80afe88
 thumb_func 0x80afeb0
-thumb_func 0x80afec8
-thumb_func 0x80afeec
-thumb_func 0x80aff58
-thumb_func 0x80aff94
-thumb_func 0x80affac
-thumb_func 0x80affb8
-thumb_func 0x80b0028
-thumb_func 0x80b0078
+thumb_func 0x80afec8 task50_0807F0C8
+thumb_func 0x80afeec Task_BattleStart
+thumb_func 0x80aff58 CreateBattleStartTask
+thumb_func 0x80aff94 BattleSetup_StartWildBattle
+thumb_func 0x80affac BattleSetup_StartBattlePikeWildBattle
+thumb_func 0x80affb8 DoStandardWildBattle
+thumb_func 0x80b0028 BattleSetup_StartRoamerBattle
+thumb_func 0x80b0078 DoSafariBattle
 thumb_func 0x80b00b0
-thumb_func 0x80b0100
+thumb_func 0x80b0100 DoTrainerBattle
 thumb_func 0x80b0124
-thumb_func 0x80b0168
-thumb_func 0x80b01a4
-thumb_func 0x80b01e8
-thumb_func 0x80b0230
-thumb_func 0x80b0314
-thumb_func 0x80b0370
-thumb_func 0x80b03f4
-thumb_func 0x80b0468
+thumb_func 0x80b0168 StartWallyTutorialBattle
+thumb_func 0x80b01a4 BattleSetup_StartScriptedWildBattle
+thumb_func 0x80b01e8 BattleSetup_StartLatiBattle
+thumb_func 0x80b0230 BattleSetup_StartLegendaryBattle
+thumb_func 0x80b0314 StartGroudonKyogreBattle
+thumb_func 0x80b0370 StartRegiBattle
+thumb_func 0x80b03f4 CB2_EndWildBattle
+thumb_func 0x80b0468 CB2_EndScriptedWildBattle
 thumb_func 0x80b04cc
-thumb_func 0x80b0620
-thumb_func 0x80b0684
+thumb_func 0x80b0620 GetBattleTransitionTypeByMap
+thumb_func 0x80b0684 GetSumOfPlayerPartyLevel
 thumb_func 0x80b06e4
-thumb_func 0x80b07b8
+thumb_func 0x80b07b8 GetWildBattleTransition
 thumb_func 0x80b0824
 thumb_func 0x80b08f8
-thumb_func 0x80b0a24
-thumb_func 0x80b0a44
-thumb_func 0x80b0a94
-thumb_func 0x80b0af0
+thumb_func 0x80b0a24 ChooseStarter
+thumb_func 0x80b0a44 CB2_GiveStarter
+thumb_func 0x80b0a94 CB2_StartFirstBattle
+thumb_func 0x80b0af0 CB2_EndFirstBattle
 thumb_func 0x80b0b04
 thumb_func 0x80b0b20
 thumb_func 0x80b0b3c TrainerBattleLoadArg32
-thumb_func 0x80b0b54
+thumb_func 0x80b0b54 TrainerBattleLoadArg16
 thumb_func 0x80b0b60
 thumb_func 0x80b0b64
 thumb_func 0x80b0b7c
-thumb_func 0x80b0b94
-thumb_func 0x80b0bd4
-thumb_func 0x80b0be8
-thumb_func 0x80b0c5c
-thumb_func 0x80b0ce4
-thumb_func 0x80b0d1c
-thumb_func 0x80b0f18
+thumb_func 0x80b0b94 IsPlayerDefeated
+thumb_func 0x80b0bd4 ResetTrainerOpponentIds
+thumb_func 0x80b0be8 InitTrainerBattleVariables
+thumb_func 0x80b0c5c TrainerBattleLoadArgs
+thumb_func 0x80b0ce4 SetMapVarsToTrainer
+thumb_func 0x80b0d1c BattleSetup_ConfigureTrainerBattle
+thumb_func 0x80b0f18 ConfigureAndSetUpOneTrainerBattle
 thumb_func 0x80b0f5c ConfigureTwoTrainersBattle
-thumb_func 0x80b0f90
-thumb_func 0x80b0fa4
-thumb_func 0x80b0fc4
+thumb_func 0x80b0f90 SetUpTwoTrainersBattle
+thumb_func 0x80b0fa4 GetTrainerFlagFromScriptPointer
+thumb_func 0x80b0fc4 SetUpTrainerMovement
 thumb_func 0x80b0ff8
-thumb_func 0x80b1004
-thumb_func 0x80b104c
-thumb_func 0x80b1078
-thumb_func 0x80b108c
+thumb_func 0x80b1004 GetTrainerFlag
+thumb_func 0x80b104c SetBattledTrainersFlags
+thumb_func 0x80b1078 SetBattledTrainerFlag
+thumb_func 0x80b108c HasTrainerBeenFought
 thumb_func 0x80b10a4
 thumb_func 0x80b10b8 SetTrainerFlag
-thumb_func 0x80b10cc
-thumb_func 0x80b1204
-thumb_func 0x80b1280
-thumb_func 0x80b12d8
-thumb_func 0x80b1300
-thumb_func 0x80b13e4
-thumb_func 0x80b13fc
-thumb_func 0x80b144c
-thumb_func 0x80b145c
-thumb_func 0x80b1558
-thumb_func 0x80b1568
-thumb_func 0x80b1590
-thumb_func 0x80b15cc
-thumb_func 0x80b15f0
-thumb_func 0x80b1604
+thumb_func 0x80b10cc BattleSetup_StartTrainerBattle
+thumb_func 0x80b1204 CB2_EndTrainerBattle
+thumb_func 0x80b1280 CB2_EndRematchBattle
+thumb_func 0x80b12d8 BattleSetup_StartRematchBattle
+thumb_func 0x80b1300 ShowTrainerIntroSpeech
+thumb_func 0x80b13e4 BattleSetup_GetScriptAddrAfterBattle
+thumb_func 0x80b13fc BattleSetup_GetTrainerPostBattleScript
+thumb_func 0x80b144c ShowTrainerCantBattleSpeech
+thumb_func 0x80b145c SetUpTrainerEncounterMusic
+thumb_func 0x80b1558 ReturnEmptyStringIfNull
+thumb_func 0x80b1568 GetIntroSpeechOfApproachingTrainer
+thumb_func 0x80b1590 GetTrainerALoseText
+thumb_func 0x80b15cc GetTrainerBLoseText
+thumb_func 0x80b15f0 GetTrainerWonSpeech
+thumb_func 0x80b1604 GetTrainerCantBattleSpeech
 thumb_func 0x80b1618 FirstBattleTrainerIdToRematchTableId
 thumb_func 0x80b163c TrainerIdToRematchTableId
 thumb_func 0x80b1680
 thumb_func 0x80b16a8 SetRematchIdForTrainer
-thumb_func 0x80b16e8
+thumb_func 0x80b16e8 UpdateRandomTrainerRematches
 thumb_func 0x80b1780 UpdateRematchIfDefeated
-thumb_func 0x80b17ac
+thumb_func 0x80b17ac DoesSomeoneWantRematchIn_
 thumb_func 0x80b17f4 IsRematchTrainerIn_
-thumb_func 0x80b1824
-thumb_func 0x80b1860
+thumb_func 0x80b1824 IsFirstTrainerIdReadyForRematch
+thumb_func 0x80b1860 IsTrainerReadyForRematch_
 thumb_func 0x80b189c GetRematchTrainerIdFromTable
 thumb_func 0x80b18f0 GetLastBeatenRematchTrainerIdFromTable
 thumb_func 0x80b1948 ClearTrainerWantRematchState
-thumb_func 0x80b1978
-thumb_func 0x80b19a8
+thumb_func 0x80b1978 GetTrainerMatchCallFlag
+thumb_func 0x80b19a8 RegisterTrainerInMatchCall
 thumb_func 0x80b19e0 WasSecondRematchWon
-thumb_func 0x80b1a14
-thumb_func 0x80b1a48
-thumb_func 0x80b1a74
+thumb_func 0x80b1a14 HasAtLeastFiveBadges
+thumb_func 0x80b1a48 IncrementRematchStepCounter
+thumb_func 0x80b1a74 IsRematchStepCounterMaxed
 thumb_func 0x80b1aa0 TryUpdateRandomTrainerRematches
 thumb_func 0x80b1ae0 DoesSomeoneWantRematchIn
 thumb_func 0x80b1b00 IsRematchTrainerIn
 thumb_func 0x80b1b20 GetRematchTrainerId
 thumb_func 0x80b1b3c GetLastBeatenRematchTrainerId
-thumb_func 0x80b1b58
+thumb_func 0x80b1b58 ShouldTryRematchBattle
 thumb_func 0x80b1b8c IsTrainerReadyForRematch
 thumb_func 0x80b1ba8 HandleRematchVarsOnBattleEnd
-thumb_func 0x80b1bc4
-thumb_func 0x80b1c04
+thumb_func 0x80b1bc4 ShouldTryGetTrainerScript
+thumb_func 0x80b1c04 CountBattledRematchTeams
 thumb_func 0x80b1c58
 thumb_func 0x80b1c9c
 thumb_func 0x80b1cf8
@@ -6066,164 +6066,164 @@ thumb_func 0x80b29cc
 thumb_func 0x80b2a00
 thumb_func 0x80b2a0c
 thumb_func 0x80b2a60
-thumb_func 0x80b2b68
-thumb_func 0x80b2cfc
+thumb_func 0x80b2b68 Task_BagMenu
+thumb_func 0x80b2cfc Cb_PrintCantStoreMail
 thumb_func 0x80b2d68
-thumb_func 0x80b2e48
-thumb_func 0x80b2e78
+thumb_func 0x80b2e48 CleanupLinkRoomState
+thumb_func 0x80b2e78 ExitLinkRoom
 thumb_func 0x80b2e84
 thumb_func 0x80b2f30
 thumb_func 0x80b2f58
 thumb_func 0x80b2ff0
-thumb_func 0x80b3080
+thumb_func 0x80b3080 PlayerEnteredTradeSeat
 thumb_func 0x80b30ac
 thumb_func 0x80b30c0 nullsub_54
-thumb_func 0x80b30c4
+thumb_func 0x80b30c4 ColosseumPlayerSpotTriggered
 thumb_func 0x80b3100
-thumb_func 0x80b3118
-thumb_func 0x80b3130
+thumb_func 0x80b3118 sp02A_crash_sound
+thumb_func 0x80b3130 GetLinkTrainerCardColor
 thumb_func 0x80b3188
 thumb_func 0x80b3204
 thumb_func 0x80b3228
 thumb_func 0x80b3250
 thumb_func 0x80b331c
-thumb_func 0x80b3340
-thumb_func 0x80b3458
-thumb_func 0x80b3548
+thumb_func 0x80b3340 CheckForTrainersWantingBattle
+thumb_func 0x80b3458 CheckTrainer
+thumb_func 0x80b3548 GetTrainerApproachDistance
 thumb_func 0x80b35f8 GetTrainerApproachDistanceSouth
 thumb_func 0x80b363c GetTrainerApproachDistanceNorth
 thumb_func 0x80b3680 GetTrainerApproachDistanceWest
 thumb_func 0x80b36c4 GetTrainerApproachDistanceEast
-thumb_func 0x80b3708
-thumb_func 0x80b37c4
+thumb_func 0x80b3708 CheckPathBetweenTrainerAndPlayer
+thumb_func 0x80b37c4 TrainerApproachPlayer
 thumb_func 0x80b3820
-thumb_func 0x80b3870
+thumb_func 0x80b3870 Task_RunTrainerSeeFuncList
 thumb_func 0x80b38d0
-thumb_func 0x80b38d4
+thumb_func 0x80b38d4 TrainerExclamationMark
 thumb_func 0x80b3918 WaitTrainerExclamationMark
-thumb_func 0x80b3958
-thumb_func 0x80b39b4
-thumb_func 0x80b3a70
+thumb_func 0x80b3958 TrainerMoveToPlayer
+thumb_func 0x80b39b4 PlayerFaceApproachingTrainer
+thumb_func 0x80b3a70 WaitPlayerFaceApproachingTrainer
 thumb_func 0x80b3ab4
-thumb_func 0x80b3ae8
+thumb_func 0x80b3ae8 WaitRevealDisguisedTrainer
 thumb_func 0x80b3b04
-thumb_func 0x80b3b38
-thumb_func 0x80b3b90
+thumb_func 0x80b3b38 PopOutOfAshHiddenTrainer
+thumb_func 0x80b3b90 JumpInPlaceHiddenTrainer
 thumb_func 0x80b3c04 WaitRevealHiddenTrainer
 thumb_func 0x80b3c20
 thumb_func 0x80b3cd0
-thumb_func 0x80b3d04
-thumb_func 0x80b3d14
-thumb_func 0x80b3d28
-thumb_func 0x80b3d78
-thumb_func 0x80b3db0
-thumb_func 0x80b3de8
-thumb_func 0x80b3e30
-thumb_func 0x80b3e7c
-thumb_func 0x80b3f14
-thumb_func 0x80b3f38
+thumb_func 0x80b3d04 EndTrainerApproach
+thumb_func 0x80b3d14 Task_DestroyTrainerApproachTask
+thumb_func 0x80b3d28 TryPrepareSecondApproachingTrainer
+thumb_func 0x80b3d78 FldEff_ExclamationMarkIcon
+thumb_func 0x80b3db0 FldEff_QuestionMarkIcon
+thumb_func 0x80b3de8 FldEff_HeartIcon
+thumb_func 0x80b3e30 SetIconSpriteData
+thumb_func 0x80b3e7c SpriteCB_TrainerIcons
+thumb_func 0x80b3f14 GetCurrentApproachingTrainerEventObjectId
+thumb_func 0x80b3f38 GetChosenApproachingTrainerEventObjectId
 thumb_func 0x80b3f60
 thumb_func 0x80b4010
-thumb_func 0x80b401c
-thumb_func 0x80b40dc
+thumb_func 0x80b401c GetRoute119WaterTileNum
+thumb_func 0x80b40dc CheckFeebas
 thumb_func 0x80b41f0
 thumb_func 0x80b4210
-thumb_func 0x80b4220
-thumb_func 0x80b42dc
-thumb_func 0x80b4330
-thumb_func 0x80b43cc
-thumb_func 0x80b4450
-thumb_func 0x80b44d0
-thumb_func 0x80b45c0
-thumb_func 0x80b46a4
+thumb_func 0x80b4220 ChooseWildMonIndex_Land
+thumb_func 0x80b42dc ChooseWildMonIndex_WaterRock
+thumb_func 0x80b4330 ChooseWildMonIndex_Fishing
+thumb_func 0x80b43cc ChooseWildMonLevel
+thumb_func 0x80b4450 GetCurrentMapWildMonHeaderId
+thumb_func 0x80b44d0 PickWildMonNature
+thumb_func 0x80b45c0 CreateWildMon
+thumb_func 0x80b46a4 TryGenerateWildMon
 thumb_func 0x80b477c GenerateFishingWildMon
-thumb_func 0x80b47b4
-thumb_func 0x80b4834
-thumb_func 0x80b489c
-thumb_func 0x80b48c8
-thumb_func 0x80b4994
-thumb_func 0x80b49b8
-thumb_func 0x80b49e0
-thumb_func 0x80b4c64
-thumb_func 0x80b4cd0
-thumb_func 0x80b4e54
-thumb_func 0x80b4e8c
-thumb_func 0x80b4ef8
-thumb_func 0x80b4f84
-thumb_func 0x80b4fc8
-thumb_func 0x80b5024
-thumb_func 0x80b508c
-thumb_func 0x80b50e8
-thumb_func 0x80b51a8
-thumb_func 0x80b5208
-thumb_func 0x80b5248
-thumb_func 0x80b5270
+thumb_func 0x80b47b4 SetUpMassOutbreakEncounter
+thumb_func 0x80b4834 DoMassOutbreakEncounterTest
+thumb_func 0x80b489c DoWildEncounterRateDiceRoll
+thumb_func 0x80b48c8 DoWildEncounterRateTest
+thumb_func 0x80b4994 DoGlobalWildEncounterDiceRoll
+thumb_func 0x80b49b8 AreLegendariesInSootopolisPreventingEncounters
+thumb_func 0x80b49e0 StandardWildEncounter
+thumb_func 0x80b4c64 RockSmashWildEncounter
+thumb_func 0x80b4cd0 SweetScentWildEncounter
+thumb_func 0x80b4e54 DoesCurrentMapHaveFishingMons
+thumb_func 0x80b4e8c FishingWildEncounter
+thumb_func 0x80b4ef8 GetLocalWildMon
+thumb_func 0x80b4f84 GetLocalWaterMon
+thumb_func 0x80b4fc8 UpdateRepelCounter
+thumb_func 0x80b5024 IsWildLevelAllowedByRepel
+thumb_func 0x80b508c IsAbilityAllowingEncounter
+thumb_func 0x80b50e8 TryGetRandomWildMonIndexByType
+thumb_func 0x80b51a8 TryGetAbilityInfluencedWildMonIndex
+thumb_func 0x80b5208 ApplyFluteEncounterRateMod
+thumb_func 0x80b5248 ApplyCleanseTagEncounterRateMod
+thumb_func 0x80b5270 FieldEffectStart
 thumb_func 0x80b52a0
-thumb_func 0x80b52b8
-thumb_func 0x80b52cc
-thumb_func 0x80b52e0
-thumb_func 0x80b52f4
+thumb_func 0x80b52b8 FieldEffectCmd_loadtiles
+thumb_func 0x80b52cc FieldEffectCmd_loadfadedpal
+thumb_func 0x80b52e0 FieldEffectCmd_loadpal
+thumb_func 0x80b52f4 FieldEffectCmd_callnative
 thumb_func 0x80b5308
 thumb_func 0x80b530c FieldEffectCmd_loadgfx_callnative
 thumb_func 0x80b5334 FieldEffectCmd_loadtiles_callnative
 thumb_func 0x80b5358 FieldEffectCmd_loadfadedpal_callnative
 thumb_func 0x80b537c FieldEffectScript_ReadWord
-thumb_func 0x80b5394
+thumb_func 0x80b5394 FieldEffectScript_LoadTiles
 thumb_func 0x80b53c4
-thumb_func 0x80b53ec
-thumb_func 0x80b5404
+thumb_func 0x80b53ec FieldEffectScript_LoadPalette
+thumb_func 0x80b5404 FieldEffectScript_CallNative
 thumb_func 0x80b5414
-thumb_func 0x80b5420
+thumb_func 0x80b5420 FieldEffectFreeGraphicsResources
 thumb_func 0x80b5444 FieldEffectStop
-thumb_func 0x80b545c
-thumb_func 0x80b54c0
+thumb_func 0x80b545c FieldEffectFreeTilesIfUnused
+thumb_func 0x80b54c0 FieldEffectFreePaletteIfUnused
 thumb_func 0x80b5518 FieldEffectActiveListClear
 thumb_func 0x80b553c FieldEffectActiveListAdd
 thumb_func 0x80b5568 FieldEffectActiveListRemove
 thumb_func 0x80b5598 FieldEffectActiveListContains
-thumb_func 0x80b55c4
-thumb_func 0x80b5664
-thumb_func 0x80b569c
-thumb_func 0x80b56dc
-thumb_func 0x80b5740
-thumb_func 0x80b57c8
+thumb_func 0x80b55c4 CreateTrainerSprite
+thumb_func 0x80b5664 LoadTrainerGfx_TrainerCard
+thumb_func 0x80b569c AddNewGameBirchObject
+thumb_func 0x80b56dc CreateMonSprite_PicBox
+thumb_func 0x80b5740 CreateMonSprite_FieldMove
+thumb_func 0x80b57c8 FreeResourcesAndDestroySprite
 thumb_func 0x80b57f4 MultiplyInvertedPaletteRGBComponents
 thumb_func 0x80b5880 MultiplyPaletteRGBComponents
-thumb_func 0x80b58f8
+thumb_func 0x80b58f8 FldEff_PokecenterHeal
 thumb_func 0x80b593c
 thumb_func 0x80b5960 nullsub_57
 thumb_func 0x80b596c PokecenterHealEffect_0
 thumb_func 0x80b59a8 PokecenterHealEffect_1
 thumb_func 0x80b59e4
 thumb_func 0x80b5a0c
-thumb_func 0x80b5a4c
+thumb_func 0x80b5a4c FldEff_HallOfFameRecord
 thumb_func 0x80b5a88
 thumb_func 0x80b5aac nullsub_58
-thumb_func 0x80b5ab8
+thumb_func 0x80b5ab8 HallOfFameRecordEffect_0
 thumb_func 0x80b5b2c HallOfFameRecordEffect_1
 thumb_func 0x80b5b5c
-thumb_func 0x80b5b84
-thumb_func 0x80b5bc4
+thumb_func 0x80b5b84 HallOfFameRecordEffect_3
+thumb_func 0x80b5bc4 CreatePokeballGlowSprite
 thumb_func 0x80b5c18
-thumb_func 0x80b5c34
-thumb_func 0x80b5ccc
-thumb_func 0x80b5d00
-thumb_func 0x80b5e40
+thumb_func 0x80b5c34 PokeballGlowEffect_0
+thumb_func 0x80b5ccc PokeballGlowEffect_1
+thumb_func 0x80b5d00 PokeballGlowEffect_2
+thumb_func 0x80b5e40 PokeballGlowEffect_3
 thumb_func 0x80b5f34 PokeballGlowEffect_4
-thumb_func 0x80b5f50
-thumb_func 0x80b5f58
+thumb_func 0x80b5f50 PokeballGlowEffect_5
+thumb_func 0x80b5f58 PokeballGlowEffect_6
 thumb_func 0x80b5f7c nullsub_201
 thumb_func 0x80b5f80 SpriteCB_PokeballGlow
-thumb_func 0x80b5fa8
-thumb_func 0x80b6004
-thumb_func 0x80b6044
+thumb_func 0x80b5fa8 PokecenterHealEffectHelper
+thumb_func 0x80b6004 SpriteCB_PokecenterMonitor
+thumb_func 0x80b6044 HallOfFameRecordEffectHelper
 thumb_func 0x80b60c8 SpriteCB_HallOfFameMonitor
 thumb_func 0x80b6134
-thumb_func 0x80b6154
-thumb_func 0x80b617c
-thumb_func 0x80b61fc
-thumb_func 0x80b6264
-thumb_func 0x80b62c0
+thumb_func 0x80b6154 mapldr_080842E8
+thumb_func 0x80b617c task00_8084310
+thumb_func 0x80b61fc mapldr_08084390
+thumb_func 0x80b6264 c3_080843F8
+thumb_func 0x80b62c0 PrintAllVariableNumsOnCardPage2
 thumb_func 0x80b62ec
 thumb_func 0x80b6324
 thumb_func 0x80b63cc
@@ -6243,29 +6243,29 @@ thumb_func 0x80b6700
 thumb_func 0x80b6710
 thumb_func 0x80b675c
 thumb_func 0x80b67a8
-thumb_func 0x80b67b8
+thumb_func 0x80b67b8 CB2_Pokenav
 thumb_func 0x80b680c
 thumb_func 0x80b6834
 thumb_func 0x80b686c
-thumb_func 0x80b68e8
-thumb_func 0x80b6928
+thumb_func 0x80b68e8 MovementAction_AcroEndWheelieMoveLeft_Step0
+thumb_func 0x80b6928 MovementAction_AcroEndWheelieMoveRight_Step0
 thumb_func 0x80b6988
 thumb_func 0x80b69c8
 thumb_func 0x80b6a28
 thumb_func 0x80b6a4c
-thumb_func 0x80b6aa4
+thumb_func 0x80b6aa4 FldEff_UseWaterfall
 thumb_func 0x80b6adc
 thumb_func 0x80b6b0c
 thumb_func 0x80b6b28
-thumb_func 0x80b6b48
+thumb_func 0x80b6b48 waterfall_1_do_anim_probably
 thumb_func 0x80b6b84 waterfall_2_wait_anim_finish_probably
 thumb_func 0x80b6ba8
 thumb_func 0x80b6bd0
-thumb_func 0x80b6c28
+thumb_func 0x80b6c28 FldEff_UseDive
 thumb_func 0x80b6c64
-thumb_func 0x80b6c9c
-thumb_func 0x80b6cb0
-thumb_func 0x80b6cd8
+thumb_func 0x80b6c9c dive_1_lock
+thumb_func 0x80b6cb0 dive_2_unknown
+thumb_func 0x80b6cd8 dive_3_unknown
 thumb_func 0x80b6d30
 thumb_func 0x80b6d48
 thumb_func 0x80b6da4
@@ -6280,7 +6280,7 @@ thumb_func 0x80b7044
 thumb_func 0x80b7074
 thumb_func 0x80b70c0
 thumb_func 0x80b7114
-thumb_func 0x80b714c
+thumb_func 0x80b714c FldEff_LavaridgeGymWarp
 thumb_func 0x80b71b0
 thumb_func 0x80b71cc
 thumb_func 0x80b71e4
@@ -6289,29 +6289,29 @@ thumb_func 0x80b7270
 thumb_func 0x80b72ec
 thumb_func 0x80b7324
 thumb_func 0x80b734c
-thumb_func 0x80b73a0
+thumb_func 0x80b73a0 FldEff_PopOutOfAsh
 thumb_func 0x80b7404
-thumb_func 0x80b7420
+thumb_func 0x80b7420 StartEscapeRopeFieldEffect
 thumb_func 0x80b743c
-thumb_func 0x80b746c
-thumb_func 0x80b748c
-thumb_func 0x80b75a0
+thumb_func 0x80b746c EscapeRopeFieldEffect_Step0
+thumb_func 0x80b748c EscapeRopeFieldEffect_Step1
+thumb_func 0x80b75a0 CB2_RayquazaScene
 thumb_func 0x80b75ec
 thumb_func 0x80b761c
 thumb_func 0x80b7640
 thumb_func 0x80b7720
 thumb_func 0x80b7734
-thumb_func 0x80b7764
-thumb_func 0x80b778c
-thumb_func 0x80b781c
-thumb_func 0x80b78f0
-thumb_func 0x80b7958
+thumb_func 0x80b7764 TeleportFieldEffectTask1
+thumb_func 0x80b778c TeleportFieldEffectTask2
+thumb_func 0x80b781c TeleportFieldEffectTask3
+thumb_func 0x80b78f0 TeleportFieldEffectTask4
+thumb_func 0x80b7958 mapldr_08085D88
 thumb_func 0x80b79a8
 thumb_func 0x80b79d8
 thumb_func 0x80b7a64
 thumb_func 0x80b7b68
-thumb_func 0x80b7bf4
-thumb_func 0x80b7c50
+thumb_func 0x80b7bf4 FldEff_FieldMoveShowMon
+thumb_func 0x80b7c50 FldEff_FieldMoveShowMonInit
 thumb_func 0x80b7cac
 thumb_func 0x80b7cdc
 thumb_func 0x80b7d50
@@ -6319,7 +6319,7 @@ thumb_func 0x80b7db8
 thumb_func 0x80b7e44
 thumb_func 0x80b7e74
 thumb_func 0x80b7ec8
-thumb_func 0x80b7f10
+thumb_func 0x80b7f10 overworld_bg_setup_2
 thumb_func 0x80b7f64
 thumb_func 0x80b7f8c
 thumb_func 0x80b7fcc
@@ -6340,7 +6340,7 @@ thumb_func 0x80b83b8
 thumb_func 0x80b8418
 thumb_func 0x80b845c
 thumb_func 0x80b8478
-thumb_func 0x80b849c
+thumb_func 0x80b849c FldEff_UseSurf
 thumb_func 0x80b84dc
 thumb_func 0x80b850c
 thumb_func 0x80b856c
@@ -6348,9 +6348,9 @@ thumb_func 0x80b85b8
 thumb_func 0x80b8600
 thumb_func 0x80b867c
 thumb_func 0x80b86f0
-thumb_func 0x80b8824
+thumb_func 0x80b8824 FldEff_NPCFlyOut
 thumb_func 0x80b8880
-thumb_func 0x80b88fc
+thumb_func 0x80b88fc FldEff_UseFly
 thumb_func 0x80b892c
 thumb_func 0x80b895c
 thumb_func 0x80b89b4
@@ -6369,7 +6369,7 @@ thumb_func 0x80b8cd4
 thumb_func 0x80b8d94
 thumb_func 0x80b8e08
 thumb_func 0x80b8eec
-thumb_func 0x80b8f18
+thumb_func 0x80b8f18 FldEff_FlyIn
 thumb_func 0x80b8f2c
 thumb_func 0x80b8f5c
 thumb_func 0x80b9010
@@ -6384,50 +6384,50 @@ thumb_func 0x80b9328
 thumb_func 0x80b9340
 thumb_func 0x80b9370
 thumb_func 0x80b9380
-thumb_func 0x80b93ac
+thumb_func 0x80b93ac SpawnLinkPlayerEventObject
 thumb_func 0x80b9434
 thumb_func 0x80b947c
 thumb_func 0x80b9510
-thumb_func 0x80b9580
-thumb_func 0x80b9634
-thumb_func 0x80b9710
-thumb_func 0x80b9750
-thumb_func 0x80b9790
-thumb_func 0x80b9800
+thumb_func 0x80b9580 Fldeff_MoveDeoxysRock
+thumb_func 0x80b9634 Fldeff_MoveDeoxysRock_Step
+thumb_func 0x80b9710 ScanlineEffect_Stop
+thumb_func 0x80b9750 ScanlineEffect_Clear
+thumb_func 0x80b9790 ScanlineEffect_SetParams
+thumb_func 0x80b9800 ScanlineEffect_InitHBlankDmaTransfer
 thumb_func 0x80b988c CopyValue16Bit
 thumb_func 0x80b98ac CopyValue32Bit
-thumb_func 0x80b98cc
+thumb_func 0x80b98cc TaskFunc_UpdateWavePerFrame
 thumb_func 0x80b9a94 GenerateWave
-thumb_func 0x80b9adc
+thumb_func 0x80b9adc ScanlineEffect_InitWave
 thumb_func 0x80b9c08
 thumb_func 0x80b9c20
-thumb_func 0x80b9c34
+thumb_func 0x80b9c34 CB2_InitOptionMenu
 thumb_func 0x80b9f94
-thumb_func 0x80b9fc4
-thumb_func 0x80ba1bc
-thumb_func 0x80ba260
-thumb_func 0x80ba290
-thumb_func 0x80ba2c0
+thumb_func 0x80b9fc4 Task_OptionMenuProcessInput
+thumb_func 0x80ba1bc Task_OptionMenuSave
+thumb_func 0x80ba260 Task_OptionMenuFadeOut
+thumb_func 0x80ba290 HighlightOptionMenuItem
+thumb_func 0x80ba2c0 DrawOptionMenuChoice
 thumb_func 0x80ba334
 thumb_func 0x80ba390
 thumb_func 0x80ba3e4
 thumb_func 0x80ba40c
 thumb_func 0x80ba468
 thumb_func 0x80ba490
-thumb_func 0x80ba4ec
+thumb_func 0x80ba4ec Sound_ProcessInput
 thumb_func 0x80ba51c
-thumb_func 0x80ba584
+thumb_func 0x80ba584 FrameType_ProcessInput
 thumb_func 0x80ba634
 thumb_func 0x80ba724
 thumb_func 0x80ba780
-thumb_func 0x80ba800
+thumb_func 0x80ba800 DrawTextOption
 thumb_func 0x80ba834
 thumb_func 0x80ba890
-thumb_func 0x80baa0c
-thumb_func 0x80baa94
+thumb_func 0x80baa0c ResetPokedex
+thumb_func 0x80baa94 ResetPokedexScrollPositions
 thumb_func 0x80baaac
 thumb_func 0x80baac0 ResetPokedexView
-thumb_func 0x80bac70
+thumb_func 0x80bac70 CB2_Pokedex
 thumb_func 0x80baeb0
 thumb_func 0x80baec8
 thumb_func 0x80baf10
@@ -6440,36 +6440,36 @@ thumb_func 0x80bb524
 thumb_func 0x80bb5ac
 thumb_func 0x80bb5f4
 thumb_func 0x80bb7e4
-thumb_func 0x80bb834
+thumb_func 0x80bb834 HandleButtonPress_StartMenu
 thumb_func 0x80bba10
 thumb_func 0x80bba9c
 thumb_func 0x80bbb18
 thumb_func 0x80bbbb8
 thumb_func 0x80bbc50
-thumb_func 0x80bbf80
+thumb_func 0x80bbf80 LoadPokedexBgPalette
 thumb_func 0x80bbfcc
 thumb_func 0x80bc010
-thumb_func 0x80bc568
-thumb_func 0x80bc5c0
-thumb_func 0x80bc890
-thumb_func 0x80bc930
+thumb_func 0x80bc568 PrintMonDexNumAndName
+thumb_func 0x80bc5c0 CreateMonListEntry
+thumb_func 0x80bc890 CreateMonDexNum
+thumb_func 0x80bc930 CreateCaughtBall
 thumb_func 0x80bc978
 thumb_func 0x80bca2c
-thumb_func 0x80bca54
+thumb_func 0x80bca54 CreateInitialPokemonSprites
 thumb_func 0x80bcba4
-thumb_func 0x80bcd48
+thumb_func 0x80bcd48 CreateNewPokemonSprite
 thumb_func 0x80bce3c
 thumb_func 0x80bd070
 thumb_func 0x80bd0d0
 thumb_func 0x80bd1e0
-thumb_func 0x80bd22c
+thumb_func 0x80bd22c GetPokemonSpriteToDisplay
 thumb_func 0x80bd26c
-thumb_func 0x80bd31c
+thumb_func 0x80bd31c CreateInterfaceSprites
 thumb_func 0x80bdbe8 nullsub_59
 thumb_func 0x80bdbec
 thumb_func 0x80bdc10
 thumb_func 0x80bdc80
-thumb_func 0x80bdda4
+thumb_func 0x80bdda4 SpriteCB_Scrollbar
 thumb_func 0x80bddf8
 thumb_func 0x80bdef8
 thumb_func 0x80bdf20
@@ -6498,18 +6498,18 @@ thumb_func 0x80bf598
 thumb_func 0x80bf5b0
 thumb_func 0x80bf5c8
 thumb_func 0x80bf638
-thumb_func 0x80bf6b0
+thumb_func 0x80bf6b0 CreateDexDisplayMonDataTask
 thumb_func 0x80bf6f4
 thumb_func 0x80bf9e4
-thumb_func 0x80bfa88
+thumb_func 0x80bfa88 blockset_load_palette_to_gpu
 thumb_func 0x80bfb28
 thumb_func 0x80bfb68
-thumb_func 0x80bfb80
-thumb_func 0x80bfbbc
+thumb_func 0x80bfb80 GetPokedexHeightWeight
+thumb_func 0x80bfbbc GetSetPokedexFlag
 thumb_func 0x80bfd4c GetNationalPokedexCount
-thumb_func 0x80bfd9c
+thumb_func 0x80bfd9c GetHoennPokedexCount
 thumb_func 0x80bfdf4
-thumb_func 0x80bfe3c
+thumb_func 0x80bfe3c HasAllHoennMons
 thumb_func 0x80bfe70
 thumb_func 0x80bfe9c
 thumb_func 0x80bff08
@@ -6522,9 +6522,9 @@ thumb_func 0x80c0288
 thumb_func 0x80c0318
 thumb_func 0x80c0364
 thumb_func 0x80c03c0
-thumb_func 0x80c03f4
+thumb_func 0x80c03f4 CreateMonSpriteFromNationalDexNumber
 thumb_func 0x80c0450
-thumb_func 0x80c0488
+thumb_func 0x80c0488 save_write_to_flash
 thumb_func 0x80c07b4
 thumb_func 0x80c07cc
 thumb_func 0x80c0810
@@ -6546,7 +6546,7 @@ thumb_func 0x80c1440
 thumb_func 0x80c1538
 thumb_func 0x80c1684
 thumb_func 0x80c16b8
-thumb_func 0x80c175c
+thumb_func 0x80c175c Cb_JumpBox
 thumb_func 0x80c1838
 thumb_func 0x80c1918
 thumb_func 0x80c19bc
@@ -6555,144 +6555,144 @@ thumb_func 0x80c1af0
 thumb_func 0x80c1b38
 thumb_func 0x80c1b84
 thumb_func 0x80c1c38
-thumb_func 0x80c1cbc
+thumb_func 0x80c1cbc VblankCb_TrainerCard
 thumb_func 0x80c1d00 HblankCb_TrainerCard
-thumb_func 0x80c1d3c
+thumb_func 0x80c1d3c CB2_TrainerCard
 thumb_func 0x80c1d54
 thumb_func 0x80c1d8c
 thumb_func 0x80c2104
-thumb_func 0x80c22b4
-thumb_func 0x80c2414
-thumb_func 0x80c242c
-thumb_func 0x80c2470
+thumb_func 0x80c22b4 CB2_InitTrainerCard
+thumb_func 0x80c2414 GetCappedGameStat
+thumb_func 0x80c242c HasAllFrontierSymbols
+thumb_func 0x80c2470 CountPlayerTrainerStars
 thumb_func 0x80c24b4 GetRubyTrainerStars
-thumb_func 0x80c24f4
-thumb_func 0x80c2650
-thumb_func 0x80c26d4
-thumb_func 0x80c2750
-thumb_func 0x80c27c0
+thumb_func 0x80c24f4 SetPlayerCardData
+thumb_func 0x80c2650 TrainerCard_GenerateCardForLinkPlayer
+thumb_func 0x80c26d4 TrainerCard_GenerateCardForPlayer
+thumb_func 0x80c2750 CopyTrainerCardData
+thumb_func 0x80c27c0 DecompressPicFromTable_2
 thumb_func 0x80c28a4
 thumb_func 0x80c2918
-thumb_func 0x80c297c
-thumb_func 0x80c29b8
-thumb_func 0x80c2a34
+thumb_func 0x80c297c HandleGpuRegs
+thumb_func 0x80c29b8 InitBgsAndWindows
+thumb_func 0x80c2a34 SetTrainerCardCb2
 thumb_func 0x80c2a44
 thumb_func 0x80c2a68
-thumb_func 0x80c2ae0
+thumb_func 0x80c2ae0 PrintStringsOnCardPage2
 thumb_func 0x80c2b78
 thumb_func 0x80c2ba4
-thumb_func 0x80c2c5c
+thumb_func 0x80c2c5c Task_PrintTestData
 thumb_func 0x80c2d14
-thumb_func 0x80c2e20
+thumb_func 0x80c2e20 GetCaughtMonsCount
 thumb_func 0x80c2e40
-thumb_func 0x80c2f5c
+thumb_func 0x80c2f5c WindowFunc_DrawDialogFrameWithCustomTileAndPalette
 thumb_func 0x80c310c
 thumb_func 0x80c31fc
 thumb_func 0x80c323c
-thumb_func 0x80c32c0
+thumb_func 0x80c32c0 PrintLinkResultsNumsOnCard
 thumb_func 0x80c3330
-thumb_func 0x80c33a0
+thumb_func 0x80c33a0 PrintHofTimeOnCard
 thumb_func 0x80c340c
-thumb_func 0x80c34b8
+thumb_func 0x80c34b8 PrintTradesNumOnCard
 thumb_func 0x80c34e4
-thumb_func 0x80c3584
+thumb_func 0x80c3584 PrintUnionNumOnCard
 thumb_func 0x80c35c0
-thumb_func 0x80c364c
+thumb_func 0x80c364c PrintBerryCrushNumOnCard
 thumb_func 0x80c3684
-thumb_func 0x80c3710
+thumb_func 0x80c3710 PrintPokeblocksNumOnCard
 thumb_func 0x80c3760
 thumb_func 0x80c37ec
 thumb_func 0x80c3828
-thumb_func 0x80c38b4
+thumb_func 0x80c38b4 PrintBattleFacilityNumsOnCard
 thumb_func 0x80c395c
-thumb_func 0x80c3a70
+thumb_func 0x80c3a70 TrainerCard_PrintPokemonIconsOnCard
 thumb_func 0x80c3b0c
 thumb_func 0x80c3be4
 thumb_func 0x80c3c6c
 thumb_func 0x80c3cc8
-thumb_func 0x80c3ce4
+thumb_func 0x80c3ce4 SetCardBgsAndPals
 thumb_func 0x80c3e84
 thumb_func 0x80c3ef4
-thumb_func 0x80c3f64
+thumb_func 0x80c3f64 TrainerCard_PrintStarsAndBadgesOnCard
 thumb_func 0x80c4080
 thumb_func 0x80c41fc
-thumb_func 0x80c4238
+thumb_func 0x80c4238 GetTrainerCardStars
 thumb_func 0x80c424c
 thumb_func 0x80c4274
-thumb_func 0x80c4294
+thumb_func 0x80c4294 Phase2Task_GridSquares
 thumb_func 0x80c42cc
 thumb_func 0x80c430c
 thumb_func 0x80c443c
 thumb_func 0x80c4550
 thumb_func 0x80c45b8
-thumb_func 0x80c46e4
+thumb_func 0x80c46e4 ResetGpuRegs
 thumb_func 0x80c4710
-thumb_func 0x80c4798
+thumb_func 0x80c4798 ShowTrainerCardInLink
 thumb_func 0x80c47ec
-thumb_func 0x80c4858
+thumb_func 0x80c4858 GetSetCardType
 thumb_func 0x80c48d0 VersionToCardType
 thumb_func 0x80c48f4
-thumb_func 0x80c49cc
-thumb_func 0x80c4ac0
-thumb_func 0x80c4ad4
-thumb_func 0x80c4aec
-thumb_func 0x80c4be0
-thumb_func 0x80c4c0c
-thumb_func 0x80c4c3c
-thumb_func 0x80c4ca8
-thumb_func 0x80c4d34
-thumb_func 0x80c4d48
-thumb_func 0x80c4d6c
-thumb_func 0x80c4d80
-thumb_func 0x80c5008
-thumb_func 0x80c50f8
-thumb_func 0x80c5164
-thumb_func 0x80c51d0
-thumb_func 0x80c5230
-thumb_func 0x80c52a0
-thumb_func 0x80c5344
-thumb_func 0x80c54d4
-thumb_func 0x80c56b4
-thumb_func 0x80c57bc
+thumb_func 0x80c49cc ResetGpuRegsAndBgs
+thumb_func 0x80c4ac0 ShowFrontierPass
+thumb_func 0x80c4ad4 LeaveFrontierPass
+thumb_func 0x80c4aec AllocateFrontierPassData
+thumb_func 0x80c4be0 FreeFrontierPassData
+thumb_func 0x80c4c0c AllocateFrontierPassGfx
+thumb_func 0x80c4c3c FreeFrontierPassGfx
+thumb_func 0x80c4ca8 VblankCb_FrontierPass
+thumb_func 0x80c4d34 CB2_FrontierPass
+thumb_func 0x80c4d48 CB2_InitFrontierPass
+thumb_func 0x80c4d6c CB2_HideFrontierPass
+thumb_func 0x80c4d80 InitFrontierPass
+thumb_func 0x80c5008 HideFrontierPass
+thumb_func 0x80c50f8 GetCursorAreaFromCoords
+thumb_func 0x80c5164 CB2_ReshowFrontierPass
+thumb_func 0x80c51d0 CB2_ReturnFromRecord
+thumb_func 0x80c5230 CB2_ShowFrontierPassFeature
+thumb_func 0x80c52a0 TryCallPassAreaFunction
+thumb_func 0x80c5344 Task_HandleFrontierPassInput
+thumb_func 0x80c54d4 DrawMultichoiceMenu
+thumb_func 0x80c56b4 Task_Truck3
+thumb_func 0x80c57bc PrintAreaDescription
 thumb_func 0x80c5844
 thumb_func 0x80c59f0
 thumb_func 0x80c5b88
-thumb_func 0x80c5bc8
-thumb_func 0x80c5ce8
+thumb_func 0x80c5bc8 LoadCursorAndSymbolSprites
+thumb_func 0x80c5ce8 FreeCursorAndSymbolSprites
 thumb_func 0x80c5d3c nullsub_601
-thumb_func 0x80c5d40
-thumb_func 0x80c5d84
-thumb_func 0x80c5db8
+thumb_func 0x80c5d40 ShowFrontierMap
+thumb_func 0x80c5d84 FreeFrontierMap
+thumb_func 0x80c5db8 InitFrontierMap
 thumb_func 0x80c5f98
-thumb_func 0x80c60a8
+thumb_func 0x80c60a8 Task_HandleFrontierMap
 thumb_func 0x80c61d4 MapNumToFrontierFacilityId
-thumb_func 0x80c6260
-thumb_func 0x80c6480
-thumb_func 0x80c655c
+thumb_func 0x80c6260 InitFrontierMapSprites
+thumb_func 0x80c6480 PrintOnFrontierMap
+thumb_func 0x80c655c HandleFrontierMapCursorMove
 thumb_func 0x80c666c
 thumb_func 0x80c66a4
 thumb_func 0x80c6738
-thumb_func 0x80c682c
-thumb_func 0x80c6860
-thumb_func 0x80c6894
-thumb_func 0x80c68dc
-thumb_func 0x80c6938
-thumb_func 0x80c6950
-thumb_func 0x80c6988
+thumb_func 0x80c682c CountMonsInBox
+thumb_func 0x80c6860 GetFirstFreeBoxSpot
+thumb_func 0x80c6894 CountPartyNonEggMons
+thumb_func 0x80c68dc CountPartyAliveNonEggMonsExcept
+thumb_func 0x80c6938 CountPartyAliveNonEggMons_IgnoreVar0x8004Slot
+thumb_func 0x80c6950 CountPartyMons
+thumb_func 0x80c6988 StringCopyAndFillWithSpaces
 thumb_func 0x80c69b4
 thumb_func 0x80c6a30
-thumb_func 0x80c6af4
-thumb_func 0x80c6e04
-thumb_func 0x80c6e34
+thumb_func 0x80c6af4 Task_PokemonStorageSystemPC
+thumb_func 0x80c6e04 ShowPokemonStorageSystemPC
+thumb_func 0x80c6e34 FieldCb_ReturnToPcMenu
 thumb_func 0x80c6e88
-thumb_func 0x80c6f10
+thumb_func 0x80c6f10 Cb2_ExitPSS
 thumb_func 0x80c6f3c
-thumb_func 0x80c7008
+thumb_func 0x80c7008 ResetPokemonStorageSystem
 thumb_func 0x80c7080
 thumb_func 0x80c7128
 thumb_func 0x80c716c
-thumb_func 0x80c717c
-thumb_func 0x80c7188
+thumb_func 0x80c717c WallyHandleGetRawMonData
+thumb_func 0x80c7188 HandleBoxChooseSelectionInput
 thumb_func 0x80c71f0
 thumb_func 0x80c73d0
 thumb_func 0x80c743c
@@ -6700,90 +6700,90 @@ thumb_func 0x80c7470
 thumb_func 0x80c74a0
 thumb_func 0x80c7528
 thumb_func 0x80c7590
-thumb_func 0x80c75c4
+thumb_func 0x80c75c4 VblankCb_PSS
 thumb_func 0x80c75f0
-thumb_func 0x80c7610
-thumb_func 0x80c7688
-thumb_func 0x80c76ec
+thumb_func 0x80c7610 Cb2_EnterPSS
+thumb_func 0x80c7688 Cb2_ReturnToPSS
+thumb_func 0x80c76ec ResetAllBgCoords
 thumb_func 0x80c7734
 thumb_func 0x80c77b8
 thumb_func 0x80c77e8
 thumb_func 0x80c781c SetPSSCallback
-thumb_func 0x80c7844
-thumb_func 0x80c7a48
-thumb_func 0x80c7a94
-thumb_func 0x80c7b48
-thumb_func 0x80c8044
-thumb_func 0x80c8084
-thumb_func 0x80c8100
-thumb_func 0x80c842c
+thumb_func 0x80c7844 Cb_InitPSS
+thumb_func 0x80c7a48 Cb_ShowPSS
+thumb_func 0x80c7a94 Cb_ReshowPSS
+thumb_func 0x80c7b48 Cb_MainPSS
+thumb_func 0x80c8044 Cb_ShowPartyPokemon
+thumb_func 0x80c8084 Cb_HidePartyPokemon
+thumb_func 0x80c8100 Cb_OnSelectedMon
+thumb_func 0x80c842c Cb_MoveMon
 thumb_func 0x80c8488
-thumb_func 0x80c84e4
-thumb_func 0x80c852c
-thumb_func 0x80c8614
-thumb_func 0x80c8750
-thumb_func 0x80c8940
-thumb_func 0x80c89c4
-thumb_func 0x80c8a78
-thumb_func 0x80c8b34
-thumb_func 0x80c8c4c
-thumb_func 0x80c8d34
-thumb_func 0x80c8de8
-thumb_func 0x80c8f0c
+thumb_func 0x80c84e4 Cb_ShiftMon
+thumb_func 0x80c852c Cb_WithdrawMon
+thumb_func 0x80c8614 Cb_DepositMenu
+thumb_func 0x80c8750 Cb_ReleaseMon
+thumb_func 0x80c8940 Cb_ShowMarkMenu
+thumb_func 0x80c89c4 Cb_TakeItemForMoving
+thumb_func 0x80c8a78 Cb_GiveMovingItemToMon
+thumb_func 0x80c8b34 Cb_ItemToBag
+thumb_func 0x80c8c4c Cb_SwitchSelectedItem
+thumb_func 0x80c8d34 Cb_ShowItemInfo
+thumb_func 0x80c8de8 Cb_CloseBoxWhileHoldingItem
+thumb_func 0x80c8f0c Cb_HandleMovingMonFromParty
 thumb_func 0x80c8f54
-thumb_func 0x80c8fc8
-thumb_func 0x80c90c0
+thumb_func 0x80c8fc8 Cb_HandleBoxOptions
+thumb_func 0x80c90c0 Cb_HandleWallpapers
 thumb_func 0x80c9274
-thumb_func 0x80c9364
-thumb_func 0x80c93c4
-thumb_func 0x80c9424
-thumb_func 0x80c9484
+thumb_func 0x80c9364 BattleSetup_GetTerrainId
+thumb_func 0x80c93c4 Cb_ShowMonSummary
+thumb_func 0x80c9424 Cb_GiveItemFromBag
+thumb_func 0x80c9484 Cb_OnCloseBoxPressed
 thumb_func 0x80c95b8
 thumb_func 0x80c96ec
-thumb_func 0x80c97e0
-thumb_func 0x80c983c
-thumb_func 0x80c9860
-thumb_func 0x80c989c
-thumb_func 0x80c98b8
+thumb_func 0x80c97e0 GiveChosenBagItem
+thumb_func 0x80c983c FreePSSData
+thumb_func 0x80c9860 SetScrollingBackground
+thumb_func 0x80c989c ScrollBackground
+thumb_func 0x80c98b8 LoadPSSMenuGfx
 thumb_func 0x80c9918
-thumb_func 0x80c993c
+thumb_func 0x80c993c LoadWaveformSpritePalette
 thumb_func 0x80c994c
 thumb_func 0x80c99c8
 thumb_func 0x80c9a38
-thumb_func 0x80c9aa4
-thumb_func 0x80c9ad4
+thumb_func 0x80c9aa4 RefreshCursorMonData
+thumb_func 0x80c9ad4 BoxSetMosaic
 thumb_func 0x80c9b2c
 thumb_func 0x80c9b44
-thumb_func 0x80c9b8c
-thumb_func 0x80c9cc0
+thumb_func 0x80c9b8c LoadCursorMonSprite
+thumb_func 0x80c9cc0 LoadCursorMonGfx
 thumb_func 0x80c9d70
 thumb_func 0x80c9ec0
 thumb_func 0x80c9f68
-thumb_func 0x80ca038
-thumb_func 0x80ca070
-thumb_func 0x80ca0ec
-thumb_func 0x80ca12c
+thumb_func 0x80ca038 SetUpShowPartyMenu
+thumb_func 0x80ca070 ShowPartyMenu
+thumb_func 0x80ca0ec SetUpHidePartyMenu
+thumb_func 0x80ca12c HidePartyMenu
 thumb_func 0x80ca1e8
 thumb_func 0x80ca224
 thumb_func 0x80ca250
 thumb_func 0x80ca278
 thumb_func 0x80ca2d8
 thumb_func 0x80ca30c
-thumb_func 0x80ca384
-thumb_func 0x80ca3b0
-thumb_func 0x80ca3d4
+thumb_func 0x80ca384 PokecenterHealEffect_3
+thumb_func 0x80ca3b0 SetUpDoShowPartyMenu
+thumb_func 0x80ca3d4 DoShowPartyMenu
 thumb_func 0x80ca444
 thumb_func 0x80ca480
-thumb_func 0x80ca4bc
+thumb_func 0x80ca4bc PrintStorageActionText
 thumb_func 0x80ca600
 thumb_func 0x80ca638
 thumb_func 0x80ca64c
-thumb_func 0x80ca680
+thumb_func 0x80ca680 AddWallpapersMenu
 thumb_func 0x80ca714
 thumb_func 0x80ca720
 thumb_func 0x80ca778
 thumb_func 0x80ca820
-thumb_func 0x80ca838
+thumb_func 0x80ca838 CreateMovingMonIcon
 thumb_func 0x80ca89c
 thumb_func 0x80ca9b4
 thumb_func 0x80caa64
@@ -6793,10 +6793,10 @@ thumb_func 0x80cab24 DestroyAllIconsInRow
 thumb_func 0x80cab6c
 thumb_func 0x80cad40
 thumb_func 0x80cadf8
-thumb_func 0x80caf64
+thumb_func 0x80caf64 SetBoxSpeciesAndPersonalities
 thumb_func 0x80cafec DestroyBoxMonIconAtPosition
 thumb_func 0x80cb020 SetBoxMonIconObjMode
-thumb_func 0x80cb05c
+thumb_func 0x80cb05c CreatePartyMonsSprites
 thumb_func 0x80cb1c4
 thumb_func 0x80cb230
 thumb_func 0x80cb244
@@ -6820,17 +6820,17 @@ thumb_func 0x80cb974
 thumb_func 0x80cb998
 thumb_func 0x80cba54
 thumb_func 0x80cbaa4
-thumb_func 0x80cbb88
+thumb_func 0x80cbb88 DestroyBoxMonIcon
 thumb_func 0x80cbba0
 thumb_func 0x80cbbd0
 thumb_func 0x80cbbe4
 thumb_func 0x80cbcd8 SetUpScrollToBox
-thumb_func 0x80cbdc0
+thumb_func 0x80cbdc0 ScrollToBox
 thumb_func 0x80cbeb8
-thumb_func 0x80cbef4
-thumb_func 0x80cbf24
-thumb_func 0x80cc014
-thumb_func 0x80cc274
+thumb_func 0x80cbef4 SetWallpaperForCurrentBox
+thumb_func 0x80cbf24 DoWallpaperGfxChange
+thumb_func 0x80cc014 LoadWallpaperGfx
+thumb_func 0x80cc274 WaitForWallpaperGfxLoad
 thumb_func 0x80cc2b0
 thumb_func 0x80cc354
 thumb_func 0x80cc3c4
@@ -6862,54 +6862,54 @@ thumb_func 0x80cd494
 thumb_func 0x80cd4a8
 thumb_func 0x80cd4b4 InitMonPlaceChange
 thumb_func 0x80cd4e0
-thumb_func 0x80cd528
+thumb_func 0x80cd528 DoMonPlaceChange
 thumb_func 0x80cd538
-thumb_func 0x80cd548
-thumb_func 0x80cd5d8
-thumb_func 0x80cd654
+thumb_func 0x80cd548 MonPlaceChange_Move
+thumb_func 0x80cd5d8 MonPlaceChange_Place
+thumb_func 0x80cd654 MonPlaceChange_Shift
 thumb_func 0x80cd730
 thumb_func 0x80cd740
 thumb_func 0x80cd750
 thumb_func 0x80cd784
-thumb_func 0x80cd7b4
-thumb_func 0x80cd828
+thumb_func 0x80cd7b4 MoveMon
+thumb_func 0x80cd828 PlaceMon
 thumb_func 0x80cd888
-thumb_func 0x80cd894
-thumb_func 0x80cd908
-thumb_func 0x80cd964
-thumb_func 0x80cd98c
-thumb_func 0x80cda18
-thumb_func 0x80cdaa8
+thumb_func 0x80cd894 SetMovedMonData
+thumb_func 0x80cd908 SetPlacedMonData
+thumb_func 0x80cd964 PurgeMonOrBoxMon
+thumb_func 0x80cd98c SetShiftedMonData
+thumb_func 0x80cda18 TryStorePartyMonInBox
+thumb_func 0x80cdaa8 WallyHandleStatusIconUpdate
 thumb_func 0x80cdacc
 thumb_func 0x80cdb24
-thumb_func 0x80cdb54
+thumb_func 0x80cdb54 ReleaseMon
 thumb_func 0x80cdba0
 thumb_func 0x80cdbcc
-thumb_func 0x80cdc1c
-thumb_func 0x80cdd98
-thumb_func 0x80cddfc
+thumb_func 0x80cdc1c InitCanRelaseMonVars
+thumb_func 0x80cdd98 AtLeastThreeUsableMons
+thumb_func 0x80cddfc RunCanReleaseMon
 thumb_func 0x80cdfdc
 thumb_func 0x80ce00c
 thumb_func 0x80ce064
 thumb_func 0x80ce160
-thumb_func 0x80ce188
-thumb_func 0x80ce224
-thumb_func 0x80ce2ac
-thumb_func 0x80ce2e8
+thumb_func 0x80ce188 CompactPartySlots
+thumb_func 0x80ce224 SetMonMarkings
+thumb_func 0x80ce2ac CanMovePartyMon
+thumb_func 0x80ce2e8 CanShiftMon
 thumb_func 0x80ce34c
 thumb_func 0x80ce358 IsCursorOnBox
 thumb_func 0x80ce374 IsCursorOnCloseBox
 thumb_func 0x80ce3a0 IsCursorInBox
 thumb_func 0x80ce3bc
 thumb_func 0x80ce458
-thumb_func 0x80ce47c
-thumb_func 0x80ce948
-thumb_func 0x80ce984
-thumb_func 0x80cebf0
-thumb_func 0x80ced2c
-thumb_func 0x80cee40
-thumb_func 0x80cf060
-thumb_func 0x80cf154
+thumb_func 0x80ce47c SetCursorMonData
+thumb_func 0x80ce948 HandleInput_InBox
+thumb_func 0x80ce984 InBoxInput_Normal
+thumb_func 0x80cebf0 InBoxInput_GrabbingMultiple
+thumb_func 0x80ced2c InBoxInput_MovingMultiple
+thumb_func 0x80cee40 HandleInput_InParty
+thumb_func 0x80cf060 HandleInput_OnBox
+thumb_func 0x80cf154 HandleInput_OnButtons
 thumb_func 0x80cf268
 thumb_func 0x80cf2b4 AddBoxMenu
 thumb_func 0x80cf2d8
@@ -6926,13 +6926,13 @@ thumb_func 0x80cf700
 thumb_func 0x80cf724
 thumb_func 0x80cf748
 thumb_func 0x80cf76c InitMenu
-thumb_func 0x80cf7b0
+thumb_func 0x80cf7b0 SetMenuText
 thumb_func 0x80cf814
 thumb_func 0x80cf84c
 thumb_func 0x80cf948
 thumb_func 0x80cf94c
 thumb_func 0x80cf9dc
-thumb_func 0x80cfa04
+thumb_func 0x80cfa04 ItemStorage_StartScrollIndicatorAndProcessInput
 thumb_func 0x80cfa58
 thumb_func 0x80cfa70
 thumb_func 0x80cfa84
@@ -6962,16 +6962,16 @@ thumb_func 0x80d0460
 thumb_func 0x80d0500
 thumb_func 0x80d062c
 thumb_func 0x80d06f0
-thumb_func 0x80d0730
+thumb_func 0x80d0730 Item_FromMonToMoving
 thumb_func 0x80d07d8
-thumb_func 0x80d084c
-thumb_func 0x80d0920
-thumb_func 0x80d09b4
+thumb_func 0x80d084c Item_SwitchMonsWithMoving
+thumb_func 0x80d0920 Item_GiveMovingToMon
+thumb_func 0x80d09b4 Item_TakeMons
 thumb_func 0x80d0a34
 thumb_func 0x80d0a6c
 thumb_func 0x80d0ab8
-thumb_func 0x80d0b1c
-thumb_func 0x80d0b58
+thumb_func 0x80d0b1c IsActiveItemMoving
+thumb_func 0x80d0b58 GetMovingItemName
 thumb_func 0x80d0b74
 thumb_func 0x80d0b88
 thumb_func 0x80d0bc4
@@ -6982,8 +6982,8 @@ thumb_func 0x80d0dc4
 thumb_func 0x80d0e74
 thumb_func 0x80d0ea4
 thumb_func 0x80d0fe0
-thumb_func 0x80d1034
-thumb_func 0x80d1044
+thumb_func 0x80d1034 GetItemIconPic
+thumb_func 0x80d1044 GetItemIconPalette
 thumb_func 0x80d1054
 thumb_func 0x80d10b8
 thumb_func 0x80d10ec
@@ -7000,31 +7000,31 @@ thumb_func 0x80d15a4 nullsub_61
 thumb_func 0x80d15a8 nullsub_60
 thumb_func 0x80d15ac
 thumb_func 0x80d15b8 SetCurrentBox
-thumb_func 0x80d15d0
-thumb_func 0x80d1614
+thumb_func 0x80d15d0 GetBoxMonDataAt
+thumb_func 0x80d1614 SetBoxMonDataAt
 thumb_func 0x80d1658 GetCurrentBoxMonData
 thumb_func 0x80d1678 SetCurrentBoxMonData
-thumb_func 0x80d169c
-thumb_func 0x80d16e4
-thumb_func 0x80d1730
-thumb_func 0x80d1770
-thumb_func 0x80d17b8
-thumb_func 0x80d17f8
-thumb_func 0x80d1838
-thumb_func 0x80d18b8
-thumb_func 0x80d18f4
-thumb_func 0x80d1934
+thumb_func 0x80d169c GetBoxMonNickAt
+thumb_func 0x80d16e4 GetBoxMonLevelAt
+thumb_func 0x80d1730 SetBoxMonNickAt
+thumb_func 0x80d1770 GetAndCopyBoxMonDataAt
+thumb_func 0x80d17b8 SetBoxMonAt
+thumb_func 0x80d17f8 CopyBoxMonAt
+thumb_func 0x80d1838 CreateBoxMonAt
+thumb_func 0x80d18b8 ZeroBoxMonAt
+thumb_func 0x80d18f4 BoxMonAtToMon
+thumb_func 0x80d1934 GetBoxedMonPtr
 thumb_func 0x80d1970 GetBoxNamePtr
 thumb_func 0x80d1998 GetBoxWallpaper
 thumb_func 0x80d19c0 SetBoxWallpaper
 thumb_func 0x80d19ec
-thumb_func 0x80d1ab8
-thumb_func 0x80d1b10
-thumb_func 0x80d1b70
-thumb_func 0x80d1bdc
-thumb_func 0x80d1c48
+thumb_func 0x80d1ab8 CheckFreePokemonStorageSpace
+thumb_func 0x80d1b10 CheckBoxMonSanityAt
+thumb_func 0x80d1b70 CountStorageNonEggMons
+thumb_func 0x80d1bdc CountAllStorageMons
+thumb_func 0x80d1c48 AnyStorageMonWithMove
 thumb_func 0x80d1ccc ResetWaldaWallpaper
-thumb_func 0x80d1d20
+thumb_func 0x80d1d20 SetWaldaWallpaperLockedOrUnlocked
 thumb_func 0x80d1d34
 thumb_func 0x80d1d48
 thumb_func 0x80d1d5c SetWaldaWallpaperPatternId
@@ -7033,7 +7033,7 @@ thumb_func 0x80d1d90 SetWaldaWallpaperIconId
 thumb_func 0x80d1db0
 thumb_func 0x80d1dc4 SetWaldaWallpaperColors
 thumb_func 0x80d1de8
-thumb_func 0x80d1dfc
+thumb_func 0x80d1dfc SetWaldaPhrase
 thumb_func 0x80d1e18 IsWaldaPhraseEmpty
 thumb_func 0x80d1e3c
 thumb_func 0x80d1e90
@@ -7052,31 +7052,31 @@ thumb_func 0x80d238c
 thumb_func 0x80d2428
 thumb_func 0x80d2460
 thumb_func 0x80d24bc
-thumb_func 0x80d2564
+thumb_func 0x80d2564 CreateMonIcon
 thumb_func 0x80d2618
 thumb_func 0x80d26a8 GetIconSpecies
-thumb_func 0x80d26e8
+thumb_func 0x80d26e8 GetUnownLetterByPersonality
 thumb_func 0x80d2724
 thumb_func 0x80d277c GetMonIconPtr
 thumb_func 0x80d2798
-thumb_func 0x80d27a4
-thumb_func 0x80d27c8
-thumb_func 0x80d2808
-thumb_func 0x80d283c
-thumb_func 0x80d2860
-thumb_func 0x80d2890
+thumb_func 0x80d27a4 LoadMonIconPalettes
+thumb_func 0x80d27c8 SafeLoadMonIconPalette
+thumb_func 0x80d2808 LoadMonIconPalette
+thumb_func 0x80d283c FreeMonIconPalettes
+thumb_func 0x80d2860 SafeFreeMonIconPalette
+thumb_func 0x80d2890 FreeMonIconPalette
 thumb_func 0x80d28b4
 thumb_func 0x80d28c0 GetMonIconTiles
 thumb_func 0x80d28ec
 thumb_func 0x80d2920 GetValidMonIconPalIndex
 thumb_func 0x80d2940
 thumb_func 0x80d2950 GetValidMonIconPalettePtr
-thumb_func 0x80d297c
-thumb_func 0x80d2a54
+thumb_func 0x80d297c UpdateMonIconFrame
+thumb_func 0x80d2a54 CreateMonIconSprite
 thumb_func 0x80d2b2c
 thumb_func 0x80d2b68
-thumb_func 0x80d2b88
-thumb_func 0x80d2be0
+thumb_func 0x80d2b88 ScriptMovement_StartObjectMovementScript
+thumb_func 0x80d2be0 ScriptMovement_IsObjectMovementFinished
 thumb_func 0x80d2c2c
 thumb_func 0x80d2c4c
 thumb_func 0x80d2c94
@@ -7088,139 +7088,139 @@ thumb_func 0x80d2da8
 thumb_func 0x80d2dcc
 thumb_func 0x80d2dfc
 thumb_func 0x80d2e24
-thumb_func 0x80d2e5c
+thumb_func 0x80d2e5c npc_obj_offscreen_culling_and_flag_update
 thumb_func 0x80d2e6c
 thumb_func 0x80d2e7c
-thumb_func 0x80d2ebc
+thumb_func 0x80d2ebc UnfreezeObjects
 thumb_func 0x80d2f00
 thumb_func 0x80d2f44
-thumb_func 0x80d2fb8
-thumb_func 0x80d32f0
+thumb_func 0x80d2fb8 SetUpFieldMove_Cut
+thumb_func 0x80d32f0 FieldCallback_CutGrass
 thumb_func 0x80d330c
-thumb_func 0x80d333c
+thumb_func 0x80d333c FieldCallback_CutTree
 thumb_func 0x80d335c
-thumb_func 0x80d338c
-thumb_func 0x80d33a0
-thumb_func 0x80d34b0
-thumb_func 0x80d35a8
-thumb_func 0x80d35fc
-thumb_func 0x80d3794
-thumb_func 0x80d3a00
-thumb_func 0x80d3a14
-thumb_func 0x80d3a70
-thumb_func 0x80d3adc
-thumb_func 0x80d3b58
-thumb_func 0x80d3bf4
+thumb_func 0x80d338c StartCutGrassFieldEffect
+thumb_func 0x80d33a0 FldEff_CutGrass
+thumb_func 0x80d34b0 SetCutGrassMetatile
+thumb_func 0x80d35a8 GetLongGrassCaseAt
+thumb_func 0x80d35fc SetCutGrassMetatiles
+thumb_func 0x80d3794 HandleLongGrassOnHyper
+thumb_func 0x80d3a00 CutGrassSpriteCallback1
+thumb_func 0x80d3a14 CutGrassSpriteCallback2
+thumb_func 0x80d3a70 CutGrassSpriteCallbackEnd
+thumb_func 0x80d3adc FixLongGrassMetatilesWindowTop
+thumb_func 0x80d3b58 FixLongGrassMetatilesWindowBottom
+thumb_func 0x80d3bf4 StartCutTreeFieldEffect
 thumb_func 0x80d3c0c ClearMailData
 thumb_func 0x80d3c3c ClearMailStruct
-thumb_func 0x80d3c90
+thumb_func 0x80d3c90 MonHasMail
 thumb_func 0x80d3cc0
 thumb_func 0x80d3e4c
 thumb_func 0x80d3e6c MailSpeciesToSpecies
-thumb_func 0x80d3e90
+thumb_func 0x80d3e90 GiveMailToMon2
 thumb_func 0x80d3f00
-thumb_func 0x80d3f04
+thumb_func 0x80d3f04 TakeMailFromMon
 thumb_func 0x80d3f64 ClearMailItemId
-thumb_func 0x80d3f84
+thumb_func 0x80d3f84 TakeMailFromMon2
 thumb_func 0x80d4040 ItemIsMail
 thumb_func 0x80d4058
-thumb_func 0x80d4068
-thumb_func 0x80d4100
-thumb_func 0x80d41f8
-thumb_func 0x80d4234
+thumb_func 0x80d4068 ShowMapNamePopup
+thumb_func 0x80d4100 Task_MapNamePopUpWindow
+thumb_func 0x80d41f8 HideMapNamePopUpWindow
+thumb_func 0x80d4234 DrawOptionMenuTexts
 thumb_func 0x80d42fc
-thumb_func 0x80d4464
-thumb_func 0x80d452c
-thumb_func 0x80d4584
-thumb_func 0x80d45bc
-thumb_func 0x80d4618
-thumb_func 0x80d4648
-thumb_func 0x80d4690
-thumb_func 0x80d46b8
+thumb_func 0x80d4464 LoadMapNamePopUpWindowBg
+thumb_func 0x80d452c RemoveBagSprite
+thumb_func 0x80d4584 AddBagVisualSprite
+thumb_func 0x80d45bc SetBagVisualPocketId
+thumb_func 0x80d4618 SpriteCB_BagVisualSwitchingPockets
+thumb_func 0x80d4648 ShakeBagVisual
+thumb_func 0x80d4690 SpriteCB_ShakeBagVisual
+thumb_func 0x80d46b8 AddSwitchPocketRotatingBallSprite
 thumb_func 0x80d4710 UpdateSwitchPocketRotatingBallCoords
-thumb_func 0x80d4734
+thumb_func 0x80d4734 SpriteCB_SwitchPocketRotatingBallInit
 thumb_func 0x80d4798 SpriteCB_SwitchPocketRotatingBallContinue
-thumb_func 0x80d47bc
+thumb_func 0x80d47bc AddBagItemIconSprite
 thumb_func 0x80d481c RemoveBagItemIconSprite
 thumb_func 0x80d4830
 thumb_func 0x80d484c
 thumb_func 0x80d4870
 thumb_func 0x80d489c
-thumb_func 0x80d48f4
-thumb_func 0x80d4958
-thumb_func 0x80d4990
-thumb_func 0x80d49a0
-thumb_func 0x80d4a10
-thumb_func 0x80d4a30
-thumb_func 0x80d4aa4
-thumb_func 0x80d4b54
-thumb_func 0x80d4c40
-thumb_func 0x80d4d08
-thumb_func 0x80d4d8c
-thumb_func 0x80d4ec8
+thumb_func 0x80d48f4 LoadBerryGfx
+thumb_func 0x80d4958 CreateBerryTagSprite
+thumb_func 0x80d4990 FreeBerryTagSpritePalette
+thumb_func 0x80d49a0 LoadSpinningBerryPicGfx
+thumb_func 0x80d4a10 CreateBerryFlavorCircleSprite
+thumb_func 0x80d4a30 AnimTask_ShakeMon
+thumb_func 0x80d4aa4 AnimTask_ShakeMonStep
+thumb_func 0x80d4b54 AnimTask_ShakeMon2
+thumb_func 0x80d4c40 AnimTask_ShakeMon2Step
+thumb_func 0x80d4d08 AnimTask_ShakeMonInPlace
+thumb_func 0x80d4d8c AnimTask_ShakeMonInPlaceStep
+thumb_func 0x80d4ec8 AnimTask_ShakeAndSinkMon
 thumb_func 0x80d4f10
-thumb_func 0x80d4f28
-thumb_func 0x80d4fbc
+thumb_func 0x80d4f28 AnimTask_ShakeAndSinkMonStep
+thumb_func 0x80d4fbc AnimTask_TranslateMonElliptical
 thumb_func 0x80d503c
-thumb_func 0x80d50b4
-thumb_func 0x80d50e4
-thumb_func 0x80d5158
-thumb_func 0x80d517c
-thumb_func 0x80d51c8
-thumb_func 0x80d51ec
-thumb_func 0x80d52a8
-thumb_func 0x80d5318
+thumb_func 0x80d50b4 AnimTask_TranslateMonEllipticalRespectSide
+thumb_func 0x80d50e4 DoHorizontalLunge
+thumb_func 0x80d5158 ReverseHorizontalLungeDirection
+thumb_func 0x80d517c DoVerticalDip
+thumb_func 0x80d51c8 ReverseVerticalDipDirection
+thumb_func 0x80d51ec SlideMonToOriginalPos
+thumb_func 0x80d52a8 SlideMonToOriginalPosStep
+thumb_func 0x80d5318 SlideMonToOffset
 thumb_func 0x80d53cc
 thumb_func 0x80d54a4
-thumb_func 0x80d54d4
-thumb_func 0x80d5568
-thumb_func 0x80d55cc
+thumb_func 0x80d54d4 AnimTask_WindUpLunge
+thumb_func 0x80d5568 AnimTask_WindUpLungePart1
+thumb_func 0x80d55cc AnimTask_WindUpLungePart2
 thumb_func 0x80d5634
 thumb_func 0x80d56f0
-thumb_func 0x80d573c
-thumb_func 0x80d57c0
-thumb_func 0x80d58e8
-thumb_func 0x80d5940
+thumb_func 0x80d573c AnimTask_SwayMon
+thumb_func 0x80d57c0 AnimTask_SwayMonStep
+thumb_func 0x80d58e8 AnimTask_ScaleMonAndRestore
+thumb_func 0x80d5940 AnimTask_ScaleMonAndRestoreStep
 thumb_func 0x80d59b8
 thumb_func 0x80d5ab0
 thumb_func 0x80d5b8c
 thumb_func 0x80d5c0c
 thumb_func 0x80d5cf0
 thumb_func 0x80d5dd8 GetBagItemQuantity
-thumb_func 0x80d5df0
+thumb_func 0x80d5df0 SetBagItemQuantity
 thumb_func 0x80d5e08
 thumb_func 0x80d5e0c
-thumb_func 0x80d5e10
-thumb_func 0x80d5e68
+thumb_func 0x80d5e10 ApplyNewEncryptionKeyToBagItems
+thumb_func 0x80d5e68 ApplyNewEncryptionKeyToBagItems_
 thumb_func 0x80d5e74 SetBagItemsPointers
 thumb_func 0x80d5ec8
-thumb_func 0x80d5f04
-thumb_func 0x80d5f3c
-thumb_func 0x80d5fdc
-thumb_func 0x80d6018
-thumb_func 0x80d6140
-thumb_func 0x80d62bc
-thumb_func 0x80d6480
-thumb_func 0x80d6494
-thumb_func 0x80d64c4
+thumb_func 0x80d5f04 IsBagPocketNonEmpty
+thumb_func 0x80d5f3c CheckBagHasItem
+thumb_func 0x80d5fdc HasAtLeastOneBerry
+thumb_func 0x80d6018 CheckBagHasSpace
+thumb_func 0x80d6140 AddBagItem
+thumb_func 0x80d62bc RemoveBagItem
+thumb_func 0x80d6480 GetPocketByItemId
+thumb_func 0x80d6494 ClearItemSlots
+thumb_func 0x80d64c4 FindFreePCItemSlot
 thumb_func 0x80d64fc CountUsedPCItemSlots
-thumb_func 0x80d6534
-thumb_func 0x80d6588
+thumb_func 0x80d6534 CheckPCHasItem
+thumb_func 0x80d6588 AddPCItem
 thumb_func 0x80d6660 RemovePCItem
 thumb_func 0x80d669c CompactPCItems
-thumb_func 0x80d66f4
+thumb_func 0x80d66f4 SwapRegisteredBike
 thumb_func 0x80d672c BagGetItemIdByPocketPosition
-thumb_func 0x80d6748
-thumb_func 0x80d6770
-thumb_func 0x80d677c
-thumb_func 0x80d67cc
+thumb_func 0x80d6748 BagGetQuantityByPocketPosition
+thumb_func 0x80d6770 SwapItemSlots
+thumb_func 0x80d677c CompactItemsInBagPocket
+thumb_func 0x80d67cc SortBerriesOrTMHMs
 thumb_func 0x80d6844 MoveItemSlotInList
 thumb_func 0x80d68ac ClearBag
-thumb_func 0x80d68d4
-thumb_func 0x80d6924
-thumb_func 0x80d699c
-thumb_func 0x80d6a1c
-thumb_func 0x80d6b4c
+thumb_func 0x80d68d4 CountTotalItemQuantityInBag
+thumb_func 0x80d6924 CheckPyramidBagHasItem
+thumb_func 0x80d699c CheckPyramidBagHasSpace
+thumb_func 0x80d6a1c AddPyramidBagItem
+thumb_func 0x80d6b4c RemovePyramidBagItem
 thumb_func 0x80d6c74 SanitizeItemId
 thumb_func 0x80d6c8c
 thumb_func 0x80d6cb0
@@ -7238,29 +7238,29 @@ thumb_func 0x80d6e44
 thumb_func 0x80d6e6c
 thumb_func 0x80d6e94 nullsub_63
 thumb_func 0x80d6e98
-thumb_func 0x80d6ea4
-thumb_func 0x80d6f50
-thumb_func 0x80d6fc8
-thumb_func 0x80d7010
+thumb_func 0x80d6ea4 SetupContestGpuRegs
+thumb_func 0x80d6f50 LoadContestBgAfterMoveAnim
+thumb_func 0x80d6fc8 InitContestInfoBgs
+thumb_func 0x80d7010 InitContestWindows
 thumb_func 0x80d7058
-thumb_func 0x80d70a8
-thumb_func 0x80d71b4
-thumb_func 0x80d7288
-thumb_func 0x80d7350
+thumb_func 0x80d70a8 InitContestResources
+thumb_func 0x80d71b4 AllocContestResources
+thumb_func 0x80d7288 FreeContestResources
+thumb_func 0x80d7350 CB2_StartContest
 thumb_func 0x80d74a8
 thumb_func 0x80d74e0
 thumb_func 0x80d75d8
 thumb_func 0x80d75f4
 thumb_func 0x80d7614
-thumb_func 0x80d7670
+thumb_func 0x80d7670 SetupContestGraphics
 thumb_func 0x80d78f4
 thumb_func 0x80d7934
-thumb_func 0x80d7a68
-thumb_func 0x80d7aa8
+thumb_func 0x80d7a68 CB2_ContestMain
+thumb_func 0x80d7aa8 vblank_cb_battle
 thumb_func 0x80d7b68
 thumb_func 0x80d7c50
 thumb_func 0x80d7cbc
-thumb_func 0x80d7e40
+thumb_func 0x80d7e40 ReadMail
 thumb_func 0x80d8038
 thumb_func 0x80d8064
 thumb_func 0x80d8090
@@ -7269,7 +7269,7 @@ thumb_func 0x80d8158
 thumb_func 0x80d8200
 thumb_func 0x80d824c
 thumb_func 0x80d8284
-thumb_func 0x80d8334
+thumb_func 0x80d8334 NamingScreen_Init
 thumb_func 0x80d9900
 thumb_func 0x80d9924
 thumb_func 0x80d9954
@@ -7301,18 +7301,18 @@ thumb_func 0x80da330
 thumb_func 0x80da460
 thumb_func 0x80da58c
 thumb_func 0x80da624
-thumb_func 0x80da664
+thumb_func 0x80da664 Rain_Main
 thumb_func 0x80da68c
 thumb_func 0x80da6a4
 thumb_func 0x80da6f8
 thumb_func 0x80da710
 thumb_func 0x80da744
 thumb_func 0x80da800
-thumb_func 0x80da828
+thumb_func 0x80da828 AnimTask_Splash
 thumb_func 0x80da884
 thumb_func 0x80da8d8
 thumb_func 0x80daa0c IsSpeciesNotUnown
-thumb_func 0x80daa20
+thumb_func 0x80daa20 SwapMoveDescAndContestTilemaps
 thumb_func 0x80daa50
 thumb_func 0x80daad4
 thumb_func 0x80dac44
@@ -7324,21 +7324,21 @@ thumb_func 0x80daeac
 thumb_func 0x80daefc
 thumb_func 0x80dafe8
 thumb_func 0x80db000
-thumb_func 0x80db01c
+thumb_func 0x80db01c GetChosenMove
 thumb_func 0x80db07c GetAllChosenMoves
-thumb_func 0x80db0a8
+thumb_func 0x80db0a8 RankContestants
 thumb_func 0x80db17c
-thumb_func 0x80db1cc
+thumb_func 0x80db1cc ContestantCanUseTurn
 thumb_func 0x80db204
-thumb_func 0x80db40c
+thumb_func 0x80db40c Contest_IsMonsTurnDisabled
 thumb_func 0x80db444
 thumb_func 0x80db47c
 thumb_func 0x80db498
-thumb_func 0x80db4b0
+thumb_func 0x80db4b0 DetermineFinalStandings
 thumb_func 0x80db638 SaveLinkContestResults
 thumb_func 0x80db694
-thumb_func 0x80db6cc
-thumb_func 0x80db6f4
+thumb_func 0x80db6cc ContestPrintLinkStandby
+thumb_func 0x80db6f4 FillContestantWindowBgs
 thumb_func 0x80db72c
 thumb_func 0x80db760
 thumb_func 0x80db78c
@@ -7351,7 +7351,7 @@ thumb_func 0x80dbb6c
 thumb_func 0x80dbbb0
 thumb_func 0x80dbbf4
 thumb_func 0x80dbc54
-thumb_func 0x80dbcf8
+thumb_func 0x80dbcf8 CreateApplauseMeterSprite
 thumb_func 0x80dbd4c
 thumb_func 0x80dbd94
 thumb_func 0x80dbdd8
@@ -7363,36 +7363,36 @@ thumb_func 0x80dbfc8
 thumb_func 0x80dbfe0
 thumb_func 0x80dc034
 thumb_func 0x80dc118
-thumb_func 0x80dc150
+thumb_func 0x80dc150 IsMetatileDirectionallyImpassable
 thumb_func 0x80dc2dc
 thumb_func 0x80dc318
 thumb_func 0x80dc334
 thumb_func 0x80dc34c
 thumb_func 0x80dc3e8
 thumb_func 0x80dc43c
-thumb_func 0x80dc46c
-thumb_func 0x80dc4ac
-thumb_func 0x80dc5bc
-thumb_func 0x80dc7b0
+thumb_func 0x80dc46c ContestDebugTogglePointTotal
+thumb_func 0x80dc4ac ContestDebugDoPrint
+thumb_func 0x80dc5bc SortContestants
+thumb_func 0x80dc7b0 DrawContestantWindows
 thumb_func 0x80dc7e4
 thumb_func 0x80dcb38 SetContestantEffectStringID
 thumb_func 0x80dcb54 SetContestantEffectStringID2
 thumb_func 0x80dcb70 SetStartledString
 thumb_func 0x80dcbc0
 thumb_func 0x80dccc4 MakeContestantNervous
-thumb_func 0x80dccf4
+thumb_func 0x80dccf4 ApplyNextTurnOrder
 thumb_func 0x80dce40
 thumb_func 0x80dce84
-thumb_func 0x80dd0a4
+thumb_func 0x80dd0a4 UpdateApplauseMeter
 thumb_func 0x80dd154 Contest_GetMoveExcitement
-thumb_func 0x80dd184
-thumb_func 0x80dd1c4
-thumb_func 0x80dd270
-thumb_func 0x80dd2d0
-thumb_func 0x80dd34c
-thumb_func 0x80dd3b0
-thumb_func 0x80dd440
-thumb_func 0x80dd484
+thumb_func 0x80dd184 StartApplauseOverflowAnimation
+thumb_func 0x80dd1c4 Task_ApplauseOverflowAnimation
+thumb_func 0x80dd270 StartMoveApplauseMeterOnscreen
+thumb_func 0x80dd2d0 Task_MoveApplauseMeterOnscreen
+thumb_func 0x80dd34c TryMoveApplauseMeterOffscreen
+thumb_func 0x80dd3b0 Task_MoveApplauseMeterOffscreen
+thumb_func 0x80dd440 ShowAndUpdateApplauseMeter
+thumb_func 0x80dd484 Task_ShowAndUpdateApplauseMeter
 thumb_func 0x80dd50c HideApplauseMeterNoAnim
 thumb_func 0x80dd548 ShowApplauseMeterNoAnim
 thumb_func 0x80dd570
@@ -7400,7 +7400,7 @@ thumb_func 0x80dd594
 thumb_func 0x80dd634
 thumb_func 0x80dd6e4
 thumb_func 0x80dd76c
-thumb_func 0x80dd854
+thumb_func 0x80dd854 GetTurnOrderNumberGfx
 thumb_func 0x80dd890
 thumb_func 0x80dd94c
 thumb_func 0x80dd988
@@ -7420,13 +7420,13 @@ thumb_func 0x80de114
 thumb_func 0x80de140
 thumb_func 0x80de184
 thumb_func 0x80de1c0
-thumb_func 0x80de20c
+thumb_func 0x80de20c SelectContestMoveBankTarget
 thumb_func 0x80de2d4
-thumb_func 0x80de338
-thumb_func 0x80de3c0
+thumb_func 0x80de338 Contest_StartTextPrinter
+thumb_func 0x80de3c0 ContestBG_FillBoxWithIncrementingTile
 thumb_func 0x80de418 ContestBG_FillBoxWithTile
-thumb_func 0x80de454
-thumb_func 0x80de468
+thumb_func 0x80de454 GetPlayerTextSpeed
+thumb_func 0x80de468 Contest_SetBgCopyFlags
 thumb_func 0x80de47c ResetContestLinkResults
 thumb_func 0x80de4b0
 thumb_func 0x80de6b0
@@ -7434,65 +7434,65 @@ thumb_func 0x80de748 ClearContestWinnerPicsInContestHall
 thumb_func 0x80de788
 thumb_func 0x80de958
 thumb_func 0x80dec00
-thumb_func 0x80dede0
+thumb_func 0x80dede0 ContestDebugToggleBitfields
 thumb_func 0x80dee2c
 thumb_func 0x80deff0
 thumb_func 0x80df098
 thumb_func 0x80df0a4 SetShopItemsForSale
-thumb_func 0x80df0d4
+thumb_func 0x80df0d4 Task_ShopMenu
 thumb_func 0x80df11c
 thumb_func 0x80df158
 thumb_func 0x80df194
-thumb_func 0x80df1b4
-thumb_func 0x80df1f0
-thumb_func 0x80df22c
-thumb_func 0x80df244
-thumb_func 0x80df290
+thumb_func 0x80df1b4 Task_HandleShopMenuQuit
+thumb_func 0x80df1f0 Task_GoToBuyOrSellMenu
+thumb_func 0x80df22c MapPostLoadHook_ReturnToShopMenu
+thumb_func 0x80df244 Task_ReturnToShopMenu
+thumb_func 0x80df290 ShowShopMenuAfterExitingBuyOrSellMenu
 thumb_func 0x80df2b0
-thumb_func 0x80df2cc
-thumb_func 0x80df2e0
-thumb_func 0x80df448
+thumb_func 0x80df2cc VBlankCB_BuyMenu
+thumb_func 0x80df2e0 CB2_InitBuyMenu
+thumb_func 0x80df448 BuyMenuFreeMemory
 thumb_func 0x80df478
-thumb_func 0x80df554
-thumb_func 0x80df594
+thumb_func 0x80df554 BuyMenuSetListEntry
+thumb_func 0x80df594 BuyMenuPrintItemDescriptionAndShowItemIcon
 thumb_func 0x80df670
-thumb_func 0x80df70c
-thumb_func 0x80df768
-thumb_func 0x80df794
-thumb_func 0x80df7c8
-thumb_func 0x80df860
-thumb_func 0x80df8b0
-thumb_func 0x80df968
-thumb_func 0x80df9ac
+thumb_func 0x80df70c BuyMenuAddScrollIndicatorArrows
+thumb_func 0x80df768 BuyMenuRemoveScrollIndicatorArrows
+thumb_func 0x80df794 BuyMenuPrintCursor
+thumb_func 0x80df7c8 BuyMenuAddItemIcon
+thumb_func 0x80df860 BuyMenuRemoveItemIcon
+thumb_func 0x80df8b0 BuyMenuInitBgs
+thumb_func 0x80df968 BuyMenuDecompressBgGraphics
+thumb_func 0x80df9ac BuyMenuInitWindows
 thumb_func 0x80df9e8
-thumb_func 0x80dfa2c
-thumb_func 0x80dfa68
-thumb_func 0x80dfab4
-thumb_func 0x80dfac8
-thumb_func 0x80dfbb4
+thumb_func 0x80dfa2c BuyMenuDisplayMessage
+thumb_func 0x80dfa68 BuyMenuDrawGraphics
+thumb_func 0x80dfab4 BuyMenuDrawMapGraphics
+thumb_func 0x80dfac8 BuyMenuDrawMapBg
+thumb_func 0x80dfbb4 BuyMenuDrawMapMetatile
 thumb_func 0x80dfc78 BuyMenuDrawMapMetatileLayer
-thumb_func 0x80dfca0
-thumb_func 0x80dfe34
+thumb_func 0x80dfca0 BuyMenuCollectEventObjectData
+thumb_func 0x80dfe34 BuyMenuDrawEventObjects
 thumb_func 0x80dff58 BuyMenuCheckIfEventObjectOverlapsMenuBg
 thumb_func 0x80dff84 BuyMenuCopyMenuBgToBg1TilemapBuffer
-thumb_func 0x80dffcc
-thumb_func 0x80e000c
-thumb_func 0x80e01f0
-thumb_func 0x80e02d4
-thumb_func 0x80e03f8
-thumb_func 0x80e0428
-thumb_func 0x80e04d4
-thumb_func 0x80e0558
-thumb_func 0x80e05c4
-thumb_func 0x80e05ec
-thumb_func 0x80e0638
-thumb_func 0x80e06b4
-thumb_func 0x80e06fc
-thumb_func 0x80e0730
-thumb_func 0x80e0750
-thumb_func 0x80e07d0
-thumb_func 0x80e07f4
-thumb_func 0x80e0814
+thumb_func 0x80dffcc BuyMenuCheckForOverlapWithMenuBg
+thumb_func 0x80e000c Task_BuyMenu
+thumb_func 0x80e01f0 Task_BuyHowManyDialogueInit
+thumb_func 0x80e02d4 Task_BuyHowManyDialogueHandleInput
+thumb_func 0x80e03f8 BuyMenuConfirmPurchase
+thumb_func 0x80e0428 BuyMenuTryMakePurchase
+thumb_func 0x80e04d4 BuyMenuSubtractMoney
+thumb_func 0x80e0558 Task_ReturnToItemListAfterItemPurchase
+thumb_func 0x80e05c4 Task_ReturnToItemListAfterDecorationPurchase
+thumb_func 0x80e05ec BuyMenuReturnToItemList
+thumb_func 0x80e0638 BuyMenuPrintItemQuantityAndPrice
+thumb_func 0x80e06b4 ExitBuyMenu
+thumb_func 0x80e06fc Task_ExitBuyMenu
+thumb_func 0x80e0730 ClearItemPurchases
+thumb_func 0x80e0750 RecordItemPurchase
+thumb_func 0x80e07d0 CreatePokemartMenu
+thumb_func 0x80e07f4 CreateDecorationShop1Menu
+thumb_func 0x80e0814 CreateDecorationShop2Menu
 thumb_func 0x80e0834
 thumb_func 0x80e0990
 thumb_func 0x80e0a58
@@ -7502,69 +7502,69 @@ thumb_func 0x80e0ad0
 thumb_func 0x80e0b04
 thumb_func 0x80e0b30 SetEnigmaBerry
 thumb_func 0x80e0b5c GetEnigmaBerryChecksum
-thumb_func 0x80e0b78
-thumb_func 0x80e0bc8
-thumb_func 0x80e0c0c
-thumb_func 0x80e0c28
-thumb_func 0x80e0c84
-thumb_func 0x80e0cbc
+thumb_func 0x80e0b78 IsEnigmaBerryValid
+thumb_func 0x80e0bc8 GetBerryInfo
+thumb_func 0x80e0c0c GetBerryTreeInfo
+thumb_func 0x80e0c28 EventObjectInteractionWaterBerryTree
+thumb_func 0x80e0c84 IsPlayerFacingEmptyBerryTreePatch
+thumb_func 0x80e0cbc TryToWaterBerryTree
 thumb_func 0x80e0ce0 ClearBerryTrees
-thumb_func 0x80e0d14
-thumb_func 0x80e0dbc
-thumb_func 0x80e0e68
+thumb_func 0x80e0d14 BerryTreeGrow
+thumb_func 0x80e0dbc BerryTreeTimeUpdate
+thumb_func 0x80e0e68 PlantBerryTree
 thumb_func 0x80e0ed0 RemoveBerryTree
-thumb_func 0x80e0ef8
+thumb_func 0x80e0ef8 GetBerryTypeByBerryTreeId
 thumb_func 0x80e0f14 GetStageByBerryTreeId
 thumb_func 0x80e0f34 ItemIdToBerryType
 thumb_func 0x80e0f5c BerryTypeToItemId
-thumb_func 0x80e0f84
-thumb_func 0x80e0fa4
+thumb_func 0x80e0f84 GetBerryNameByBerryType
+thumb_func 0x80e0fa4 ResetBerryTreeSparkleFlag
 thumb_func 0x80e0fbc BerryTreeGetNumStagesWatered
-thumb_func 0x80e0ff8
-thumb_func 0x80e1010
-thumb_func 0x80e1064
+thumb_func 0x80e0ff8 GetNumStagesWateredByBerryTreeId
+thumb_func 0x80e1010 CalcBerryYieldInternal
+thumb_func 0x80e1064 CalcBerryYield
 thumb_func 0x80e1090 GetBerryCountByBerryTreeId
-thumb_func 0x80e10a8
-thumb_func 0x80e10c0
+thumb_func 0x80e10a8 GetStageDurationByBerryType
+thumb_func 0x80e10c0 EventObjectInteractionGetBerryTreeData
 thumb_func 0x80e1154
 thumb_func 0x80e1164
-thumb_func 0x80e119c
+thumb_func 0x80e119c EventObjectInteractionPickBerryTree
 thumb_func 0x80e11e8
-thumb_func 0x80e121c
-thumb_func 0x80e122c
-thumb_func 0x80e12c8
-thumb_func 0x80e1318
+thumb_func 0x80e121c PlayerHasBerries
+thumb_func 0x80e122c ResetBerryTreeSparkleFlags
+thumb_func 0x80e12c8 ScriptMenu_Multichoice
+thumb_func 0x80e1318 ScriptMenu_MultichoiceWithDefault
 thumb_func 0x80e1378
 thumb_func 0x80e13bc
 thumb_func 0x80e13fc
 thumb_func 0x80e14cc
-thumb_func 0x80e1568
-thumb_func 0x80e1618
-thumb_func 0x80e1650
-thumb_func 0x80e166c
+thumb_func 0x80e1568 Task_HandleMultichoiceInput
+thumb_func 0x80e1618 ScriptMenu_YesNo
+thumb_func 0x80e1650 IsScriptActive
+thumb_func 0x80e166c Task_HandleYesNoInput
 thumb_func 0x80e16e0
-thumb_func 0x80e17ec
+thumb_func 0x80e17ec Task_HandleMultichoiceGridInput
 thumb_func 0x80e1850
-thumb_func 0x80e1880
-thumb_func 0x80e1a0c
+thumb_func 0x80e1880 ShowDomeResultsWindow
+thumb_func 0x80e1a0c ScriptMenu_DisplayPCStartupPrompt
 thumb_func 0x80e1a40
 thumb_func 0x80e1a70
 thumb_func 0x80e1d6c
-thumb_func 0x80e1d8c
-thumb_func 0x80e1df4
-thumb_func 0x80e1eb8
-thumb_func 0x80e1ef0
-thumb_func 0x80e1f10
+thumb_func 0x80e1d8c Task_PokemonPicWindow
+thumb_func 0x80e1df4 ScriptMenu_ShowPokemonPic
+thumb_func 0x80e1eb8 ScriptMenu_GetPicboxWaitFunc
+thumb_func 0x80e1ef0 IsPicboxClosed
+thumb_func 0x80e1f10 CreateWindowFromRect
 thumb_func 0x80e1f6c
 thumb_func 0x80e1f88
 thumb_func 0x80e2070
 thumb_func 0x80e20a0
 thumb_func 0x80e21f8
-thumb_func 0x80e2244
-thumb_func 0x80e22d0
+thumb_func 0x80e2244 DoNamingScreen
+thumb_func 0x80e22d0 C2_NamingScreen
 thumb_func 0x80e2374
 thumb_func 0x80e246c
-thumb_func 0x80e24ac
+thumb_func 0x80e24ac NamingScreen_InitBGs
 thumb_func 0x80e265c
 thumb_func 0x80e2678
 thumb_func 0x80e270c
@@ -7572,26 +7572,26 @@ thumb_func 0x80e2734
 thumb_func 0x80e2758
 thumb_func 0x80e2788
 thumb_func 0x80e27b8
-thumb_func 0x80e28f0
-thumb_func 0x80e292c
-thumb_func 0x80e293c
-thumb_func 0x80e296c
-thumb_func 0x80e29dc
-thumb_func 0x80e2a10
-thumb_func 0x80e2a78
+thumb_func 0x80e28f0 MainState_WaitFadeIn
+thumb_func 0x80e292c MainState_HandleInput
+thumb_func 0x80e293c MainState_MoveToOKButton
+thumb_func 0x80e296c MainState_6
+thumb_func 0x80e29dc MainState_BeginFadeInOut
+thumb_func 0x80e2a10 MainState_WaitFadeOutAndExit
+thumb_func 0x80e2a78 DisplaySentToPCMessage
 thumb_func 0x80e2b98
 thumb_func 0x80e2bd4
 thumb_func 0x80e2c14
-thumb_func 0x80e2c6c
+thumb_func 0x80e2c6c StartPageSwapAnim
 thumb_func 0x80e2c8c
-thumb_func 0x80e2cc4
+thumb_func 0x80e2cc4 IsPageSwapAnimNotInProgress
 thumb_func 0x80e2ce4 PageSwapAnimState_Init
-thumb_func 0x80e2d0c
-thumb_func 0x80e2da0
-thumb_func 0x80e2e34
+thumb_func 0x80e2d0c PageSwapAnimState_1
+thumb_func 0x80e2da0 PageSwapAnimState_2
+thumb_func 0x80e2e34 PageSwapAnimState_Done
 thumb_func 0x80e2e50
 thumb_func 0x80e2e78
-thumb_func 0x80e2eec
+thumb_func 0x80e2eec Task_80E39BC
 thumb_func 0x80e2fa4
 thumb_func 0x80e3018
 thumb_func 0x80e3040
@@ -7599,7 +7599,7 @@ thumb_func 0x80e3060
 thumb_func 0x80e3144
 thumb_func 0x80e3190
 thumb_func 0x80e31ec
-thumb_func 0x80e3208
+thumb_func 0x80e3208 CursorInit
 thumb_func 0x80e329c
 thumb_func 0x80e32e4 GetCursorPos
 thumb_func 0x80e3310
@@ -7608,7 +7608,7 @@ thumb_func 0x80e3378
 thumb_func 0x80e33bc
 thumb_func 0x80e33e8 IsCursorAnimFinished
 thumb_func 0x80e3414
-thumb_func 0x80e344c
+thumb_func 0x80e344c CreatePageSwitcherSprites
 thumb_func 0x80e3510
 thumb_func 0x80e3544
 thumb_func 0x80e356c
@@ -7616,27 +7616,27 @@ thumb_func 0x80e35c0
 thumb_func 0x80e35c4
 thumb_func 0x80e3638
 thumb_func 0x80e3678
-thumb_func 0x80e36d8
+thumb_func 0x80e36d8 CreateBackOkSprites
 thumb_func 0x80e3750
-thumb_func 0x80e3820
+thumb_func 0x80e3820 CreateInputTargetIcon
 thumb_func 0x80e383c nullsub_641
 thumb_func 0x80e384c nullsub_65
-thumb_func 0x80e3850
-thumb_func 0x80e38ac
-thumb_func 0x80e38ec
-thumb_func 0x80e3948
-thumb_func 0x80e3988
-thumb_func 0x80e39e4
-thumb_func 0x80e3a30
-thumb_func 0x80e3a58
-thumb_func 0x80e3a7c
+thumb_func 0x80e3850 NamingScreen_CreatePlayerIcon
+thumb_func 0x80e38ac NamingScreen_CreatePCIcon
+thumb_func 0x80e38ec NamingScreen_CreateMonIcon
+thumb_func 0x80e3948 NamingScreen_CreateWandaDadIcon
+thumb_func 0x80e3988 HandleKeyboardEvent
+thumb_func 0x80e39e4 KeyboardKeyHandler_Character
+thumb_func 0x80e3a30 KeyboardKeyHandler_Page
+thumb_func 0x80e3a58 KeyboardKeyHandler_Backspace
+thumb_func 0x80e3a7c KeyboardKeyHandler_OK
 thumb_func 0x80e3ab8
 thumb_func 0x80e3ad0
-thumb_func 0x80e3ae4
-thumb_func 0x80e3b08
+thumb_func 0x80e3ae4 GetInputEvent
+thumb_func 0x80e3b08 SetInputState
 thumb_func 0x80e3b34
 thumb_func 0x80e3b64
-thumb_func 0x80e3b6c
+thumb_func 0x80e3b6c InputState_Enabled
 thumb_func 0x80e3bd0
 thumb_func 0x80e3bf4
 thumb_func 0x80e3d50
@@ -7648,20 +7648,20 @@ thumb_func 0x80e3e68 nullsub_67
 thumb_func 0x80e3e78 nullsub_68
 thumb_func 0x80e3e7c
 thumb_func 0x80e3eec
-thumb_func 0x80e3f20
-thumb_func 0x80e3f74
-thumb_func 0x80e3fb8
+thumb_func 0x80e3f20 GetTextCaretPosition
+thumb_func 0x80e3f74 GetPreviousTextCaretPosition
+thumb_func 0x80e3fb8 DeleteTextCharacter
 thumb_func 0x80e4018
 thumb_func 0x80e40a8
 thumb_func 0x80e4110
 thumb_func 0x80e414c
-thumb_func 0x80e4188
+thumb_func 0x80e4188 AddTextCharacter
 thumb_func 0x80e41b0
 thumb_func 0x80e4208
 thumb_func 0x80e4248
-thumb_func 0x80e4318
+thumb_func 0x80e4318 GetMultiplayerId_
 thumb_func 0x80e437c
-thumb_func 0x80e43ec
+thumb_func 0x80e43ec choose_name_or_words_screen_load_bg_tile_patterns
 thumb_func 0x80e4450
 thumb_func 0x80e4460
 thumb_func 0x80e4490
@@ -7671,9 +7671,9 @@ thumb_func 0x80e45d0
 thumb_func 0x80e4648
 thumb_func 0x80e46e4
 thumb_func 0x80e474c
-thumb_func 0x80e4764
-thumb_func 0x80e4778
-thumb_func 0x80e4788
+thumb_func 0x80e4764 NamingScreen_TurnOffScreen
+thumb_func 0x80e4778 NamingScreen_InitDisplayMode
+thumb_func 0x80e4788 VBlankCB_NamingScreen
 thumb_func 0x80e4810
 thumb_func 0x80e4830
 thumb_func 0x80e4868
@@ -7687,104 +7687,104 @@ thumb_func 0x80e4948 AddMoney
 thumb_func 0x80e4980 RemoveMoney
 thumb_func 0x80e49a4 IsEnoughForCostInVar0x8005
 thumb_func 0x80e49c8 SubtractMoneyFromVar0x8005
-thumb_func 0x80e49e8
-thumb_func 0x80e4a08
-thumb_func 0x80e4a74
-thumb_func 0x80e4ab0
-thumb_func 0x80e4ac8
-thumb_func 0x80e4b60
-thumb_func 0x80e4b88
-thumb_func 0x80e4bd0
-thumb_func 0x80e4bf0
+thumb_func 0x80e49e8 PrintMoneyAmountInMoneyBox
+thumb_func 0x80e4a08 CreateBicycleAnimationTask
+thumb_func 0x80e4a74 PrintMoneyAmountInMoneyBoxWithBorder
+thumb_func 0x80e4ab0 ChangeAmountInMoneyBox
+thumb_func 0x80e4ac8 DrawMoneyBox
+thumb_func 0x80e4b60 HideMoneyBox
+thumb_func 0x80e4b88 AddMoneyLabelObject
+thumb_func 0x80e4bd0 RemoveMoneyLabelObject
+thumb_func 0x80e4bf0 AreMovesContestCombo
 thumb_func 0x80e4c58 nullsub_21
-thumb_func 0x80e4c5c
-thumb_func 0x80e4c8c
+thumb_func 0x80e4c5c ContestEffect_UserMoreEasilyStartled
+thumb_func 0x80e4c8c ContestEffect_GreatAppealButNoMoreMoves
 thumb_func 0x80e4cbc ContestEffect_RepetitionNotBoring
-thumb_func 0x80e4d10
-thumb_func 0x80e4d3c
-thumb_func 0x80e4d6c
-thumb_func 0x80e4d98
-thumb_func 0x80e4dc8
-thumb_func 0x80e4e40
-thumb_func 0x80e4ebc
-thumb_func 0x80e4ef4
-thumb_func 0x80e4fa8
-thumb_func 0x80e5068
-thumb_func 0x80e5114
-thumb_func 0x80e514c
-thumb_func 0x80e518c
-thumb_func 0x80e51ac
+thumb_func 0x80e4d10 ContestEffect_AvoidStartleOnce
+thumb_func 0x80e4d3c ContestEffect_AvoidStartle
+thumb_func 0x80e4d6c ContestEffect_AvoidStartleSlightly
+thumb_func 0x80e4d98 ContestEffect_UserLessEasilyStartled
+thumb_func 0x80e4dc8 ContestEffect_StartleFrontMon
+thumb_func 0x80e4e40 ContestEffect_StartlePrevMons
+thumb_func 0x80e4ebc ContestEffect_StartlePrevMon2
+thumb_func 0x80e4ef4 ContestEffect_StartlePrevMons2
+thumb_func 0x80e4fa8 ContestEffect_ShiftJudgeAttention
+thumb_func 0x80e5068 ContestEffect_StartleMonWithJudgesAttention
+thumb_func 0x80e5114 ContestEffect_JamsOthersButMissOneTurn
+thumb_func 0x80e514c ContestEffect_StartleMonsSameTypeAppeal
+thumb_func 0x80e518c ContestEffect_StartleMonsCoolAppeal
+thumb_func 0x80e51ac ContestEffect_StartleMonsBeautyAppeal
 thumb_func 0x80e51cc
-thumb_func 0x80e51ec
-thumb_func 0x80e520c
-thumb_func 0x80e522c
-thumb_func 0x80e52b0
-thumb_func 0x80e54b0
-thumb_func 0x80e5558
-thumb_func 0x80e55e0
-thumb_func 0x80e5638
-thumb_func 0x80e5690
-thumb_func 0x80e5740
-thumb_func 0x80e57c0
-thumb_func 0x80e5844
-thumb_func 0x80e58f8
-thumb_func 0x80e59e8
-thumb_func 0x80e5a94
-thumb_func 0x80e5b10
-thumb_func 0x80e5b74
-thumb_func 0x80e5bc4
-thumb_func 0x80e5cfc
+thumb_func 0x80e51ec ContestEffect_StartleMonsSmartAppeal
+thumb_func 0x80e520c ContestEffect_StartleMonsToughAppeal
+thumb_func 0x80e522c ContestEffect_MakeFollowingMonNervous
+thumb_func 0x80e52b0 ContestEffect_MakeFollowingMonsNervous
+thumb_func 0x80e54b0 ContestEffect_WorsenConditionOfPrevMons
+thumb_func 0x80e5558 ContestEffect_BadlyStartlesMonsInGoodCondition
+thumb_func 0x80e55e0 ContestEffect_BetterIfFirst
+thumb_func 0x80e5638 ContestEffect_BetterIfLast
+thumb_func 0x80e5690 ContestEffect_AppealAsGoodAsPrevOnes
+thumb_func 0x80e5740 ContestEffect_AppealAsGoodAsPrevOne
+thumb_func 0x80e57c0 ContestEffect_BetterWhenLater
+thumb_func 0x80e5844 ContestEffect_QualityDependsOnTiming
+thumb_func 0x80e58f8 ContestEffect_BetterIfSameType
+thumb_func 0x80e59e8 ContestEffect_BetterIfDiffType
+thumb_func 0x80e5a94 ContestEffect_AffectedByPrevAppeal
+thumb_func 0x80e5b10 ContestEffect_ImproveConditionPreventNervousness
+thumb_func 0x80e5b74 ContestEffect_BetterWithGoodCondition
+thumb_func 0x80e5bc4 ContestEffect_NextAppealEarlier
+thumb_func 0x80e5cfc ContestEffect_NextAppealLater
 thumb_func 0x80e5e40 nullsub_20
-thumb_func 0x80e5e44
+thumb_func 0x80e5e44 ContestEffect_ScrambleNextTurnOrder
 thumb_func 0x80e5f54 ContestEffect_ExciteAudienceInAnyContest
-thumb_func 0x80e5f98
-thumb_func 0x80e6044
-thumb_func 0x80e60c8
-thumb_func 0x80e6110
-thumb_func 0x80e61a4
-thumb_func 0x80e6208
+thumb_func 0x80e5f98 ContestEffect_BadlyStartleMonsWithGoodAppeals
+thumb_func 0x80e6044 ContestEffect_BetterWhenAudienceExcited
+thumb_func 0x80e60c8 ContestEffect_DontExciteAudience
+thumb_func 0x80e6110 JamByMoveCategory
+thumb_func 0x80e61a4 CanUnnerveContestant
+thumb_func 0x80e6208 WasAtLeastOneOpponentJammed
 thumb_func 0x80e6318 JamContestant
-thumb_func 0x80e634c
-thumb_func 0x80e6390
-thumb_func 0x80e63c4
+thumb_func 0x80e634c RoundTowardsZero
+thumb_func 0x80e6390 RoundUp
+thumb_func 0x80e63c4 RecordMixingPlayerSpotTriggered
 thumb_func 0x80e63d4 SetSrcLookupPointers
-thumb_func 0x80e647c
+thumb_func 0x80e647c PrepareUnknownExchangePacket
 thumb_func 0x80e6530
-thumb_func 0x80e6604
-thumb_func 0x80e6738
-thumb_func 0x80e68cc
-thumb_func 0x80e6900
-thumb_func 0x80e6934
-thumb_func 0x80e6afc
-thumb_func 0x80e6d44
-thumb_func 0x80e6e08
+thumb_func 0x80e6604 PrepareExchangePacket
+thumb_func 0x80e6738 ReceiveExchangePacket
+thumb_func 0x80e68cc PrintTextOnRecordMixing
+thumb_func 0x80e6900 Task_RecordMixing_SoundEffect
+thumb_func 0x80e6934 Task_RecordMixing_Main
+thumb_func 0x80e6afc Task_MixingRecordsRecv
+thumb_func 0x80e6d44 Task_SendPacket
+thumb_func 0x80e6e08 Task_CopyReceiveBuffer
 thumb_func 0x80e6f44
 thumb_func 0x80e6f78 Task_ReceivePacket
 thumb_func 0x80e6fac Task_SendPacket_SwitchToReceive
-thumb_func 0x80e6fd4
-thumb_func 0x80e6fe0
+thumb_func 0x80e6fd4 LoadPtrFromTaskData
+thumb_func 0x80e6fe0 StorePtrInTaskData
 thumb_func 0x80e6fe8
-thumb_func 0x80e6ff8
-thumb_func 0x80e7008
+thumb_func 0x80e6ff8 GetPlayerRecvBuffer
+thumb_func 0x80e7008 ShufflePlayerIndices
 thumb_func 0x80e709c
 thumb_func 0x80e711c
-thumb_func 0x80e71e4
+thumb_func 0x80e71e4 ReceiveLilycoveLadyData
 thumb_func 0x80e726c
 thumb_func 0x80e7274
 thumb_func 0x80e72fc
 thumb_func 0x80e7324
 thumb_func 0x80e7330
-thumb_func 0x80e7750
-thumb_func 0x80e77e0
+thumb_func 0x80e7750 ReceiveGiftItem
+thumb_func 0x80e77e0 Task_DoRecordMixing
 thumb_func 0x80e78f8
-thumb_func 0x80e7a48
+thumb_func 0x80e7a48 GetPlayerHallRecords
 thumb_func 0x80e7c04
-thumb_func 0x80e7c50
+thumb_func 0x80e7c50 ReceiveApprenticeData
 thumb_func 0x80e7d60
 thumb_func 0x80e8068
 thumb_func 0x80e80b4
 thumb_func 0x80e810c
-thumb_func 0x80e8194
+thumb_func 0x80e8194 ReceiveRankingHallRecords
 thumb_func 0x80e81e0
 thumb_func 0x80e823c
 thumb_func 0x80e8290
@@ -7810,98 +7810,98 @@ thumb_func 0x80e9284
 thumb_func 0x80e9410
 thumb_func 0x80e94b8
 thumb_func 0x80e9560
-thumb_func 0x80e96a8
+thumb_func 0x80e96a8 PutFirstMemBlockHeader
 thumb_func 0x80e96c8
 thumb_func 0x80e96dc
 thumb_func 0x80e9734
-thumb_func 0x80e9750
-thumb_func 0x80e977c
+thumb_func 0x80e9750 RemoveTrainerHillRecordsWindow
+thumb_func 0x80e977c ClearSecretBase
 thumb_func 0x80e97b4 ClearSecretBases
-thumb_func 0x80e97e4
-thumb_func 0x80e97f8
-thumb_func 0x80e9854
-thumb_func 0x80e9884
+thumb_func 0x80e97e4 SetCurSecretBaseId
+thumb_func 0x80e97f8 TrySetCurSecretBaseIndex
+thumb_func 0x80e9854 CheckPlayerHasSecretBase
+thumb_func 0x80e9884 GetSecretBaseTypeInFrontOfPlayer_
 thumb_func 0x80e9924 GetSecretBaseTypeInFrontOfPlayer
-thumb_func 0x80e993c
-thumb_func 0x80e99d8
+thumb_func 0x80e993c FindMetatileIdMapCoords
+thumb_func 0x80e99d8 ToggleSecretBaseEntranceMetatile
 thumb_func 0x80e9a80 GetNameLength
-thumb_func 0x80e9aa4
-thumb_func 0x80e9b6c
-thumb_func 0x80e9c28
-thumb_func 0x80e9c5c
-thumb_func 0x80e9cf4
-thumb_func 0x80e9d28
-thumb_func 0x80e9d54
-thumb_func 0x80e9d94
-thumb_func 0x80e9df8
+thumb_func 0x80e9aa4 SetPlayerSecretBase
+thumb_func 0x80e9b6c SetOccupiedSecretBaseEntranceMetatiles
+thumb_func 0x80e9c28 SetSecretBaseWarpDestination
+thumb_func 0x80e9c5c Task_EnterSecretBase
+thumb_func 0x80e9cf4 EnterSecretBase
+thumb_func 0x80e9d28 SecretBaseMapPopupEnabled
+thumb_func 0x80e9d54 EnterNewlyCreatedSecretBase_WaitFadeIn
+thumb_func 0x80e9d94 EnterNewlyCreatedSecretBase_StartFadeIn
+thumb_func 0x80e9df8 Task_EnterNewlyCreatedSecretBase
 thumb_func 0x80e9e84
-thumb_func 0x80e9ea0
+thumb_func 0x80e9ea0 CurMapIsSecretBase
 thumb_func 0x80e9ec4
-thumb_func 0x80e9fd4
-thumb_func 0x80ea218
-thumb_func 0x80ea274
-thumb_func 0x80ea2a8
-thumb_func 0x80ea308
-thumb_func 0x80ea320
-thumb_func 0x80ea344
+thumb_func 0x80e9fd4 InitSecretBaseDecorationSprites
+thumb_func 0x80ea218 HideSecretBaseDecorationSprites
+thumb_func 0x80ea274 SetSecretBaseOwnerGfxId
+thumb_func 0x80ea2a8 SetCurSecretBaseIdFromPosition
+thumb_func 0x80ea308 FldEffPoison_Start
+thumb_func 0x80ea320 TrySetCurSecretBase
+thumb_func 0x80ea344 Task_WarpOutOfSecretBase
 thumb_func 0x80ea3c8
-thumb_func 0x80ea3e4
+thumb_func 0x80ea3e4 IsCurSecretBaseOwnedByAnotherPlayer
 thumb_func 0x80ea420
 thumb_func 0x80ea46c
 thumb_func 0x80ea48c
-thumb_func 0x80ea4d8
-thumb_func 0x80ea50c
-thumb_func 0x80ea574
-thumb_func 0x80ea6f0
-thumb_func 0x80ea720
-thumb_func 0x80ea730
-thumb_func 0x80ea7d0
+thumb_func 0x80ea4d8 IsSecretBaseRegistered
+thumb_func 0x80ea50c GetAverageEVs
+thumb_func 0x80ea574 SetPlayerSecretBaseParty
+thumb_func 0x80ea6f0 ClearAndLeaveSecretBase
+thumb_func 0x80ea720 MoveOutOfSecretBase
+thumb_func 0x80ea730 ClosePlayerSecretBaseEntrance
+thumb_func 0x80ea7d0 MoveOutOfSecretBaseFromOutside
 thumb_func 0x80ea808 GetNumRegisteredSecretBases
-thumb_func 0x80ea83c
-thumb_func 0x80ea88c
+thumb_func 0x80ea83c GetCurSecretBaseRegistrationValidity
+thumb_func 0x80ea88c ToggleCurSecretBaseRegistry
 thumb_func 0x80ea8d4
 thumb_func 0x80ea8e8
-thumb_func 0x80ea8fc
-thumb_func 0x80ea98c
+thumb_func 0x80ea8fc Task_ShowSecretBaseRegistryMenu
+thumb_func 0x80ea98c BuildRegistryMenuItems
 thumb_func 0x80eaa4c
-thumb_func 0x80eaa60
-thumb_func 0x80eaaa4
-thumb_func 0x80eaaf0
+thumb_func 0x80eaa60 FinalizeRegistryMenu
+thumb_func 0x80eaaa4 AddRegistryMenuScrollArrows
+thumb_func 0x80eaaf0 HandleRegistryMenuInput
 thumb_func 0x80eab80
 thumb_func 0x80eabf8
-thumb_func 0x80eac44
+thumb_func 0x80eac44 ShowRegistryMenuDeleteConfirmation
 thumb_func 0x80eacb4
-thumb_func 0x80eacd4
+thumb_func 0x80eacd4 DeleteRegistry_Yes_Callback
 thumb_func 0x80ead68
-thumb_func 0x80ead84
-thumb_func 0x80eadd4
-thumb_func 0x80eae18
-thumb_func 0x80eae54
-thumb_func 0x80eae98
-thumb_func 0x80eaf2c
+thumb_func 0x80ead84 DeleteRegistry_No
+thumb_func 0x80eadd4 ReturnToMainRegistryMenu
+thumb_func 0x80eae18 EventObjectInteractionPlantBerryTree
+thumb_func 0x80eae54 GetSecretBaseOwnerType
+thumb_func 0x80eae98 GetSecretBaseTrainerLoseText
+thumb_func 0x80eaf2c PrepSecretBaseBattleFlags
 thumb_func 0x80eaf54
-thumb_func 0x80eaf9c
-thumb_func 0x80eb02c
+thumb_func 0x80eaf9c GetSecretBaseOwnerInteractionState
+thumb_func 0x80eb02c SecretBasePerStepCallback
 thumb_func 0x80eb470
 thumb_func 0x80eb4cc SecretBasesHaveSameTrainerId
 thumb_func 0x80eb4fc SecretBasesHaveSameTrainerName
 thumb_func 0x80eb548 SecretBasesBelongToSamePlayer
-thumb_func 0x80eb588
-thumb_func 0x80eb5d0
+thumb_func 0x80eb588 GetSecretBaseIndexFromId
+thumb_func 0x80eb5d0 FindAvailableSecretBaseIndex
 thumb_func 0x80eb610
 thumb_func 0x80eb65c
-thumb_func 0x80eb6e8
+thumb_func 0x80eb6e8 SortSecretBasesByRegistryStatus
 thumb_func 0x80eb798
-thumb_func 0x80eb7cc
-thumb_func 0x80eb84c
+thumb_func 0x80eb7cc SecretBaseBelongsToPlayer
+thumb_func 0x80eb84c DeleteFirstOldBaseFromPlayerInRecordMixingFriendsRecords
 thumb_func 0x80eb904
 thumb_func 0x80eb984
 thumb_func 0x80eba80
 thumb_func 0x80ebaa4
 thumb_func 0x80ebae0
-thumb_func 0x80ebb64
-thumb_func 0x80ebd2c
-thumb_func 0x80ebd4c
+thumb_func 0x80ebb64 ReceiveSecretBasesData
+thumb_func 0x80ebd2c ClearJapaneseSecretBases
+thumb_func 0x80ebd4c EventObjectInteractionRemoveBerryTree
 thumb_func 0x80ebdb8
 thumb_func 0x80ebe30
 thumb_func 0x80ebe68
@@ -7909,82 +7909,82 @@ thumb_func 0x80ebea0
 thumb_func 0x80ebf08
 thumb_func 0x80ebf70
 thumb_func 0x80ebfd8
-thumb_func 0x80ec038
+thumb_func 0x80ec038 SetSecretBaseSecretsTvFlags_Poster
 thumb_func 0x80ec10c
-thumb_func 0x80ec580
-thumb_func 0x80ec6c8
-thumb_func 0x80eca1c
-thumb_func 0x80eca80
-thumb_func 0x80ecadc
-thumb_func 0x80ecb94
-thumb_func 0x80ecbe4
-thumb_func 0x80ecc6c
-thumb_func 0x80eccd0
-thumb_func 0x80eccec
+thumb_func 0x80ec580 SetSecretBaseSecretsTvFlags_LargeDecorationSpot
+thumb_func 0x80ec6c8 SetSecretBaseSecretsTvFlags_SmallDecorationSpot
+thumb_func 0x80eca1c SetSecretBaseSecretsTvFlags_SandOrnament
+thumb_func 0x80eca80 ClearTVShowData
+thumb_func 0x80ecadc special_0x44
+thumb_func 0x80ecb94 FindAnyTVShowOnTheAir
+thumb_func 0x80ecbe4 UpdateTVScreensOnMap
+thumb_func 0x80ecc6c SetTVMetatilesOnMap
+thumb_func 0x80eccd0 TurnOffTVScreen
+thumb_func 0x80eccec TurnOnTVScreen
 thumb_func 0x80ecd08 special_0x45
-thumb_func 0x80ecd2c
+thumb_func 0x80ecd2c FindFirstActiveTVShowThatIsNotAMassOutbreak
 thumb_func 0x80ecd74
 thumb_func 0x80ecdbc ResetGabbyAndTy
-thumb_func 0x80ecebc
-thumb_func 0x80ecfe8
+thumb_func 0x80ecebc GabbyAndTyBeforeInterview
+thumb_func 0x80ecfe8 GabbyAndTyAfterInterview
 thumb_func 0x80ed088 TakeTVShowInSearchOfTrainersOffTheAir
-thumb_func 0x80ed0a4
-thumb_func 0x80ed0d0
-thumb_func 0x80ed0e8
-thumb_func 0x80ed12c
-thumb_func 0x80ed178
-thumb_func 0x80ed25c
-thumb_func 0x80ed2c8
+thumb_func 0x80ed0a4 GabbyAndTyGetBattleNum
+thumb_func 0x80ed0d0 IsTVShowInSearchOfTrainersAiring
+thumb_func 0x80ed0e8 GabbyAndTyGetLastQuote
+thumb_func 0x80ed12c GabbyAndTyGetLastBattleTrivia
+thumb_func 0x80ed178 GabbyAndTySetScriptVarsToEventObjectLocalIds
+thumb_func 0x80ed25c InterviewAfter
+thumb_func 0x80ed2c8 PutPokemonTodayCaughtOnAir
 thumb_func 0x80ed438
-thumb_func 0x80ed490
-thumb_func 0x80ed57c
-thumb_func 0x80ed5a4
-thumb_func 0x80ed5cc
+thumb_func 0x80ed490 PutPokemonTodayFailedOnTheAir
+thumb_func 0x80ed57c tv_store_id_3x
+thumb_func 0x80ed5a4 tv_store_id_2x
+thumb_func 0x80ed5cc InterviewAfter_ContestLiveUpdates
 thumb_func 0x80ed694
-thumb_func 0x80ed784
+thumb_func 0x80ed784 Put3CheersForPokeblocksOnTheAir
 thumb_func 0x80ed870
-thumb_func 0x80ed900
-thumb_func 0x80ed950
-thumb_func 0x80ed990
-thumb_func 0x80ed9d0
+thumb_func 0x80ed900 ContestLiveUpdates_BeforeInterview_1
+thumb_func 0x80ed950 ContestLiveUpdates_BeforeInterview_2
+thumb_func 0x80ed990 ContestLiveUpdates_BeforeInterview_3
+thumb_func 0x80ed9d0 ContestLiveUpdates_BeforeInterview_4
 thumb_func 0x80eda10
-thumb_func 0x80edab0
-thumb_func 0x80edb90
+thumb_func 0x80edab0 InterviewAfter_BravoTrainerPokemonProfile
+thumb_func 0x80edb90 BravoTrainerPokemonProfile_BeforeInterview1
 thumb_func 0x80edbe4
-thumb_func 0x80edcac
-thumb_func 0x80edd80
-thumb_func 0x80ede68
+thumb_func 0x80edcac InterviewAfter_BravoTrainerBattleTowerProfile
+thumb_func 0x80edd80 SaveRecordedItemPurchasesForTVShow
+thumb_func 0x80ede68 PutNameRaterShowOnTheAir
 thumb_func 0x80edf64 StartMassOutbreak
-thumb_func 0x80ee010
-thumb_func 0x80ee07c
-thumb_func 0x80ee0ec
+thumb_func 0x80ee010 PutLilycoveContestLadyShowOnTheAir
+thumb_func 0x80ee07c InterviewAfter_FanClubLetter
+thumb_func 0x80ee0ec InterviewAfter_RecentHappenings
 thumb_func 0x80ee144
 thumb_func 0x80ee234 nullsub_14
 thumb_func 0x80ee238
 thumb_func 0x80ee328 EndMassOutbreak
-thumb_func 0x80ee3a8
+thumb_func 0x80ee3a8 UpdateTVShowsPerDay
 thumb_func 0x80ee3d4
-thumb_func 0x80ee444
+thumb_func 0x80ee444 UpdateMassOutbreakTimeLeft
 thumb_func 0x80ee470
-thumb_func 0x80ee4c8
+thumb_func 0x80ee4c8 PutFishingAdviceShowOnTheAir
 thumb_func 0x80ee55c
 thumb_func 0x80ee568
 thumb_func 0x80ee5a0
 thumb_func 0x80ee664
 thumb_func 0x80ee780
 thumb_func 0x80ee808
-thumb_func 0x80ee898
-thumb_func 0x80ee990
-thumb_func 0x80ee9a4
+thumb_func 0x80ee898 AlertTVOfNewCoinTotal
+thumb_func 0x80ee990 AlertTVThatPlayerPlayedSlotMachine
+thumb_func 0x80ee9a4 AlertTVThatPlayerPlayedRoulette
 thumb_func 0x80ee9b8
 thumb_func 0x80eead4
-thumb_func 0x80eec24
+thumb_func 0x80eec24 TV_PutSecretBaseVisitOnTheAir
 thumb_func 0x80eeca4
 thumb_func 0x80eedec
 thumb_func 0x80eee7c
 thumb_func 0x80eef6c
 thumb_func 0x80eeffc
-thumb_func 0x80ef0bc
+thumb_func 0x80ef0bc GetRibbonCount
 thumb_func 0x80ef1b4 TV_MonDataIdxToRibbon
 thumb_func 0x80ef244
 thumb_func 0x80ef2d8
@@ -8005,57 +8005,57 @@ thumb_func 0x80ef934
 thumb_func 0x80ef960 ClearPokemonNews
 thumb_func 0x80ef97c ClearPokemonNewsI
 thumb_func 0x80ef9bc
-thumb_func 0x80efa24
-thumb_func 0x80efa70
-thumb_func 0x80efb3c
-thumb_func 0x80efb98
+thumb_func 0x80efa24 FindAnyTVNewsOnTheAir
+thumb_func 0x80efa70 DoPokeNews
+thumb_func 0x80efb3c GetPriceReduction
+thumb_func 0x80efb98 IsPriceDiscounted
 thumb_func 0x80efbe8
 thumb_func 0x80efc24
-thumb_func 0x80efcc0
-thumb_func 0x80efd54
+thumb_func 0x80efcc0 CopyContestRankToStringVar
+thumb_func 0x80efd54 CopyContestCategoryToStringVar
 thumb_func 0x80efe10 SetContestCategoryStringVarForInterview
-thumb_func 0x80efe44
-thumb_func 0x80efe74
+thumb_func 0x80efe44 TV_PrintIntToStringVar
+thumb_func 0x80efe74 CountDigits
 thumb_func 0x80eff10
-thumb_func 0x80eff70
+thumb_func 0x80eff70 HasMixableShowAlreadyBeenSpawnedWithPlayerID
 thumb_func 0x80f0004 TV_SortPurchasesByQuantity
-thumb_func 0x80f0054
+thumb_func 0x80f0054 FindActiveBroadcastByShowType_SetScriptResult
 thumb_func 0x80f00bc
-thumb_func 0x80f0150
-thumb_func 0x80f01c8
-thumb_func 0x80f0208
+thumb_func 0x80f0150 InterviewBefore_FanClubLetter
+thumb_func 0x80f01c8 InterviewBefore_RecentHappenings
+thumb_func 0x80f0208 InterviewBefore_PkmnFanClubOpinions
 thumb_func 0x80f02a0
-thumb_func 0x80f02ac
-thumb_func 0x80f02b8
-thumb_func 0x80f02f8
-thumb_func 0x80f0304
-thumb_func 0x80f0310
-thumb_func 0x80f0350
+thumb_func 0x80f02ac InterviewBefore_NameRater
+thumb_func 0x80f02b8 InterviewBefore_BravoTrainerPkmnProfile
+thumb_func 0x80f02f8 InterviewBefore_ContestLiveUpdates
+thumb_func 0x80f0304 InterviewBefore_3CheersForPokeblocks
+thumb_func 0x80f0310 InterviewBefore_BravoTrainerBTProfile
+thumb_func 0x80f0350 InterviewBefore_FanClubSpecial
 thumb_func 0x80f0390
 thumb_func 0x80f03e4
 thumb_func 0x80f03fc DeleteTVShowInArrayByIdx
 thumb_func 0x80f0428
-thumb_func 0x80f04d4
-thumb_func 0x80f0514
+thumb_func 0x80f04d4 TV_GetSomeOtherSpeciesAlreadySeenByPlayer_AndPrintName
+thumb_func 0x80f0514 TV_GetSomeOtherSpeciesAlreadySeenByPlayer
 thumb_func 0x80f0578
 thumb_func 0x80f05cc FindEmptyTVSlotWithinFirstFiveShowsOfArray
 thumb_func 0x80f05f8 FindEmptyTVSlotBeyondFirstFiveShowsOfArray
-thumb_func 0x80f0628
-thumb_func 0x80f0648
+thumb_func 0x80f0628 TV_BernoulliTrial
+thumb_func 0x80f0648 TV_FanClubLetter_RandomWordToStringVar3
 thumb_func 0x80f0694 TV_GetNicknameSumMod8
 thumb_func 0x80f06cc
-thumb_func 0x80f0820
-thumb_func 0x80f0864
-thumb_func 0x80f08a8
-thumb_func 0x80f0964
-thumb_func 0x80f0990
-thumb_func 0x80f0a14
-thumb_func 0x80f0a38
-thumb_func 0x80f0a68
+thumb_func 0x80f0820 TV_IsScriptShowKindAlreadyInQueue
+thumb_func 0x80f0864 TV_PutNameRaterShowOnTheAirIfNicknameChanged
+thumb_func 0x80f08a8 ChangePokemonNickname
+thumb_func 0x80f0964 ChangePokemonNickname_CB
+thumb_func 0x80f0990 ChangeBoxPokemonNickname
+thumb_func 0x80f0a14 ChangeBoxPokemonNickname_CB
+thumb_func 0x80f0a38 TV_CopyNicknameToStringVar1AndEnsureTerminated
+thumb_func 0x80f0a68 TV_CheckMonOTIDEqualsPlayerID
 thumb_func 0x80f0aac GetTVChannelByShowType
 thumb_func 0x80f0aec GetPlayerIDAsU32
-thumb_func 0x80f0b0c
-thumb_func 0x80f0b70
+thumb_func 0x80f0b0c CheckForBigMovieOrEmergencyNewsOnTV
+thumb_func 0x80f0b70 GetMomOrDadStringForTVMessage
 thumb_func 0x80f0c84
 thumb_func 0x80f0cb4
 thumb_func 0x80f0e34
@@ -8070,7 +8070,7 @@ thumb_func 0x80f1600
 thumb_func 0x80f1640
 thumb_func 0x80f1694
 thumb_func 0x80f16e0
-thumb_func 0x80f1758
+thumb_func 0x80f1758 ReceivePokeNewsData
 thumb_func 0x80f183c
 thumb_func 0x80f1934
 thumb_func 0x80f1960
@@ -8079,42 +8079,42 @@ thumb_func 0x80f19c8
 thumb_func 0x80f1a00
 thumb_func 0x80f1a40
 thumb_func 0x80f1ce4
-thumb_func 0x80f1d28
+thumb_func 0x80f1d28 DoTVShow
 thumb_func 0x80f1ed8
-thumb_func 0x80f2164
-thumb_func 0x80f23ec
-thumb_func 0x80f2620
-thumb_func 0x80f28fc
-thumb_func 0x80f2b50
-thumb_func 0x80f2cb8
+thumb_func 0x80f2164 DoTVShowBravoTrainerBattleTower
+thumb_func 0x80f23ec DoTVShowTodaysSmartShopper
+thumb_func 0x80f2620 DoTVShowTheNameRaterShow
+thumb_func 0x80f28fc DoTVShowPokemonTodaySuccessfulCapture
+thumb_func 0x80f2b50 DoTVShowPokemonTodayFailedCapture
+thumb_func 0x80f2cb8 DoTVShowPokemonFanClubLetter
 thumb_func 0x80f2ee8
-thumb_func 0x80f3080
+thumb_func 0x80f3080 DoTVShowPokemonFanClubOpinions
 thumb_func 0x80f3174 nullsub_15
-thumb_func 0x80f3178
+thumb_func 0x80f3178 DoTVShowPokemonNewsMassOutbreak
 thumb_func 0x80f31e8
 thumb_func 0x80f39cc
 thumb_func 0x80f3c00
 thumb_func 0x80f3eac
-thumb_func 0x80f40a4
-thumb_func 0x80f4180
+thumb_func 0x80f40a4 DoTVShowPokemonAngler
+thumb_func 0x80f4180 DoTVShowTheWorldOfMasters
 thumb_func 0x80f4260
-thumb_func 0x80f4470
-thumb_func 0x80f45e0
-thumb_func 0x80f46e0
+thumb_func 0x80f4470 DoTVShowDewfordTrendWatcherNetwork
+thumb_func 0x80f45e0 DoTVShowHoennTreasureInvestigators
+thumb_func 0x80f46e0 DoTVShowFindThatGamer
 thumb_func 0x80f488c
-thumb_func 0x80f4bbc
-thumb_func 0x80f4e0c
+thumb_func 0x80f4bbc DoTVShowSecretBaseVisit
+thumb_func 0x80f4e0c DoTVShowPokemonLotteryWinnerFlashReport
 thumb_func 0x80f4ea0
 thumb_func 0x80f50ac
 thumb_func 0x80f51e0
 thumb_func 0x80f537c
 thumb_func 0x80f55b0
-thumb_func 0x80f5858
+thumb_func 0x80f5858 DoTVShowWhatsNo1InHoennToday
 thumb_func 0x80f59a4 TVShowGetFlagCount
-thumb_func 0x80f59d0
+thumb_func 0x80f59d0 SecretBaseSecrets_GetStateForFlagNumber
 thumb_func 0x80f5a10
-thumb_func 0x80f5d54
-thumb_func 0x80f5ed0
+thumb_func 0x80f5d54 DoTVShowSafariFanClub
+thumb_func 0x80f5ed0 DoTVShowPokemonContestLiveUpdates2
 thumb_func 0x80f5f74 TVShowDone
 thumb_func 0x80f5fb0
 thumb_func 0x80f5fbc
@@ -8143,11 +8143,11 @@ thumb_func 0x80f70d8
 thumb_func 0x80f7114
 thumb_func 0x80f71dc
 thumb_func 0x80f7288 LoadAllContestMonIcons
-thumb_func 0x80f72c0
+thumb_func 0x80f72c0 HealStatusConditions
 thumb_func 0x80f730c
 thumb_func 0x80f739c
 thumb_func 0x80f760c
-thumb_func 0x80f76e8
+thumb_func 0x80f76e8 SpeciesToMailSpecies
 thumb_func 0x80f7708
 thumb_func 0x80f7760
 thumb_func 0x80f77ac
@@ -8156,7 +8156,7 @@ thumb_func 0x80f7848
 thumb_func 0x80f7880
 thumb_func 0x80f78e8
 thumb_func 0x80f79b8
-thumb_func 0x80f7a3c
+thumb_func 0x80f7a3c RecordedBattle_SaveParties
 thumb_func 0x80f7ba0
 thumb_func 0x80f7bf4
 thumb_func 0x80f7c6c
@@ -8186,7 +8186,7 @@ thumb_func 0x80f8bd4
 thumb_func 0x80f8c14
 thumb_func 0x80f8c54
 thumb_func 0x80f8c64
-thumb_func 0x80f8c90
+thumb_func 0x80f8c90 WarpIntoSecretBase
 thumb_func 0x80f8cbc
 thumb_func 0x80f8cdc
 thumb_func 0x80f8d08
@@ -8199,7 +8199,7 @@ thumb_func 0x80f8e24
 thumb_func 0x80f8e40
 thumb_func 0x80f8f3c
 thumb_func 0x80f8f64
-thumb_func 0x80f8f98
+thumb_func 0x80f8f98 ReceiveOldManData
 thumb_func 0x80f901c
 thumb_func 0x80f9044
 thumb_func 0x80f9068 SetContestTrainerGfxIds
@@ -8210,17 +8210,17 @@ thumb_func 0x80f916c
 thumb_func 0x80f9178
 thumb_func 0x80f91d0 CountPlayerContestPaintings
 thumb_func 0x80f9200
-thumb_func 0x80f935c
-thumb_func 0x80f936c
+thumb_func 0x80f935c ShowContestWinnerCleanup
+thumb_func 0x80f936c ShowContestWinner
 thumb_func 0x80f938c
 thumb_func 0x80f9424
-thumb_func 0x80f950c
+thumb_func 0x80f950c GiveMonArtistRibbon
 thumb_func 0x80f95b4
-thumb_func 0x80f95b8
+thumb_func 0x80f95b8 ShowContestEntryMonPic
 thumb_func 0x80f9748
 thumb_func 0x80f9778
-thumb_func 0x80f9830
-thumb_func 0x80f9878
+thumb_func 0x80f9830 ScriptGetMultiplayerId
+thumb_func 0x80f9878 ScriptRandom
 thumb_func 0x80f98cc
 thumb_func 0x80f98ec
 thumb_func 0x80f9918
@@ -8229,152 +8229,152 @@ thumb_func 0x80f999c
 thumb_func 0x80f99c4
 thumb_func 0x80f99e4
 thumb_func 0x80f99f0
-thumb_func 0x80f9a10
-thumb_func 0x80f9ad4
-thumb_func 0x80f9b58
-thumb_func 0x80f9b88
-thumb_func 0x80f9bb0
+thumb_func 0x80f9a10 HealPlayerParty
+thumb_func 0x80f9ad4 ScriptGiveMon
+thumb_func 0x80f9b58 ScriptGiveEgg
+thumb_func 0x80f9b88 HasEnoughMonsForDoubleBattle
+thumb_func 0x80f9bb0 CheckPartyMonHasHeldItem
 thumb_func 0x80f9c00
-thumb_func 0x80f9c30
-thumb_func 0x80f9c90
-thumb_func 0x80f9cc8
+thumb_func 0x80f9c30 CreateScriptedWildMon
+thumb_func 0x80f9c90 ScriptSetMonMoveSlot
+thumb_func 0x80f9cc8 ChooseHalfPartyForBattle
 thumb_func 0x80f9cf0
 thumb_func 0x80f9d20
 thumb_func 0x80f9d48
-thumb_func 0x80f9d78
+thumb_func 0x80f9d78 ReducePlayerPartyToSelectedMons
 thumb_func 0x80f9df8
-thumb_func 0x80f9e1c
-thumb_func 0x80f9e50
-thumb_func 0x80f9e9c
-thumb_func 0x80f9ee4
+thumb_func 0x80f9e1c AllMonsFainted
+thumb_func 0x80f9e50 FaintFromFieldPoison
+thumb_func 0x80f9e9c MonFaintedFromPoison
+thumb_func 0x80f9ee4 Task_WhiteOut
 thumb_func 0x80f9fbc
-thumb_func 0x80f9fd4
-thumb_func 0x80fa058
-thumb_func 0x80fa0fc
-thumb_func 0x80fa12c
+thumb_func 0x80f9fd4 DoPoisonFieldEffect
+thumb_func 0x80fa058 GetMonSizeHash
+thumb_func 0x80fa0fc TranslateBigMonSizeTableIndex
+thumb_func 0x80fa12c GetMonSize
 thumb_func 0x80fa1a0
-thumb_func 0x80fa1f0
-thumb_func 0x80fa280
+thumb_func 0x80fa1f0 CompareMonSize
+thumb_func 0x80fa280 GetMonSizeRecordInfo
 thumb_func 0x80fa2ec
-thumb_func 0x80fa300
-thumb_func 0x80fa31c
+thumb_func 0x80fa300 GetSeedotSizeRecordInfo
+thumb_func 0x80fa31c CompareSeedotSize
 thumb_func 0x80fa344
-thumb_func 0x80fa358
-thumb_func 0x80fa374
-thumb_func 0x80fa3a0
+thumb_func 0x80fa358 GetLotadSizeRecordInfo
+thumb_func 0x80fa374 CompareLotadSize
+thumb_func 0x80fa3a0 GiveGiftRibbonToParty
 thumb_func 0x80fa43c
 thumb_func 0x80fa464
 thumb_func 0x80fa48c
-thumb_func 0x80fa4a0
+thumb_func 0x80fa4a0 FldEffPoison_IsActive
 thumb_func 0x80fa4b4
 thumb_func 0x80fa500
 thumb_func 0x80fa66c
-thumb_func 0x80fa7cc
-thumb_func 0x80fa7e8
-thumb_func 0x80fa874
+thumb_func 0x80fa7cc SetCurrentSecretBase
+thumb_func 0x80fa7e8 AdjustSecretPowerSpritePixelOffsets
+thumb_func 0x80fa874 SetUpFieldMove_SecretPower
 thumb_func 0x80fa94c
 thumb_func 0x80fa96c
-thumb_func 0x80fa998
-thumb_func 0x80fa9ac
+thumb_func 0x80fa998 StartSecretBaseCaveFieldEffect
+thumb_func 0x80fa9ac FldEff_SecretPowerCave
 thumb_func 0x80fa9fc
 thumb_func 0x80faa18
-thumb_func 0x80faa48
+thumb_func 0x80faa48 CaveEntranceSpriteCallbackEnd
 thumb_func 0x80faa58
 thumb_func 0x80faa78
-thumb_func 0x80faaa4
-thumb_func 0x80faab8
-thumb_func 0x80fab48
-thumb_func 0x80fab74
-thumb_func 0x80fabac
+thumb_func 0x80faaa4 StartSecretBaseTreeFieldEffect
+thumb_func 0x80faab8 FldEff_SecretPowerTree
+thumb_func 0x80fab48 TreeEntranceSpriteCallback1
+thumb_func 0x80fab74 TreeEntranceSpriteCallback2
+thumb_func 0x80fabac TreeEntranceSpriteCallbackEnd
 thumb_func 0x80fabbc
 thumb_func 0x80fabdc
-thumb_func 0x80fac08
+thumb_func 0x80fac08 StartSecretBaseShrubFieldEffect
 thumb_func 0x80fac1c
-thumb_func 0x80fac6c
+thumb_func 0x80fac6c ShrubEntranceSpriteCallback1
 thumb_func 0x80fac88
-thumb_func 0x80facb8
-thumb_func 0x80facc8
-thumb_func 0x80fad10
-thumb_func 0x80fadec
-thumb_func 0x80fae54
-thumb_func 0x80fae9c
-thumb_func 0x80faf1c
+thumb_func 0x80facb8 ShrubEntranceSpriteCallbackEnd
+thumb_func 0x80facc8 FldEff_SecretBasePCTurnOn
+thumb_func 0x80fad10 Task_SecretBasePCTurnOn
+thumb_func 0x80fadec DoSecretBasePCTurnOffEffect
+thumb_func 0x80fae54 PopSecretBaseBalloon
+thumb_func 0x80fae9c Task_PopSecretBaseBalloon
+thumb_func 0x80faf1c DoBalloonSoundEffect
 thumb_func 0x80faf6c
 thumb_func 0x80faf70 nullsub_69
-thumb_func 0x80faf74
-thumb_func 0x80fafc4
-thumb_func 0x80fb004
-thumb_func 0x80fb05c
-thumb_func 0x80fb1e0
-thumb_func 0x80fb214
-thumb_func 0x80fb240
-thumb_func 0x80fb2ec
-thumb_func 0x80fb414
-thumb_func 0x80fb494
+thumb_func 0x80faf74 DoSecretBaseBreakableDoorEffect
+thumb_func 0x80fafc4 Task_ShatterSecretBaseBreakableDoor
+thumb_func 0x80fb004 ShatterSecretBaseBreakableDoor
+thumb_func 0x80fb05c Task_SecretBaseMusicNoteMatSound
+thumb_func 0x80fb1e0 PlaySecretBaseMusicNoteMatSound
+thumb_func 0x80fb214 SpriteCB_GlitterMatSparkle
+thumb_func 0x80fb240 DoSecretBaseGlitterMatSparkle
+thumb_func 0x80fb2ec FldEff_SandPillar
+thumb_func 0x80fb414 SpriteCB_SandPillar_0
+thumb_func 0x80fb494 SpriteCB_SandPillar_1
 thumb_func 0x80fb4d8
-thumb_func 0x80fb4e8
+thumb_func 0x80fb4e8 GetShieldToyTVDecorationInfo
 thumb_func 0x80fb654
-thumb_func 0x80fb6a8
+thumb_func 0x80fb6a8 Task_FieldPoisonEffect
 thumb_func 0x80fb718
 thumb_func 0x80fb730
 thumb_func 0x80fb744
-thumb_func 0x80fb760
-thumb_func 0x80fb7d4
-thumb_func 0x80fb844
-thumb_func 0x80fb868
-thumb_func 0x80fb87c
-thumb_func 0x80fb8e4
+thumb_func 0x80fb760 Task_WateringBerryTreeAnim_1
+thumb_func 0x80fb7d4 Task_WateringBerryTreeAnim_2
+thumb_func 0x80fb844 AnimBonemerangProjectileEnd
+thumb_func 0x80fb868 DoWateringBerryTreeAnim
+thumb_func 0x80fb87c CreateRecordMixingSprite
+thumb_func 0x80fb8e4 DestroyRecordMixingSprite
 thumb_func 0x80fb920
-thumb_func 0x80fb94c
-thumb_func 0x80fb968
-thumb_func 0x80fba1c
+thumb_func 0x80fb94c GetTruckBoxMovement
+thumb_func 0x80fb968 Task_Truck1
+thumb_func 0x80fba1c Task_Truck2
 thumb_func 0x80fbb30
-thumb_func 0x80fbbdc
-thumb_func 0x80fbd50
-thumb_func 0x80fbdb0
+thumb_func 0x80fbbdc Task_HandleTruckSequence
+thumb_func 0x80fbd50 ExecuteTruckSequence
+thumb_func 0x80fbdb0 EndTruckSequence
 thumb_func 0x80fbe0c
-thumb_func 0x80fbe58
+thumb_func 0x80fbe58 Task_HandlePorthole
 thumb_func 0x80fbf5c
 thumb_func 0x80fbfd8
 thumb_func 0x80fc014
-thumb_func 0x80fc058
-thumb_func 0x80fc088
-thumb_func 0x80fc0c4
-thumb_func 0x80fc0e0
+thumb_func 0x80fc058 GetCurrentMapRotatingGatePuzzleType
+thumb_func 0x80fc088 RotatingGate_ResetAllGateOrientations
+thumb_func 0x80fc0c4 RotatingGate_GetGateOrientation
+thumb_func 0x80fc0e0 RotatingGate_SetGateOrientation
 thumb_func 0x80fc100 RotatingGate_RotateInDirection
-thumb_func 0x80fc13c
+thumb_func 0x80fc13c RotatingGate_LoadPuzzleConfig
 thumb_func 0x80fc198 RotatingGate_CreateGatesWithinViewport
-thumb_func 0x80fc26c
-thumb_func 0x80fc354
+thumb_func 0x80fc26c RotatingGate_CreateGate
+thumb_func 0x80fc354 SpriteCallback_RotatingGate
 thumb_func 0x80fc3d4 RotatingGate_HideGatesOutsideViewport
 thumb_func 0x80fc470
-thumb_func 0x80fc480
-thumb_func 0x80fc54c
+thumb_func 0x80fc480 RotatingGate_DestroyGatesOutsideViewport
+thumb_func 0x80fc54c RotatingGate_CanRotate
 thumb_func 0x80fc624 RotatingGate_HasArm
 thumb_func 0x80fc678 RotatingGate_TriggerRotationAnimation
-thumb_func 0x80fc6ac
+thumb_func 0x80fc6ac RotatingGate_GetRotationInfo
 thumb_func 0x80fc700 RotatingGate_InitPuzzle
 thumb_func 0x80fc718 RotatingGatePuzzleCameraUpdate
 thumb_func 0x80fc740 RotatingGate_InitPuzzleAndGraphics
-thumb_func 0x80fc760
+thumb_func 0x80fc760 CheckForRotatingGatePuzzleCollision
 thumb_func 0x80fc844 CheckForRotatingGatePuzzleCollisionWithoutAnimation
 thumb_func 0x80fc910
 thumb_func 0x80fc924
 thumb_func 0x80fc934
-thumb_func 0x80fc944
-thumb_func 0x80fc984
-thumb_func 0x80fc9bc
+thumb_func 0x80fc944 EnterSafariMode
+thumb_func 0x80fc984 ExitSafariMode
+thumb_func 0x80fc9bc SafariZoneTakeStep
 thumb_func 0x80fc9f0
-thumb_func 0x80fca00
-thumb_func 0x80fca98
-thumb_func 0x80fcab4
-thumb_func 0x80fcac8
-thumb_func 0x80fcb58
-thumb_func 0x80fcbf8
-thumb_func 0x80fcc28
-thumb_func 0x80fcc58
+thumb_func 0x80fca00 CB2_EndSafariBattle
+thumb_func 0x80fca98 ClearPokeblockFeeder
+thumb_func 0x80fcab4 ClearAllPokeblockFeeders
+thumb_func 0x80fcac8 GetPokeblockFeederInFront
+thumb_func 0x80fcb58 GetPokeblockFeederWithinRange
+thumb_func 0x80fcbf8 SafariZoneGetPokeblockInFront
+thumb_func 0x80fcc28 SafariZoneGetActivePokeblock
+thumb_func 0x80fcc58 SafariZoneActivatePokeblockFeeder
 thumb_func 0x80fccf0 DecrementFeederStepCounters
-thumb_func 0x80fcd24
+thumb_func 0x80fcd24 GetInFrontFeederPokeblockAndSteps
 thumb_func 0x80fcd64
 thumb_func 0x80fcda0
 thumb_func 0x80fcdcc
@@ -8382,7 +8382,7 @@ thumb_func 0x80fcdf0
 thumb_func 0x80fce30
 thumb_func 0x80fce4c
 thumb_func 0x80fcee0
-thumb_func 0x80fcf2c
+thumb_func 0x80fcf2c ContestLiveUpdates_BeforeInterview_5
 thumb_func 0x80fd058
 thumb_func 0x80fd0e8
 thumb_func 0x80fd1ec
@@ -8392,27 +8392,27 @@ thumb_func 0x80fd4dc
 thumb_func 0x80fd69c
 thumb_func 0x80fd794
 thumb_func 0x80fd824
-thumb_func 0x80fd8b4
-thumb_func 0x80fd930
-thumb_func 0x80fd978
-thumb_func 0x80fd990
-thumb_func 0x80fd9b8
+thumb_func 0x80fd8b4 SetUpItemUseCallback
+thumb_func 0x80fd930 SetUpItemUseOnFieldCallback
+thumb_func 0x80fd978 MapPostLoadHook_UseItem
+thumb_func 0x80fd990 Task_CallItemUseOnFieldCallback
+thumb_func 0x80fd9b8 DisplayCannotUseItemMessage
 thumb_func 0x80fda1c DisplayDadsAdviceCannotUseItemMessage
 thumb_func 0x80fda34 DisplayCannotDismountBikeMessage
-thumb_func 0x80fda4c
-thumb_func 0x80fda70
+thumb_func 0x80fda4c CleanUpAfterFailingToUseRegisteredKeyItemOnField
+thumb_func 0x80fda70 CheckIfItemIsTMHMOrEvolutionStone
 thumb_func 0x80fdaa8
 thumb_func 0x80fdacc
-thumb_func 0x80fdaec
+thumb_func 0x80fdaec ItemUseOutOfBattle_Bike
 thumb_func 0x80fdbac
-thumb_func 0x80fdbe8
-thumb_func 0x80fdc7c
+thumb_func 0x80fdbe8 CanFish
+thumb_func 0x80fdc7c ItemUseOutOfBattle_Rod
 thumb_func 0x80fdcbc
-thumb_func 0x80fdce4
-thumb_func 0x80fdd0c
+thumb_func 0x80fdce4 ItemUseOutOfBattle_Itemfinder
+thumb_func 0x80fdd0c ItemUseOnFieldCB_Itemfinder
 thumb_func 0x80fdd58
 thumb_func 0x80fde20
-thumb_func 0x80fde44
+thumb_func 0x80fde44 ItemfinderCheckForHiddenItems
 thumb_func 0x80fdf28
 thumb_func 0x80fdf84
 thumb_func 0x80fe01c
@@ -8421,14 +8421,14 @@ thumb_func 0x80fe204
 thumb_func 0x80fe278
 thumb_func 0x80fe2e8
 thumb_func 0x80fe330
-thumb_func 0x80fe3c0
+thumb_func 0x80fe3c0 ItemUseOutOfBattle_PokeblockCase
 thumb_func 0x80fe440
 thumb_func 0x80fe454
-thumb_func 0x80fe488
-thumb_func 0x80fe4f8
+thumb_func 0x80fe488 ItemUseOutOfBattle_CoinCase
+thumb_func 0x80fe4f8 ItemUseOutOfBattle_PowderJar
 thumb_func 0x80fe564
 thumb_func 0x80fe5c8
-thumb_func 0x80fe5f8
+thumb_func 0x80fe5f8 ItemUseOutOfBattle_WailmerPail
 thumb_func 0x80fe65c
 thumb_func 0x80fe680
 thumb_func 0x80fe6d0
@@ -8438,87 +8438,87 @@ thumb_func 0x80fe72c ItemUseOutOfBattle_SacredAsh
 thumb_func 0x80fe748 ItemUseOutOfBattle_PPRecovery
 thumb_func 0x80fe764 ItemUseOutOfBattle_PPUp
 thumb_func 0x80fe780 ItemUseOutOfBattle_RareCandy
-thumb_func 0x80fe79c
+thumb_func 0x80fe79c ItemUseOutOfBattle_TMHM
 thumb_func 0x80fe7e4
 thumb_func 0x80fe810
 thumb_func 0x80fe874
 thumb_func 0x80fe88c
 thumb_func 0x80fe8a8
-thumb_func 0x80fe90c
+thumb_func 0x80fe90c ItemUseOutOfBattle_Repel
 thumb_func 0x80fe974
 thumb_func 0x80fe9b4
 thumb_func 0x80fea20
-thumb_func 0x80fea84
+thumb_func 0x80fea84 ItemUseOutOfBattle_BlackWhiteFlute
 thumb_func 0x80feb0c
-thumb_func 0x80feb28
-thumb_func 0x80feb64
-thumb_func 0x80feb84
-thumb_func 0x80febc8
-thumb_func 0x80febe4
+thumb_func 0x80feb28 re_escape_rope
+thumb_func 0x80feb64 CanUseEscapeRopeOnCurrMap
+thumb_func 0x80feb84 ItemUseOutOfBattle_EscapeRope
+thumb_func 0x80febc8 ItemUseOutOfBattle_EvolutionStone
+thumb_func 0x80febe4 ItemUseInBattle_PokeBall
 thumb_func 0x80fec58
-thumb_func 0x80fec90
-thumb_func 0x80fed08
+thumb_func 0x80fec90 OpponentHandleFaintAnimation
+thumb_func 0x80fed08 ItemUseInBattle_StatIncrease
 thumb_func 0x80fed9c
 thumb_func 0x80fede0 ItemUseInBattle_Medicine
 thumb_func 0x80fedfc
 thumb_func 0x80fee18 ItemUseInBattle_PPRecovery
 thumb_func 0x80fee34
-thumb_func 0x80feea0
+thumb_func 0x80feea0 ItemUseOutOfBattle_EnigmaBerry
 thumb_func 0x80fefcc
-thumb_func 0x80ff070
-thumb_func 0x80ff090
-thumb_func 0x80ff0e8
-thumb_func 0x80ff130
+thumb_func 0x80ff070 ItemUseOutOfBattle_CannotUse
+thumb_func 0x80ff090 AnimMovePowderParticle
+thumb_func 0x80ff0e8 AnimMovePowderParticleStep
+thumb_func 0x80ff130 AnimPowerAbsorptionOrb
 thumb_func 0x80ff180
 thumb_func 0x80ff1d8
-thumb_func 0x80ff234
-thumb_func 0x80ff2a8
-thumb_func 0x80ff328
+thumb_func 0x80ff234 AnimSolarbeamSmallOrbStep
+thumb_func 0x80ff2a8 AnimTask_CreateSmallSolarbeamOrbs
+thumb_func 0x80ff328 AnimAbsorptionOrb
 thumb_func 0x80ff378
-thumb_func 0x80ff394
-thumb_func 0x80ff44c
-thumb_func 0x80ff498
-thumb_func 0x80ff508
-thumb_func 0x80ff540
-thumb_func 0x80ff578
-thumb_func 0x80ff5c4
-thumb_func 0x80ff66c
-thumb_func 0x80ff6c8
-thumb_func 0x80ff71c
-thumb_func 0x80ff794
-thumb_func 0x80ff7e8
-thumb_func 0x80ff84c
-thumb_func 0x80ff894
-thumb_func 0x80ff8e0
-thumb_func 0x80ff944
-thumb_func 0x80ffa10
-thumb_func 0x80ffab8
-thumb_func 0x80ffb0c
-thumb_func 0x80ffbc4
-thumb_func 0x80ffc00
-thumb_func 0x80ffc3c
+thumb_func 0x80ff394 AnimHyperBeamOrb
+thumb_func 0x80ff44c AnimHyperBeamOrbStep
+thumb_func 0x80ff498 AnimLeechSeed
+thumb_func 0x80ff508 AnimLeechSeedStep
+thumb_func 0x80ff540 AnimLeechSeedSprouts
+thumb_func 0x80ff578 AnimSporeParticle
+thumb_func 0x80ff5c4 AnimSporeParticleStep
+thumb_func 0x80ff66c AnimTask_SporeDoubleBattle
+thumb_func 0x80ff6c8 AnimPetalDanceBigFlower
+thumb_func 0x80ff71c AnimPetalDanceBigFlowerStep
+thumb_func 0x80ff794 AnimPetalDanceSmallFlower
+thumb_func 0x80ff7e8 AnimPetalDanceSmallFlowerStep
+thumb_func 0x80ff84c AnimCuttingSlice
+thumb_func 0x80ff894 AnimRazorLeafParticleStep1
+thumb_func 0x80ff8e0 AnimRazorLeafParticleStep2
+thumb_func 0x80ff944 AnimTranslateLinearSingleSineWave
+thumb_func 0x80ffa10 AnimTranslateLinearSingleSineWaveStep
+thumb_func 0x80ffab8 AnimMoveTwisterParticle
+thumb_func 0x80ffb0c AnimMoveTwisterParticleStep
+thumb_func 0x80ffbc4 AnimConstrictBinding
+thumb_func 0x80ffc00 AnimConstrictBindingStep1
+thumb_func 0x80ffc3c AnimConstrictBindingStep2
 thumb_func 0x80ffca8
 thumb_func 0x80ffd8c
 thumb_func 0x80ffe1c
-thumb_func 0x80ffee8
-thumb_func 0x80fffb8
-thumb_func 0x810003c
-thumb_func 0x810012c
-thumb_func 0x8100184
+thumb_func 0x80ffee8 AnimMimicOrb
+thumb_func 0x80fffb8 AnimIngrainRoot
+thumb_func 0x810003c AnimFrenzyPlantRoot
+thumb_func 0x810012c AnimRootFlickerOut
+thumb_func 0x8100184 AnimIngrainOrb
 thumb_func 0x8100208
 thumb_func 0x8100230
 thumb_func 0x81002d4
 thumb_func 0x8100304
-thumb_func 0x8100368
+thumb_func 0x8100368 AnimPresent
 thumb_func 0x81003e0
-thumb_func 0x8100444
-thumb_func 0x81004c0
-thumb_func 0x8100504
-thumb_func 0x810057c
-thumb_func 0x810060c
-thumb_func 0x81006a8
-thumb_func 0x8100714
-thumb_func 0x81007cc
+thumb_func 0x8100444 AnimKnockOffItem
+thumb_func 0x81004c0 AnimPresentHealParticle
+thumb_func 0x8100504 AnimItemSteal
+thumb_func 0x810057c AnimItemStealStep
+thumb_func 0x810060c AnimTrickBag
+thumb_func 0x81006a8 AnimTrickBagStep1
+thumb_func 0x8100714 AnimTrickBagStep2
+thumb_func 0x81007cc AnimTrickBagStep3
 thumb_func 0x8100810
 thumb_func 0x8100978
 thumb_func 0x8100d54
@@ -8535,8 +8535,8 @@ thumb_func 0x81012a0
 thumb_func 0x81012e4
 thumb_func 0x8101330
 thumb_func 0x81013d8
-thumb_func 0x810151c
-thumb_func 0x8101588
+thumb_func 0x810151c AnimSliceStep
+thumb_func 0x8101588 unref_sub_8100D38
 thumb_func 0x810166c
 thumb_func 0x81016d0
 thumb_func 0x8101740
@@ -8585,8 +8585,8 @@ thumb_func 0x8102b24
 thumb_func 0x8102b9c
 thumb_func 0x8102bcc
 thumb_func 0x8102c30
-thumb_func 0x8102c84
-thumb_func 0x8102cf8
+thumb_func 0x8102c84 unref_sub_8102434
+thumb_func 0x8102cf8 unref_sub_81024A8
 thumb_func 0x8102d30
 thumb_func 0x8102d78
 thumb_func 0x8102d90
@@ -8628,12 +8628,12 @@ thumb_func 0x8103ddc
 thumb_func 0x8103e70
 thumb_func 0x8103ea8
 thumb_func 0x8103ed0
-thumb_func 0x8103ef0
-thumb_func 0x8103f2c
-thumb_func 0x8104028
+thumb_func 0x8103ef0 AnimTask_Withdraw
+thumb_func 0x8103f2c AnimTask_WithdrawStep
+thumb_func 0x8104028 Anim_KinesisZapEnergy
 thumb_func 0x81040cc
-thumb_func 0x81040f0
-thumb_func 0x8104118
+thumb_func 0x81040f0 Anim_SwordsDanceBladeStep
+thumb_func 0x8104118 AnimSonicBoomProjectile
 thumb_func 0x810421c
 thumb_func 0x8104250
 thumb_func 0x81042f4
@@ -8648,25 +8648,25 @@ thumb_func 0x81049a4
 thumb_func 0x8104a14
 thumb_func 0x8104a6c
 thumb_func 0x8104af0
-thumb_func 0x8104b54
-thumb_func 0x8104bb4
+thumb_func 0x8104b54 Anim_RazorWindTornado
+thumb_func 0x8104bb4 Anim_ViceGripPincer
 thumb_func 0x8104c48
-thumb_func 0x8104c64
-thumb_func 0x8104d0c
-thumb_func 0x8104d80
+thumb_func 0x8104c64 Anim_GuillotinePincer
+thumb_func 0x8104d0c Anim_GuillotinePincerStep1
+thumb_func 0x8104d80 Anim_GuillotinePincerStep2
 thumb_func 0x8104de4
-thumb_func 0x8104e00
-thumb_func 0x8104e64
-thumb_func 0x8104ec4
-thumb_func 0x8104f1c
-thumb_func 0x8105050
-thumb_func 0x8105140
+thumb_func 0x8104e00 AnimTask_GrowAndGreyscale
+thumb_func 0x8104e64 AnimTask_GrowAndGreyscaleStep
+thumb_func 0x8104ec4 AnimTask_Minimize
+thumb_func 0x8104f1c AnimTask_MinimizeStep1
+thumb_func 0x8105050 CreateMinimizeSprite
+thumb_func 0x8105140 ClonedMinizeSprite_Step
 thumb_func 0x8105188
-thumb_func 0x81051e8
-thumb_func 0x8105304
+thumb_func 0x81051e8 AnimTask_SplashStep
+thumb_func 0x8105304 AnimTask_GrowAndShrink
 thumb_func 0x8105340
-thumb_func 0x810536c
-thumb_func 0x81053fc
+thumb_func 0x810536c Anim_BreathPuff
+thumb_func 0x81053fc Anim_AngerMark
 thumb_func 0x8105488
 thumb_func 0x81054c8
 thumb_func 0x81054f4
@@ -8711,14 +8711,14 @@ thumb_func 0x81069dc
 thumb_func 0x8106a14
 thumb_func 0x8106a9c
 thumb_func 0x8106acc
-thumb_func 0x8106b38
+thumb_func 0x8106b38 AnimTask_HeartsBackground
 thumb_func 0x8106bf8
 thumb_func 0x8106d48
 thumb_func 0x8106e3c
-thumb_func 0x8106f8c
-thumb_func 0x8106fec
+thumb_func 0x8106f8c AnimOrbitFast
+thumb_func 0x8106fec AnimOrbitFastStep
 thumb_func 0x81070c8
-thumb_func 0x810711c
+thumb_func 0x810711c AnimOrbitScatterStep
 thumb_func 0x8107164
 thumb_func 0x8107194
 thumb_func 0x81071ec
@@ -8739,9 +8739,9 @@ thumb_func 0x81077b0
 thumb_func 0x8107868
 thumb_func 0x810788c
 thumb_func 0x81078fc
-thumb_func 0x8107994
-thumb_func 0x81079b8
-thumb_func 0x81079d8
+thumb_func 0x8107994 AnimTask_IsFuryCutterHitRight
+thumb_func 0x81079b8 AnimTask_GetFuryCutterHitCount
+thumb_func 0x81079d8 AnimTask_CreateRaindrops
 thumb_func 0x8107a6c
 thumb_func 0x8107a78
 thumb_func 0x8107ab0
@@ -8762,7 +8762,7 @@ thumb_func 0x8108010
 thumb_func 0x81080e4
 thumb_func 0x8108120
 thumb_func 0x810815c
-thumb_func 0x81081a4
+thumb_func 0x81081a4 AnimTask_CreateSurfWave
 thumb_func 0x81083d4
 thumb_func 0x8108514
 thumb_func 0x81085a8
@@ -8797,14 +8797,14 @@ thumb_func 0x8109878
 thumb_func 0x81098b4
 thumb_func 0x8109928
 thumb_func 0x81099bc
-thumb_func 0x81099e8
+thumb_func 0x81099e8 AnimEmberFlare
 thumb_func 0x8109a50
-thumb_func 0x8109a6c
-thumb_func 0x8109a94
-thumb_func 0x8109aec
-thumb_func 0x8109b64
-thumb_func 0x8109b88
-thumb_func 0x8109bb4
+thumb_func 0x8109a6c AnimFireRing
+thumb_func 0x8109a94 AnimFireRingStep1
+thumb_func 0x8109aec AnimFireRingStep2
+thumb_func 0x8109b64 AnimFireRingStep3
+thumb_func 0x8109b88 UpdateFireRingCircleOffset
+thumb_func 0x8109bb4 AnimFireCross
 thumb_func 0x8109bf4
 thumb_func 0x8109c34
 thumb_func 0x8109c5c
@@ -8822,7 +8822,7 @@ thumb_func 0x810a49c
 thumb_func 0x810a500
 thumb_func 0x810a60c
 thumb_func 0x810a67c
-thumb_func 0x810a8b0
+thumb_func 0x810a8b0 AnimTask_BlendBackground
 thumb_func 0x810a8e4
 thumb_func 0x810a9f8
 thumb_func 0x810aa48
@@ -8864,54 +8864,54 @@ thumb_func 0x810bed4
 thumb_func 0x810bf14
 thumb_func 0x810c098
 thumb_func 0x810c0fc
-thumb_func 0x810c13c
-thumb_func 0x810c1c4
-thumb_func 0x810c238
-thumb_func 0x810c274
-thumb_func 0x810c3b0
-thumb_func 0x810c418
-thumb_func 0x810c49c
-thumb_func 0x810c4e4
-thumb_func 0x810c628
-thumb_func 0x810c698
-thumb_func 0x810c720
-thumb_func 0x810c858
-thumb_func 0x810c8f0
-thumb_func 0x810c9b4
-thumb_func 0x810cb40
-thumb_func 0x810cb74
-thumb_func 0x810cc40
-thumb_func 0x810cdb0
-thumb_func 0x810cf24
+thumb_func 0x810c13c AnimIceBeamParticle
+thumb_func 0x810c1c4 AnimIceEffectParticle
+thumb_func 0x810c238 AnimFlickerIceEffectParticle
+thumb_func 0x810c274 AnimSwirlingSnowball_Step1
+thumb_func 0x810c3b0 AnimSwirlingSnowball_Step2
+thumb_func 0x810c418 AnimSwirlingSnowball_Step3
+thumb_func 0x810c49c AnimSwirlingSnowball_End
+thumb_func 0x810c4e4 AnimMoveParticleBeyondTarget
+thumb_func 0x810c628 AnimWiggleParticleTowardsTarget
+thumb_func 0x810c698 AnimWaveFromCenterOfTarget
+thumb_func 0x810c720 InitSwirlingFogAnim
+thumb_func 0x810c858 AnimSwirlingFogAnim
+thumb_func 0x810c8f0 AnimTask_Haze1
+thumb_func 0x810c9b4 AnimTask_Haze2
+thumb_func 0x810cb40 AnimThrowMistBall
+thumb_func 0x810cb74 AnimTask_LoadMistTiles
+thumb_func 0x810cc40 AnimTask_OverlayFogTiles
+thumb_func 0x810cdb0 InitPoisonGasCloudAnim
+thumb_func 0x810cf24 MovePoisonGasCloud
 thumb_func 0x810d168 AnimTask_Hail1
-thumb_func 0x810d184
-thumb_func 0x810d234
-thumb_func 0x810d3a8
-thumb_func 0x810d48c
-thumb_func 0x810d4d8
+thumb_func 0x810d184 AnimTask_Hail2
+thumb_func 0x810d234 GenerateHailParticle
+thumb_func 0x810d3a8 AnimHailBegin
+thumb_func 0x810d48c AnimHailContinue
+thumb_func 0x810d4d8 InitIceBallAnim
 thumb_func 0x810d56c
 thumb_func 0x810d59c
 thumb_func 0x810d600
-thumb_func 0x810d64c
-thumb_func 0x810d67c
+thumb_func 0x810d64c AnimTask_GetRolloutCounter
+thumb_func 0x810d67c unc_080B08A0
 thumb_func 0x810d6b8
 thumb_func 0x810d704
-thumb_func 0x810d730
+thumb_func 0x810d730 AnimBasicFistOrFoot
 thumb_func 0x810d780
 thumb_func 0x810d908
 thumb_func 0x810d95c
 thumb_func 0x810d9b4
 thumb_func 0x810da04
 thumb_func 0x810da90
-thumb_func 0x810dac8
-thumb_func 0x810db00
-thumb_func 0x810db34
-thumb_func 0x810db58
-thumb_func 0x810dbb0
+thumb_func 0x810dac8 AnimSpinningKickOrPunch
+thumb_func 0x810db00 AnimSpinningKickOrPunchFinish
+thumb_func 0x810db34 AnimStompFoot
+thumb_func 0x810db58 AnimStompFootStep
+thumb_func 0x810dbb0 AnimStompFootEnd
 thumb_func 0x810dbcc
 thumb_func 0x810dc5c
 thumb_func 0x810dccc
-thumb_func 0x810dd44
+thumb_func 0x810dd44 DaycarePrintMonLvl
 thumb_func 0x810de2c
 thumb_func 0x810de58
 thumb_func 0x810def8
@@ -8931,8 +8931,8 @@ thumb_func 0x810e504
 thumb_func 0x810e520
 thumb_func 0x810e574
 thumb_func 0x810e5a0
-thumb_func 0x810e614
-thumb_func 0x810e67c
+thumb_func 0x810e614 AnimBubbleEffect
+thumb_func 0x810e67c AnimBubbleEffectStep
 thumb_func 0x810e6c0
 thumb_func 0x810e6e8
 thumb_func 0x810e728
@@ -8955,7 +8955,7 @@ thumb_func 0x810f484
 thumb_func 0x810f4e4
 thumb_func 0x810f578
 thumb_func 0x810f5c0
-thumb_func 0x810f620
+thumb_func 0x810f620 LinkOpponentHandlePaletteFade
 thumb_func 0x810f664
 thumb_func 0x810f748
 thumb_func 0x810f7f8
@@ -8963,7 +8963,7 @@ thumb_func 0x810f854
 thumb_func 0x810f868
 thumb_func 0x810f8d4
 thumb_func 0x810f990
-thumb_func 0x810f9d4
+thumb_func 0x810f9d4 unref_sub_810F184
 thumb_func 0x810fa3c
 thumb_func 0x810fb90
 thumb_func 0x810fc18
@@ -8993,26 +8993,26 @@ thumb_func 0x8110984
 thumb_func 0x8110a90
 thumb_func 0x8110bb8
 thumb_func 0x8110c88
-thumb_func 0x8110d34
+thumb_func 0x8110d34 AnimTranslateWebThread
 thumb_func 0x8110dcc
 thumb_func 0x8110e04
 thumb_func 0x8110e80
 thumb_func 0x8110ecc
 thumb_func 0x8110ef4
 thumb_func 0x8110f50
-thumb_func 0x8110f70
+thumb_func 0x8110f70 AnimTranslateStinger
 thumb_func 0x81110a0
-thumb_func 0x811111c
+thumb_func 0x811111c AnimMissileArcStep
 thumb_func 0x81111e4
 thumb_func 0x8111240
 thumb_func 0x81112c0
 thumb_func 0x8111304
 thumb_func 0x8111388
 thumb_func 0x81113d0
-thumb_func 0x811141c
+thumb_func 0x811141c AnimTask_LoadSandstormBackground
 thumb_func 0x8111500
-thumb_func 0x811169c
-thumb_func 0x8111780
+thumb_func 0x811169c AnimDirtParticleAcrossScreen
+thumb_func 0x8111780 AnimRaiseSprite
 thumb_func 0x81117c4
 thumb_func 0x81118f4
 thumb_func 0x8111a64
@@ -9023,7 +9023,7 @@ thumb_func 0x8111c18
 thumb_func 0x8111c68
 thumb_func 0x8111c94
 thumb_func 0x8111cec
-thumb_func 0x8111d3c
+thumb_func 0x8111d3c SafariHandleLoadMonSprite
 thumb_func 0x8111d7c
 thumb_func 0x8111de0
 thumb_func 0x8111e5c
@@ -9035,8 +9035,8 @@ thumb_func 0x8112064
 thumb_func 0x81120dc
 thumb_func 0x8112164
 thumb_func 0x81121bc
-thumb_func 0x8112230
-thumb_func 0x81122d8
+thumb_func 0x8112230 InitAnimShadowBall
+thumb_func 0x81122d8 AnimShadowBallStep
 thumb_func 0x81123ec
 thumb_func 0x8112404
 thumb_func 0x81124a0
@@ -9096,18 +9096,18 @@ thumb_func 0x8114bc4
 thumb_func 0x8114c10
 thumb_func 0x8114cc0
 thumb_func 0x8114d0c
-thumb_func 0x8114d48
+thumb_func 0x8114d48 AnimTask_MetallicShine
 thumb_func 0x8114f98
-thumb_func 0x81150ec
+thumb_func 0x81150ec AnimTask_SetGreyscaleOrOriginalPal
 thumb_func 0x81151b0
-thumb_func 0x81151e4
-thumb_func 0x811524c
-thumb_func 0x81152b0
+thumb_func 0x81151e4 AnimBonemerangProjectile
+thumb_func 0x811524c AnimBonemerangProjectileStep
+thumb_func 0x81152b0 AnimFissureDirtPlumeParticleStep
 thumb_func 0x81152cc
-thumb_func 0x8115340
+thumb_func 0x8115340 AnimDirtScatter
 thumb_func 0x81153d0
-thumb_func 0x8115460
-thumb_func 0x811549c
+thumb_func 0x8115460 AnimMudSportDirtRising
+thumb_func 0x811549c AnimMudSportDirtFalling
 thumb_func 0x811550c
 thumb_func 0x811554c
 thumb_func 0x8115704
@@ -9115,20 +9115,20 @@ thumb_func 0x8115764
 thumb_func 0x81157a4
 thumb_func 0x8115828
 thumb_func 0x8115930
-thumb_func 0x81159f0
+thumb_func 0x81159f0 AnimFissureDirtPlumeParticle
 thumb_func 0x8115a78
-thumb_func 0x8115a94
+thumb_func 0x8115a94 AnimDigDirtMound
 thumb_func 0x8115b2c
 thumb_func 0x8115bfc
 thumb_func 0x8115cf4
 thumb_func 0x8115dd8
-thumb_func 0x8115e50
+thumb_func 0x8115e50 AnimTask_IsPowerOver99
 thumb_func 0x8115e78
 thumb_func 0x8115f20
-thumb_func 0x8115f7c
-thumb_func 0x8115fe8
-thumb_func 0x811604c
-thumb_func 0x811608c
+thumb_func 0x8115f7c AnimConfusionDuck
+thumb_func 0x8115fe8 AnimConfusionDuckStep
+thumb_func 0x811604c AnimSimplePaletteBlend
+thumb_func 0x811608c UnpackSelectedBattleAnimPalettes
 thumb_func 0x81160d4
 thumb_func 0x81160f4
 thumb_func 0x8116148
@@ -9163,10 +9163,10 @@ thumb_func 0x8116df8
 thumb_func 0x8116e34
 thumb_func 0x8116e70
 thumb_func 0x8116eb4
-thumb_func 0x8116fac
-thumb_func 0x8117098
-thumb_func 0x81170c4
-thumb_func 0x8117108
+thumb_func 0x8116fac AnimTask_SetCamouflageBlend
+thumb_func 0x8117098 AnimTask_BlendParticle
+thumb_func 0x81170c4 StartBlendAnimSpriteColor
+thumb_func 0x8117108 AnimTask_BlendSpriteColor_Step2
 thumb_func 0x81171b0
 thumb_func 0x81171f0
 thumb_func 0x8117210
@@ -9186,89 +9186,89 @@ thumb_func 0x8117eb0
 thumb_func 0x8117f28
 thumb_func 0x8117fa4
 thumb_func 0x8117fd0
-thumb_func 0x8117ffc
+thumb_func 0x8117ffc AnimTask_GetTargetIsAttackerPartner
 thumb_func 0x8118034
 thumb_func 0x81180a4
 thumb_func 0x81182b0
-thumb_func 0x8118474
+thumb_func 0x8118474 AnimTask_GetBattleTerrain
 thumb_func 0x8118494
 thumb_func 0x81184c0
 thumb_func 0x81184f0
 thumb_func 0x811858c
 thumb_func 0x8118628
-thumb_func 0x81186b0
+thumb_func 0x81186b0 AnimTask_IsContest
 thumb_func 0x81186e4
-thumb_func 0x8118714
+thumb_func 0x8118714 AnimTask_IsTargetSameSide
 thumb_func 0x8118760
 thumb_func 0x8118780
 thumb_func 0x81187b0
 thumb_func 0x8118820
-thumb_func 0x811887c
-thumb_func 0x8118990
-thumb_func 0x8118a24
+thumb_func 0x811887c SetAnimBgAttribute
+thumb_func 0x8118990 GetAnimBgAttribute
+thumb_func 0x8118a24 HandleIntroSlide
 thumb_func 0x8118adc
-thumb_func 0x8118b3c
-thumb_func 0x8118d88
-thumb_func 0x8119094
-thumb_func 0x8119310
-thumb_func 0x81195b8
+thumb_func 0x8118b3c BattleIntroSlide1
+thumb_func 0x8118d88 BattleIntroSlide2
+thumb_func 0x8119094 BattleIntroSlide3
+thumb_func 0x8119310 BattleIntroSlideLink
+thumb_func 0x81195b8 BattleIntroSlidePartner
 thumb_func 0x811980c
 thumb_func 0x81198e4 unref_sub_8119094
-thumb_func 0x81199b4
-thumb_func 0x81199ec
+thumb_func 0x81199b4 MovePlayerOnBike
+thumb_func 0x81199ec MovePlayerOnMachBike
 thumb_func 0x8119a10
-thumb_func 0x8119a1c
-thumb_func 0x8119a74
-thumb_func 0x8119a88
-thumb_func 0x8119ad0
+thumb_func 0x8119a1c GetMachBikeTransition
+thumb_func 0x8119a74 MachBikeTransition_FaceDirection
+thumb_func 0x8119a88 MachBikeTransition_TurnDirection
+thumb_func 0x8119ad0 MachBikeTransition_TrySpeedUp
 thumb_func 0x8119b94
-thumb_func 0x8119c18
+thumb_func 0x8119c18 MovePlayerOnAcroBike
 thumb_func 0x8119c44
-thumb_func 0x8119c50
-thumb_func 0x8119c7c
-thumb_func 0x8119d18
-thumb_func 0x8119d90
-thumb_func 0x8119e30
-thumb_func 0x8119ed8
-thumb_func 0x8119fb4
+thumb_func 0x8119c50 CheckMovementInputAcroBike
+thumb_func 0x8119c7c AcroBikeHandleInputNormal
+thumb_func 0x8119d18 AcroBikeHandleInputTurning
+thumb_func 0x8119d90 AcroBikeHandleInputWheelieStanding
+thumb_func 0x8119e30 AcroBikeHandleInputBunnyHop
+thumb_func 0x8119ed8 AcroBikeHandleInputWheelieMoving
+thumb_func 0x8119fb4 AcroBikeHandleInputSidewaysJump
 thumb_func 0x811a010 AcroBikeHandleInputTurnJump
-thumb_func 0x811a034
-thumb_func 0x811a044
-thumb_func 0x811a080
-thumb_func 0x811a110
-thumb_func 0x811a14c
-thumb_func 0x811a188
-thumb_func 0x811a1c4
-thumb_func 0x811a200
-thumb_func 0x811a274
+thumb_func 0x811a034 AcroBikeTransition_TurnJump
+thumb_func 0x811a044 AcroBikeTransition_TurnDirection
+thumb_func 0x811a080 AcroBikeTransition_Moving
+thumb_func 0x811a110 AcroBikeTransition_NormalToWheelie
+thumb_func 0x811a14c AcroBikeTransition_WheelieToNormal
+thumb_func 0x811a188 AcroBikeTransition_WheelieIdle
+thumb_func 0x811a1c4 AcroBikeTransition_WheelieHoppingStanding
+thumb_func 0x811a200 AcroBikeTransition_WheelieHoppingMoving
+thumb_func 0x811a274 AcroBikeTransition_SideJump
 thumb_func 0x811a2e4
-thumb_func 0x811a2f4
-thumb_func 0x811a384
-thumb_func 0x811a414
+thumb_func 0x811a2f4 AcroBikeTransition_WheelieMoving
+thumb_func 0x811a384 AcroBikeTransition_WheelieRisingMoving
+thumb_func 0x811a414 AcroBikeTransition_WheelieLoweringMoving
 thumb_func 0x811a48c Bike_TryAcroBikeHistoryUpdate
-thumb_func 0x811a4b4
-thumb_func 0x811a51c
-thumb_func 0x811a580
+thumb_func 0x811a4b4 AcroBike_TryHistoryUpdate
+thumb_func 0x811a51c HasPlayerInputTakenLongerThanList
+thumb_func 0x811a580 AcroBike_GetJumpDirection
 thumb_func 0x811a5d0 Bike_UpdateDirTimerHistory
 thumb_func 0x811a60c Bike_UpdateABStartSelectHistory
 thumb_func 0x811a648 Bike_DPadToDirection
-thumb_func 0x811a688
-thumb_func 0x811a6f4
-thumb_func 0x811a740
-thumb_func 0x811a768
+thumb_func 0x811a688 get_some_collision
+thumb_func 0x811a6f4 Bike_CheckCollisionTryAdvanceCollisionCount
+thumb_func 0x811a740 RS_IsRunningDisallowed
+thumb_func 0x811a768 IsRunningDisallowedByMetatile
 thumb_func 0x811a7a0 Bike_TryAdvanceCyclingRoadCollisions
-thumb_func 0x811a7c4
+thumb_func 0x811a7c4 CanBikeFaceDirOnMetatile
 thumb_func 0x811a814 WillPlayerCollideWithCollision
-thumb_func 0x811a848
-thumb_func 0x811a894
-thumb_func 0x811a8d0
+thumb_func 0x811a848 IsBikingDisallowedByPlayer
+thumb_func 0x811a894 IsMonValidSpecies
+thumb_func 0x811a8d0 GetOnOffBike
 thumb_func 0x811a920 BikeClearState
-thumb_func 0x811a964
-thumb_func 0x811a978
-thumb_func 0x811a988
-thumb_func 0x811a9d8
-thumb_func 0x811aa2c
-thumb_func 0x811aa5c
+thumb_func 0x811a964 Bike_UpdateBikeCounterSpeed
+thumb_func 0x811a978 Bike_SetBikeStill
+thumb_func 0x811a988 GetPlayerSpeed
+thumb_func 0x811a9d8 Bike_HandleBumpySlopeJump
+thumb_func 0x811aa2c IsRunningDisallowed
+thumb_func 0x811aa5c DoEasyChatScreen
 thumb_func 0x811aac8
 thumb_func 0x811aae0
 thumb_func 0x811aaf4
@@ -9276,7 +9276,7 @@ thumb_func 0x811ab10
 thumb_func 0x811ab4c
 thumb_func 0x811ac78
 thumb_func 0x811ad20
-thumb_func 0x811ad40
+thumb_func 0x811ad40 ShowEasyChatScreen
 thumb_func 0x811b034
 thumb_func 0x811b0a8
 thumb_func 0x811b0b8
@@ -9286,7 +9286,7 @@ thumb_func 0x811b11c DoQuizAnswerEasyChatScreen
 thumb_func 0x811b140 DoQuizQuestionEasyChatScreen
 thumb_func 0x811b164 DoQuizSetAnswerEasyChatScreen
 thumb_func 0x811b188 DoQuizSetQuestionEasyChatScreen
-thumb_func 0x811b1ac
+thumb_func 0x811b1ac EasyChat_AllocateResources
 thumb_func 0x811b2d0
 thumb_func 0x811b2ec
 thumb_func 0x811b384
@@ -9321,7 +9321,7 @@ thumb_func 0x811bd38
 thumb_func 0x811be04
 thumb_func 0x811be94
 thumb_func 0x811bf14
-thumb_func 0x811bf38
+thumb_func 0x811bf38 AnimTask_GrowAndShrinkStep
 thumb_func 0x811bf64
 thumb_func 0x811c098
 thumb_func 0x811c0b8
@@ -9335,16 +9335,16 @@ thumb_func 0x811c220
 thumb_func 0x811c240 FooterHasFourOptions
 thumb_func 0x811c260
 thumb_func 0x811c26c GetEasyChatScreenFrameId
-thumb_func 0x811c28c
-thumb_func 0x811c298
-thumb_func 0x811c2a4
-thumb_func 0x811c2b0
-thumb_func 0x811c2bc
+thumb_func 0x811c28c GetTitleText
+thumb_func 0x811c298 GetEasyChatWordBuffer
+thumb_func 0x811c2a4 GetNumRows
+thumb_func 0x811c2b0 GetNumColumns
+thumb_func 0x811c2bc GetMainCursorColumn
 thumb_func 0x811c2c8
 thumb_func 0x811c2d4 GetEasyChatInstructionsText
 thumb_func 0x811c30c GetEasyChatConfirmText
 thumb_func 0x811c344
-thumb_func 0x811c38c
+thumb_func 0x811c38c GetEasyChatConfirmDeletionText
 thumb_func 0x811c3a0
 thumb_func 0x811c3b4
 thumb_func 0x811c3c0
@@ -9354,10 +9354,10 @@ thumb_func 0x811c3ec
 thumb_func 0x811c3f8
 thumb_func 0x811c3fc
 thumb_func 0x811c430
-thumb_func 0x811c474
+thumb_func 0x811c474 FooterHasFourOptions_
 thumb_func 0x811c480
-thumb_func 0x811c4c0
-thumb_func 0x811c4cc
+thumb_func 0x811c4c0 GetDisplayedPersonType
+thumb_func 0x811c4cc GetEachChatScreenTemplateId
 thumb_func 0x811c4f8
 thumb_func 0x811c530
 thumb_func 0x811c568
@@ -9390,7 +9390,7 @@ thumb_func 0x811d034
 thumb_func 0x811d040
 thumb_func 0x811d088
 thumb_func 0x811d0e4
-thumb_func 0x811d1a4
+thumb_func 0x811d1a4 IsDma3ManagerBusyWithBgCopy_
 thumb_func 0x811d250
 thumb_func 0x811d310
 thumb_func 0x811d3cc
@@ -9429,7 +9429,7 @@ thumb_func 0x811e004
 thumb_func 0x811e048
 thumb_func 0x811e07c
 thumb_func 0x811e164
-thumb_func 0x811e1c8
+thumb_func 0x811e1c8 VBlankCB_MailRead
 thumb_func 0x811e1e0
 thumb_func 0x811e2b8
 thumb_func 0x811e2f0
@@ -9469,14 +9469,14 @@ thumb_func 0x811ee2c
 thumb_func 0x811ee6c
 thumb_func 0x811eee0
 thumb_func 0x811ef44
-thumb_func 0x811ef74
+thumb_func 0x811ef74 GetCoolColorFromPersonality
 thumb_func 0x811f044
-thumb_func 0x811f088
+thumb_func 0x811f088 EasyChat_GetNumWordsInGroup
 thumb_func 0x811f0c0
-thumb_func 0x811f12c
-thumb_func 0x811f180
+thumb_func 0x811f12c GetEasyChatWord
+thumb_func 0x811f180 CopyEasyChatWord
 thumb_func 0x811f1cc ConvertEasyChatWordsToString
-thumb_func 0x811f25c
+thumb_func 0x811f25c GetEasyChatWordStringLength
 thumb_func 0x811f2a4
 thumb_func 0x811f318
 thumb_func 0x811f370
@@ -9495,9 +9495,9 @@ thumb_func 0x811f814
 thumb_func 0x811f830
 thumb_func 0x811f908
 thumb_func 0x811f914
-thumb_func 0x811f93c
+thumb_func 0x811f93c unref_sub_811F3E0
 thumb_func 0x811f980
-thumb_func 0x811f990
+thumb_func 0x811f990 CopyEasyChatWordPadded
 thumb_func 0x811f9c8
 thumb_func 0x811faa0
 thumb_func 0x811fad0
@@ -9519,7 +9519,7 @@ thumb_func 0x8120018
 thumb_func 0x81200c4
 thumb_func 0x81201a0
 thumb_func 0x812045c nullsub_71
-thumb_func 0x8120460
+thumb_func 0x8120460 OpponentHandleChosenMonReturnValue
 thumb_func 0x812049c
 thumb_func 0x81204b4
 thumb_func 0x81204d4
@@ -9527,85 +9527,85 @@ thumb_func 0x81204f4
 thumb_func 0x81205a4
 thumb_func 0x81205c0 SetupBard
 thumb_func 0x8120618 SetupHipster
-thumb_func 0x812063c
+thumb_func 0x812063c SafariHandleDrawPartyStatusSummary
 thumb_func 0x8120648 SetupGiddy
 thumb_func 0x8120674
-thumb_func 0x8120680
+thumb_func 0x8120680 SetMauvilleOldMan
 thumb_func 0x81206e8
 thumb_func 0x81206fc ScrSpecial_GetCurrentMauvilleMan
-thumb_func 0x8120714
-thumb_func 0x8120730
+thumb_func 0x8120714 ScrSpecial_HasBardSongBeenChanged
+thumb_func 0x8120730 ScrSpecial_SaveBardSongLyrics
 thumb_func 0x81207a0
-thumb_func 0x8120820
-thumb_func 0x8120838
-thumb_func 0x8120854
-thumb_func 0x812086c
-thumb_func 0x81208a4
-thumb_func 0x81208dc
-thumb_func 0x81209bc
+thumb_func 0x8120820 ScrSpecial_PlayBardSong
+thumb_func 0x8120838 ScrSpecial_GetHipsterSpokenFlag
+thumb_func 0x8120854 ScrSpecial_SetHipsterSpokenFlag
+thumb_func 0x812086c ScrSpecial_HipsterTeachWord
+thumb_func 0x81208a4 ScrSpecial_GiddyShouldTellAnotherTale
+thumb_func 0x81208dc ScrSpecial_GenerateGiddyLine
+thumb_func 0x81209bc InitGiddyTaleList
 thumb_func 0x8120b08
-thumb_func 0x8120b20
+thumb_func 0x8120b20 ResetHipsterFlag
 thumb_func 0x8120b38
 thumb_func 0x8120b44
-thumb_func 0x8120b50
-thumb_func 0x8120ba0
+thumb_func 0x8120b50 ResetMauvilleOldManFlag
+thumb_func 0x8120ba0 StartBardSong
 thumb_func 0x8120bd0
 thumb_func 0x8120bdc
 thumb_func 0x8120be8
 thumb_func 0x8120c2c
-thumb_func 0x8120e18
+thumb_func 0x8120e18 ScrSpecial_SetMauvilleOldManEventObjGfx
 thumb_func 0x8120e2c
 thumb_func 0x8120e90
 thumb_func 0x8120f54 StorytellerSetup
 thumb_func 0x8120f9c Storyteller_ResetFlag
-thumb_func 0x8120fc0
-thumb_func 0x8120fd4
-thumb_func 0x8121000
-thumb_func 0x812100c
-thumb_func 0x8121018
+thumb_func 0x8120fc0 StorytellerGetGameStat
+thumb_func 0x8120fd4 GetStoryByStat
+thumb_func 0x8121000 GetStoryTitleByStat
+thumb_func 0x812100c GetStoryTextByStat
+thumb_func 0x8121018 GetStoryActionByStat
 thumb_func 0x8121024 GetFreeStorySlot
 thumb_func 0x8121054 StorytellerGetRecordedTrainerStat
 thumb_func 0x8121078 StorytellerSetRecordedTrainerStat
-thumb_func 0x8121098
-thumb_func 0x81210c8
-thumb_func 0x81210f8
-thumb_func 0x8121128
-thumb_func 0x81211b0
-thumb_func 0x8121204
+thumb_func 0x8121098 HasTrainerStatIncreased
+thumb_func 0x81210c8 GetStoryByStattellerPlayerName
+thumb_func 0x81210f8 StorytellerSetPlayerName
+thumb_func 0x8121128 StorytellerRecordNewStat
+thumb_func 0x81211b0 ScrambleStatList
+thumb_func 0x8121204 StorytellerInitializeRandomStat
 thumb_func 0x81212c4
-thumb_func 0x8121320
-thumb_func 0x81213ec
-thumb_func 0x8121478
+thumb_func 0x8121320 Task_Dive
+thumb_func 0x81213ec Task_StoryListMenu
+thumb_func 0x8121478 ScrSpecial_StorytellerStoryListMenu
 thumb_func 0x812148c
 thumb_func 0x81214a0
-thumb_func 0x81214c8
-thumb_func 0x8121514
+thumb_func 0x81214c8 ScrSpecial_StorytellerUpdateStat
+thumb_func 0x8121514 ScrSpecial_HasStorytellerAlreadyRecorded
 thumb_func 0x8121540
 thumb_func 0x8121568
-thumb_func 0x8121688
-thumb_func 0x8121a60
+thumb_func 0x8121688 MailReadBuildGraphics
+thumb_func 0x8121a60 CB2_InitMailRead
 thumb_func 0x8121a8c
-thumb_func 0x8121b64
+thumb_func 0x8121b64 LoadSavedMapView
 thumb_func 0x8121c60
 thumb_func 0x8121c74
 thumb_func 0x8121c94
-thumb_func 0x8121ca0
-thumb_func 0x8121cc4
-thumb_func 0x8121d00
-thumb_func 0x8121d90
-thumb_func 0x8121e00
-thumb_func 0x8121e58
-thumb_func 0x8121e6c
-thumb_func 0x8121f10
-thumb_func 0x8121f2c
+thumb_func 0x8121ca0 CB2_WaitForPaletteExitOnKeyPress
+thumb_func 0x8121cc4 CB2_ExitOnKeyPress
+thumb_func 0x8121d00 CB2_ExitMailReadFreeVars
+thumb_func 0x8121d90 ResetVramOamAndBgCntRegs
+thumb_func 0x8121e00 ResetAllBgsCoordinates
+thumb_func 0x8121e58 SetVBlankHBlankCallbacksToNull
+thumb_func 0x8121e6c DisplayMessageAndContinueTask
+thumb_func 0x8121f10 RunTextPrintersRetIsActive
+thumb_func 0x8121f2c Task_ContinueTaskAfterMessagePrints
 thumb_func 0x8121f58 DoYesNoFuncWithChoice
 thumb_func 0x8121f84
-thumb_func 0x8121fe8
-thumb_func 0x8122040
-thumb_func 0x81220dc
+thumb_func 0x8121fe8 Task_CallYesOrNoCallback
+thumb_func 0x8122040 AdjustQuantityAccordingToDPadInput
+thumb_func 0x81220dc GetLRKeysState
 thumb_func 0x8122118
 thumb_func 0x8122154
-thumb_func 0x8122188
+thumb_func 0x8122188 itemid_80BF6D8_mail_related
 thumb_func 0x81221b8
 thumb_func 0x81221dc
 thumb_func 0x81221f8
@@ -9617,73 +9617,73 @@ thumb_func 0x8122350
 thumb_func 0x81223bc
 thumb_func 0x8122408
 thumb_func 0x8122454
-thumb_func 0x81224e0
-thumb_func 0x812258c
+thumb_func 0x81224e0 InitDewfordTrend
+thumb_func 0x812258c UpdateDewfordTrendPerDay
 thumb_func 0x81226e4
 thumb_func 0x8122810
-thumb_func 0x8122888
-thumb_func 0x81229a4
+thumb_func 0x8122888 ReceiveEasyChatPairsData
+thumb_func 0x81229a4 BufferTrendyPhraseString
 thumb_func 0x81229d4 TrendyPhraseIsOld
 thumb_func 0x8122a3c GetDewfordHallPaintingNameIndex
 thumb_func 0x8122a64
 thumb_func 0x8122b34
-thumb_func 0x8122bbc
+thumb_func 0x8122bbc SB1ContainsWords
 thumb_func 0x8122bfc IsEasyChatPairEqual
 thumb_func 0x8122c28 GetEqualEasyChatPairIndex
-thumb_func 0x8122c68
-thumb_func 0x8122ca0
-thumb_func 0x8122cc8
+thumb_func 0x8122c68 GetHealLocationIndexByMap
+thumb_func 0x8122ca0 GetHealLocationByMap
+thumb_func 0x8122cc8 GetHealLocation
 thumb_func 0x8122ce8 InitRegionMap
 thumb_func 0x8122d04
 thumb_func 0x8122d94
 thumb_func 0x8122dbc
 thumb_func 0x812303c
-thumb_func 0x8123068
+thumb_func 0x8123068 FreeRegionMapIconResources
 thumb_func 0x81230b8
 thumb_func 0x81230c4
-thumb_func 0x81230d0
-thumb_func 0x812319c
+thumb_func 0x81230d0 ProcessRegionMapInput_Full
+thumb_func 0x812319c MoveRegionMapCursor_Full
 thumb_func 0x8123260 ProcessRegionMapInput_Zoomed
-thumb_func 0x8123340
+thumb_func 0x8123340 MoveRegionMapCursor_Zoomed
 thumb_func 0x8123424
 thumb_func 0x8123520
 thumb_func 0x81236d0 CalcZoomScrollParams
 thumb_func 0x8123798 RegionMap_SetBG2XAndBG2Y
-thumb_func 0x81237c0
+thumb_func 0x81237c0 UpdateRegionMapVideoRegs
 thumb_func 0x8123830 PokedexAreaScreen_UpdateRegionMapVariablesAndVideoRegs
 thumb_func 0x8123878 GetRegionMapSectionIdAt_Internal
-thumb_func 0x81238b8
-thumb_func 0x8123c0c
-thumb_func 0x8123d64
+thumb_func 0x81238b8 RegionMap_InitializeStateBasedOnPlayerLocation
+thumb_func 0x8123c0c RegionMap_InitializeStateBasedOnSSTidalLocation
+thumb_func 0x8123d64 get_flagnr_blue_points
 thumb_func 0x8123ea8 GetRegionMapSectionIdAt
-thumb_func 0x8123ec0
-thumb_func 0x8123f10
+thumb_func 0x8123ec0 CorrectSpecialMapSecId_Internal
+thumb_func 0x8123f10 RegionMap_GetTerraCaveMapSecId
 thumb_func 0x8123f3c
-thumb_func 0x8123f80
-thumb_func 0x8123fa8
-thumb_func 0x8123fbc
+thumb_func 0x8123f80 RegionMap_IsPlayerInCave
+thumb_func 0x8123fa8 CorrectSpecialMapSecId
+thumb_func 0x8123fbc RegionMap_GetPositionOfCursorWithinMapSection
 thumb_func 0x8124044 RegionMap_IsMapSecIdInNextRow
 thumb_func 0x8124094 SpriteCallback_CursorFull
 thumb_func 0x81240dc nullsub_70
-thumb_func 0x81240e0
-thumb_func 0x8124244
+thumb_func 0x81240e0 CreateRegionMapCursor
+thumb_func 0x8124244 FreeRegionMapCursorSprite
 thumb_func 0x8124274
 thumb_func 0x8124284
-thumb_func 0x8124294
+thumb_func 0x8124294 CreateRegionMapPlayerIcon
 thumb_func 0x81243bc HideRegionMapPlayerIcon
-thumb_func 0x81243e8
-thumb_func 0x8124468
+thumb_func 0x81243e8 UnhideRegionMapPlayerIcon
+thumb_func 0x8124468 RegionMapPlayerIconSpriteCallback_Zoomed
 thumb_func 0x81244f8
-thumb_func 0x8124504
+thumb_func 0x8124504 RegionMapPlayerIconSpriteCallback
 thumb_func 0x8124558
-thumb_func 0x8124578
+thumb_func 0x8124578 GetMapName
 thumb_func 0x81245e8
 thumb_func 0x812461c
 thumb_func 0x812463c
 thumb_func 0x8124664
 thumb_func 0x8124674
-thumb_func 0x812469c
-thumb_func 0x81248cc
+thumb_func 0x812469c MCB2_FlyMap
+thumb_func 0x81248cc CheckLeadMonTough
 thumb_func 0x81248e0
 thumb_func 0x81248f0
 thumb_func 0x8124900
@@ -9735,68 +9735,68 @@ thumb_func 0x81268f0
 thumb_func 0x8126924
 thumb_func 0x8126950 InitDecorationContextItems
 thumb_func 0x81269bc
-thumb_func 0x81269f8
+thumb_func 0x81269f8 RemoveDecorationWindow
 thumb_func 0x8126a28
-thumb_func 0x8126a84
+thumb_func 0x8126a84 InitDecorationActionsWindow
 thumb_func 0x8126aa0 DoSecretBaseDecorationMenu
 thumb_func 0x8126af4 DoPlayerRoomDecorationMenu
-thumb_func 0x8126b48
-thumb_func 0x8126bd0
-thumb_func 0x8126c10
-thumb_func 0x8126c6c
+thumb_func 0x8126b48 HandleDecorationActionsMenuInput
+thumb_func 0x8126bd0 PrintCurMainMenuDescription
+thumb_func 0x8126c10 DecorationMenuAction_Decorate
+thumb_func 0x8126c6c DecorationMenuAction_PutAway
 thumb_func 0x8126cd8
-thumb_func 0x8126d34
+thumb_func 0x8126d34 DecorationMenuAction_Cancel
 thumb_func 0x8126d6c ReturnToDecorationActionsAfterInvalidSelection
-thumb_func 0x8126d94
+thumb_func 0x8126d94 SecretBasePC_PrepMenuForSelectingStoredDecors
 thumb_func 0x8126dc4
-thumb_func 0x8126e1c
+thumb_func 0x8126e1c task_map_chg_seq_0807EC34
 thumb_func 0x8126e78
 thumb_func 0x8126f20
-thumb_func 0x8127010
-thumb_func 0x8127040
-thumb_func 0x81270a0
-thumb_func 0x8127138
-thumb_func 0x8127154
-thumb_func 0x8127184
-thumb_func 0x81271c0
-thumb_func 0x8127208
-thumb_func 0x8127220
-thumb_func 0x812723c
+thumb_func 0x8127010 ColorMenuItemString
+thumb_func 0x8127040 HandleDecorationCategoriesMenuInput
+thumb_func 0x81270a0 SelectDecorationCategory
+thumb_func 0x8127138 ReturnToDecorationCategoriesAfterInvalidSelection
+thumb_func 0x8127154 ExitDecorationCategoriesMenu
+thumb_func 0x8127184 ReturnToActionsMenuFromCategories
+thumb_func 0x81271c0 ShowDecorationCategoriesWindow
+thumb_func 0x8127208 CopyDecorationCategoryName
+thumb_func 0x8127220 ExitTraderDecorationMenu
+thumb_func 0x812723c InitDecorationItemsMenuLimits
 thumb_func 0x8127280
 thumb_func 0x81272b0
-thumb_func 0x81272e8
-thumb_func 0x8127404
-thumb_func 0x8127430
+thumb_func 0x81272e8 PrintDecorationItemMenuItems
+thumb_func 0x8127404 CopyDecorationMenuItemName
+thumb_func 0x8127430 DecorationItemsMenu_OnCursorMove
 thumb_func 0x8127450
-thumb_func 0x81274b0
+thumb_func 0x81274b0 AddDecorationItemsScrollIndicators
 thumb_func 0x8127504
 thumb_func 0x8127530
-thumb_func 0x812754c
-thumb_func 0x81275cc
-thumb_func 0x81275f8
-thumb_func 0x81276c4
-thumb_func 0x81276f0
-thumb_func 0x8127758
+thumb_func 0x812754c InitDecorationItemsWindow
+thumb_func 0x81275cc ShowDecorationItemsWindow
+thumb_func 0x81275f8 HandleDecorationItemsMenuInput
+thumb_func 0x81276c4 ShowDecorationCategorySummaryWindow
+thumb_func 0x81276f0 PrintDecorationItemDescription
+thumb_func 0x8127758 RemoveDecorationItemsOtherWindows
 thumb_func 0x812776c
 thumb_func 0x8127798
-thumb_func 0x81277c4
-thumb_func 0x8127964
-thumb_func 0x8127974
+thumb_func 0x81277c4 IdentifyOwnedDecorationsCurrentlyInUseInternal
+thumb_func 0x8127964 IdentifyOwnedDecorationsCurrentlyInUse
+thumb_func 0x8127974 IsSelectedDecorInThePC
 thumb_func 0x81279c4
 thumb_func 0x81279e0
 thumb_func 0x8127a0c
-thumb_func 0x8127a3c
+thumb_func 0x8127a3c SafariHandleSuccessBallThrowAnim
 thumb_func 0x8127a7c
 thumb_func 0x8127ab4
-thumb_func 0x8127b04
-thumb_func 0x8127b40
+thumb_func 0x8127b04 GetDecorationElevation
+thumb_func 0x8127b40 ShowDecorationOnMap_
 thumb_func 0x8127d08
 thumb_func 0x8127dec
 thumb_func 0x8127f0c
 thumb_func 0x8127f3c
 thumb_func 0x8128034
-thumb_func 0x81280ec
-thumb_func 0x812817c
+thumb_func 0x81280ec ConfigureCameraObjectForPlacingDecoration
+thumb_func 0x812817c SetUpPlacingDecorationPlayerAvatar
 thumb_func 0x8128240
 thumb_func 0x8128394
 thumb_func 0x81283ec
@@ -9811,7 +9811,7 @@ thumb_func 0x8128a8c
 thumb_func 0x8128b60
 thumb_func 0x8128b80
 thumb_func 0x8128b9c
-thumb_func 0x8128bcc
+thumb_func 0x8128bcc c1_overworld_prev_quest
 thumb_func 0x8128c44
 thumb_func 0x8128cb4
 thumb_func 0x8128cf0
@@ -9830,17 +9830,17 @@ thumb_func 0x812923c SetDecorSelectionBoxOamAttributes
 thumb_func 0x81292b0
 thumb_func 0x81292c8
 thumb_func 0x8129314
-thumb_func 0x81293bc
+thumb_func 0x81293bc AddDecorationIconObjectFromIconTable
 thumb_func 0x8129480 GetDecorationIconPicOrPalette
 thumb_func 0x81294a4
-thumb_func 0x81295b4
+thumb_func 0x81295b4 AddDecorationIconObject
 thumb_func 0x81296d4
 thumb_func 0x81296f0
 thumb_func 0x8129798
 thumb_func 0x81297e4
 thumb_func 0x81298dc
 thumb_func 0x812999c
-thumb_func 0x81299cc
+thumb_func 0x81299cc SetUpPuttingAwayDecorationPlayerAvatar
 thumb_func 0x8129aac
 thumb_func 0x8129b24
 thumb_func 0x8129bbc
@@ -9863,128 +9863,128 @@ thumb_func 0x812a268
 thumb_func 0x812a2d0
 thumb_func 0x812a340
 thumb_func 0x812a378
-thumb_func 0x812a3a8
+thumb_func 0x812a3a8 CB2_PokeblockMenu
 thumb_func 0x812a3d4
 thumb_func 0x812a3e0
 thumb_func 0x812a468
 thumb_func 0x812a488
-thumb_func 0x812a4ec
-thumb_func 0x812a550
-thumb_func 0x812a598
+thumb_func 0x812a4ec Task_FadeToSlotMachine
+thumb_func 0x812a550 PlaySlotMachine
+thumb_func 0x812a598 CB2_SlotMachineSetup
 thumb_func 0x812a680
-thumb_func 0x812a698
-thumb_func 0x812a6e4
+thumb_func 0x812a698 mevent_srv_new_wcard
+thumb_func 0x812a6e4 PlaySlotMachine_Internal
 thumb_func 0x812a720
 thumb_func 0x812a75c nullsub_73
-thumb_func 0x812a760
-thumb_func 0x812a7ac
+thumb_func 0x812a760 SlotMachineSetup_0_0
+thumb_func 0x812a7ac ContestEffect_StartleMonsCuteAppeal
 thumb_func 0x812a7cc SlotMachineSetup_1_0
 thumb_func 0x812a820 SlotMachineSetup_2_0
-thumb_func 0x812a844
-thumb_func 0x812a8d4
-thumb_func 0x812a9bc
-thumb_func 0x812a9dc
-thumb_func 0x812aa58
+thumb_func 0x812a844 SlotMachineSetup_2_1
+thumb_func 0x812a8d4 SlotMachineSetup_0_1
+thumb_func 0x812a9bc SlotMachineSetup_3_0
+thumb_func 0x812a9dc SlotMachineSetup_4_0
+thumb_func 0x812aa58 SlotMachineSetup_5_0
 thumb_func 0x812aa88 SlotMachineSetup_10_0
 thumb_func 0x812aaa0 SlotMachineSetupGameplayTasks
 thumb_func 0x812aab8
-thumb_func 0x812aad8
-thumb_func 0x812ab14
+thumb_func 0x812aad8 RunSlotActions
+thumb_func 0x812ab14 SlotAction_UnfadeScreen
 thumb_func 0x812ab48 SlotAction_WaitForUnfade
-thumb_func 0x812ab70
+thumb_func 0x812ab70 SlotAction_SetSlotMachineVars
 thumb_func 0x812abb8 SlotAction3
 thumb_func 0x812abd8 SlotAction4
-thumb_func 0x812ac08
+thumb_func 0x812ac08 SlotAction_AwaitPlayerInput
 thumb_func 0x812ad04
 thumb_func 0x812ad44
 thumb_func 0x812ad70 SlotAction_GivingInformation
-thumb_func 0x812ad90
+thumb_func 0x812ad90 SlotAction9
 thumb_func 0x812ae04 SlotAction10
 thumb_func 0x812ae34 SlotAction_SetLuckySpins
-thumb_func 0x812ae5c
-thumb_func 0x812ae98
-thumb_func 0x812aed4
+thumb_func 0x812ae5c SlotAction_AwaitReelStop
+thumb_func 0x812ae98 SlotAction_WaitForAllReelsToStop
+thumb_func 0x812aed4 SlotAction_CheckMatches
 thumb_func 0x812b00c SlotAction_WaitForPayoutToBeAwarded
-thumb_func 0x812b02c
+thumb_func 0x812b02c SlotAction_EndOfRoll
 thumb_func 0x812b0a4 SlotAction_MatchedPower
 thumb_func 0x812b0e8 SlotAction18
 thumb_func 0x812b118 SlotAction_Loop
 thumb_func 0x812b140 SlotAction_NoMatches
-thumb_func 0x812b168
-thumb_func 0x812b1c0
+thumb_func 0x812b168 SlotAction_PrintQuitTheGame
+thumb_func 0x812b1c0 SlotAction_SeeIfPlayerQuits
 thumb_func 0x812b224
 thumb_func 0x812b264
-thumb_func 0x812b290
+thumb_func 0x812b290 SlotAction_PrintMessage_NoMoreCoins
 thumb_func 0x812b2d0
-thumb_func 0x812b2fc
-thumb_func 0x812b33c
+thumb_func 0x812b2fc SlotAction_EndGame
+thumb_func 0x812b33c SlotAction_FreeDataStructures
 thumb_func 0x812b4fc DrawLuckyFlags
 thumb_func 0x812b56c SetLuckySpins
-thumb_func 0x812b58c
-thumb_func 0x812b5c0
-thumb_func 0x812b5fc
-thumb_func 0x812b644
-thumb_func 0x812b6dc
-thumb_func 0x812b710
-thumb_func 0x812b770
-thumb_func 0x812b79c
+thumb_func 0x812b58c GetBiasTag
+thumb_func 0x812b5c0 IsThisRoundLucky
+thumb_func 0x812b5fc AttemptsAtLuckyFlags_Top3
+thumb_func 0x812b644 AttemptsAtLuckyFlags_NotTop3
+thumb_func 0x812b6dc GetReelTimeProbability
+thumb_func 0x812b710 GetReeltimeDraw
+thumb_func 0x812b770 SkipToReeltimeAction14
+thumb_func 0x812b79c SlowReelSpeed
 thumb_func 0x812b838 CheckMatch
 thumb_func 0x812b86c CheckMatch_CenterRow
 thumb_func 0x812b8e0 CheckMatch_TopAndBottom
 thumb_func 0x812b9b0 CheckMatch_Diagonals
-thumb_func 0x812ba7c
-thumb_func 0x812bacc
+thumb_func 0x812ba7c GetMatchFromSymbolsInRow
+thumb_func 0x812bacc AwardPayout
 thumb_func 0x812baec
 thumb_func 0x812bb0c
-thumb_func 0x812bb44
-thumb_func 0x812bb78
-thumb_func 0x812bc30
-thumb_func 0x812bc54
-thumb_func 0x812bca8
-thumb_func 0x812bcf8
-thumb_func 0x812bd38
-thumb_func 0x812bd80
-thumb_func 0x812bde4
-thumb_func 0x812be1c
-thumb_func 0x812be6c
+thumb_func 0x812bb44 AwardPayoutAction0
+thumb_func 0x812bb78 AwardPayoutAction_GivePayoutToPlayer
+thumb_func 0x812bc30 AwardPayoutAction_FreeTask
+thumb_func 0x812bc54 GetNearbyTag_Quantized
+thumb_func 0x812bca8 GetNearbyTag
+thumb_func 0x812bcf8 GetNearbyReelTimeTag
+thumb_func 0x812bd38 AdvanceSlotReel
+thumb_func 0x812bd80 AdvanceSlotReelToNextTag
+thumb_func 0x812bde4 AdvanceReeltimeReel
+thumb_func 0x812be1c AdvanceReeltimeReelToNextTag
+thumb_func 0x812be6c GameplayTask_StopSlotReel
 thumb_func 0x812beb4 ReelTasks_SetUnkTaskData
 thumb_func 0x812beec
 thumb_func 0x812bf14 IsSlotReelMoving
 thumb_func 0x812bf3c
 thumb_func 0x812bf74
 thumb_func 0x812bf78 SlotReelAction_Spin
-thumb_func 0x812bf98
-thumb_func 0x812c02c
+thumb_func 0x812bf98 SlotReelAction_DecideWhereToStop
+thumb_func 0x812c02c SlotReelAction_MoveToStop
 thumb_func 0x812c0f0 SlotReelAction_OscillatingStop
-thumb_func 0x812c148
+thumb_func 0x812c148 DecideReelTurns_BiasTag_Reel1
 thumb_func 0x812c180
-thumb_func 0x812c194
+thumb_func 0x812c194 AreTagsAtPosition_Reel1
 thumb_func 0x812c1d4 AreCherriesOnScreen_Reel1
-thumb_func 0x812c228
-thumb_func 0x812c248
-thumb_func 0x812c2a0
-thumb_func 0x812c3b0
+thumb_func 0x812c228 IsBiasTowardsCherryOr7s
+thumb_func 0x812c248 DecideReelTurns_BiasTag_Reel1_Bet1
+thumb_func 0x812c2a0 DecideReelTurns_BiasTag_Reel1_Bet2or3
+thumb_func 0x812c3b0 DecideReelTurns_BiasTag_Reel2
 thumb_func 0x812c3c8
-thumb_func 0x812c3d8
-thumb_func 0x812c424
-thumb_func 0x812c4cc
-thumb_func 0x812c510
-thumb_func 0x812c56c
+thumb_func 0x812c3d8 DecideReelTurns_BiasTag_Reel2_Bet1or2
+thumb_func 0x812c424 DecideReelTurns_BiasTag_Reel2_Bet3
+thumb_func 0x812c4cc DecideReelTurns_BiasTag_Reel3
+thumb_func 0x812c510 DecideReelTurns_BiasTag_Reel3_Bet1or2
+thumb_func 0x812c56c DecideReelTurns_BiasTag_Reel3_Bet3
 thumb_func 0x812c5ec DecideReelTurns_NoBiasTag_Reel1
 thumb_func 0x812c618 IsBiasTag777_SwitchColor
 thumb_func 0x812c638
 thumb_func 0x812c650 nullsub_741
-thumb_func 0x812c65c
-thumb_func 0x812c6dc
-thumb_func 0x812c75c
+thumb_func 0x812c65c DecideReelTurns_NoBiasTag_Reel2_Bet1
+thumb_func 0x812c6dc DecideReelTurns_NoBiasTag_Reel2_Bet2
+thumb_func 0x812c75c DecideReelTurns_NoBiasTag_Reel2_Bet3
 thumb_func 0x812c864 AreTagsMixed77
 thumb_func 0x812c88c AreTagsMixed777
 thumb_func 0x812c8bc TagsDontMatchOrHaveAny7s
 thumb_func 0x812c90c
 thumb_func 0x812c924 nullsub_75
-thumb_func 0x812c930
-thumb_func 0x812ca18
-thumb_func 0x812cb90
+thumb_func 0x812c930 DecideReelTurns_NoBiasTag_Reel3_Bet1
+thumb_func 0x812ca18 DecideReelTurns_NoBiasTag_Reel3_Bet2
+thumb_func 0x812cb90 DecideReelTurns_NoBiasTag_Reel3_Bet3
 thumb_func 0x812cd50
 thumb_func 0x812cd84
 thumb_func 0x812cda8
@@ -10004,7 +10004,7 @@ thumb_func 0x812d034
 thumb_func 0x812d0c0
 thumb_func 0x812d0f0
 thumb_func 0x812d138
-thumb_func 0x812d198
+thumb_func 0x812d198 GameplayTask_PikaPower
 thumb_func 0x812d1b8 DisplayPikaPower
 thumb_func 0x812d1ec
 thumb_func 0x812d21c
@@ -10015,40 +10015,40 @@ thumb_func 0x812d29c
 thumb_func 0x812d31c
 thumb_func 0x812d3a4 ClearTaskDataFields_2orHigher
 thumb_func 0x812d3c4
-thumb_func 0x812d4bc
+thumb_func 0x812d4bc BeginReeltime
 thumb_func 0x812d4dc
 thumb_func 0x812d4fc
-thumb_func 0x812d52c
-thumb_func 0x812d5a4
+thumb_func 0x812d52c ReeltimeAction0
+thumb_func 0x812d5a4 ReeltimeAction1
 thumb_func 0x812d61c ReeltimeAction2
-thumb_func 0x812d64c
-thumb_func 0x812d6fc
+thumb_func 0x812d64c ReeltimeAction3
+thumb_func 0x812d6fc ReeltimeAction4
 thumb_func 0x812d750 ReeltimeAction5
-thumb_func 0x812d784
-thumb_func 0x812d7f4
-thumb_func 0x812d880
+thumb_func 0x812d784 ReeltimeAction6
+thumb_func 0x812d7f4 ReelTimeAction_LandOnOutcome
+thumb_func 0x812d880 ReeltimeAction8
 thumb_func 0x812d930 ReeltimeAction9
-thumb_func 0x812d960
-thumb_func 0x812d9b4
-thumb_func 0x812da30
-thumb_func 0x812da7c
-thumb_func 0x812daa0
-thumb_func 0x812db14
-thumb_func 0x812db9c
-thumb_func 0x812dbcc
+thumb_func 0x812d960 ReeltimeAction10
+thumb_func 0x812d9b4 ReeltimeAction11
+thumb_func 0x812da30 ReeltimeAction12
+thumb_func 0x812da7c ReeltimeAction13
+thumb_func 0x812daa0 ReeltimeAction14
+thumb_func 0x812db14 ReeltimeAction15
+thumb_func 0x812db9c ReeltimeAction16
+thumb_func 0x812dbcc ReeltimeAction17
 thumb_func 0x812dc18
 thumb_func 0x812dc60
-thumb_func 0x812dc90
+thumb_func 0x812dc90 OpenInfoBox
 thumb_func 0x812dcc4
 thumb_func 0x812dce4
-thumb_func 0x812dd14
+thumb_func 0x812dd14 InfoBox_FadeIn
 thumb_func 0x812dd38 InfoBox_WaitForFade
-thumb_func 0x812dd58
-thumb_func 0x812dd88
-thumb_func 0x812ddd4
-thumb_func 0x812de24
+thumb_func 0x812dd58 InfoBox_8104B80
+thumb_func 0x812dd88 InfoBox_AddText
+thumb_func 0x812ddd4 InfoBox_AwaitPlayerInput
+thumb_func 0x812de24 InfoBox_812DE14
 thumb_func 0x812de40 InfoBox_812DE30
-thumb_func 0x812de58
+thumb_func 0x812de58 InfoBox_8104BFC
 thumb_func 0x812de8c
 thumb_func 0x812dea4
 thumb_func 0x812def4
@@ -10075,15 +10075,15 @@ thumb_func 0x812e7dc
 thumb_func 0x812e83c
 thumb_func 0x812e8d4
 thumb_func 0x812e908
-thumb_func 0x812e944
+thumb_func 0x812e944 CreateReelTimeSprites1
 thumb_func 0x812e9f8
 thumb_func 0x812ea54
 thumb_func 0x812ea8c
-thumb_func 0x812eac0
+thumb_func 0x812eac0 CreateReelTimeSprite2
 thumb_func 0x812eb58
 thumb_func 0x812ebbc
 thumb_func 0x812ebdc
-thumb_func 0x812ec30
+thumb_func 0x812ec30 VBlankCB_ContestPainting
 thumb_func 0x812ec74
 thumb_func 0x812ec80
 thumb_func 0x812eca4
@@ -10119,26 +10119,26 @@ thumb_func 0x812f7a4
 thumb_func 0x812f7d0
 thumb_func 0x812f7f4
 thumb_func 0x812f8b0
-thumb_func 0x812f918
+thumb_func 0x812f918 Anim_SwordsDanceBlade
 thumb_func 0x812f968
 thumb_func 0x812f978
-thumb_func 0x812f9a4
+thumb_func 0x812f9a4 LoadSlotMachineWheelOverlay
 thumb_func 0x812fa9c
 thumb_func 0x812fb18
 thumb_func 0x812fb4c SlotMachineSetup_9_0
-thumb_func 0x812fbfc
+thumb_func 0x812fbfc SlotMachineSetup_8_0
 thumb_func 0x812fde0
-thumb_func 0x812fe24
-thumb_func 0x812fe30
-thumb_func 0x812fe44
-thumb_func 0x812fe90
-thumb_func 0x8130000
-thumb_func 0x81300d0
+thumb_func 0x812fe24 CB2_ContestPainting
+thumb_func 0x812fe30 CB2_HoldContestPainting
+thumb_func 0x812fe44 CB2_QuitContestPainting
+thumb_func 0x812fe90 ShowContestPainting
+thumb_func 0x8130000 HoldContestPainting
+thumb_func 0x81300d0 InitContestPaintingWindow
 thumb_func 0x8130144
-thumb_func 0x8130244
+thumb_func 0x8130244 InitContestPaintingBg
 thumb_func 0x8130290 InitContestPaintingVars
-thumb_func 0x81302d8
-thumb_func 0x8130328
+thumb_func 0x81302d8 UpdateContestPaintingMosaicEffect
+thumb_func 0x8130328 SlotMachineSetup_6_0
 thumb_func 0x8130340
 thumb_func 0x81303d8
 thumb_func 0x8130488
@@ -10148,103 +10148,103 @@ thumb_func 0x8130790
 thumb_func 0x81307b8
 thumb_func 0x81308dc
 thumb_func 0x8130920
-thumb_func 0x81309a4
+thumb_func 0x81309a4 BattleAI_SetupAIData
 thumb_func 0x8130bec
-thumb_func 0x8130c10
-thumb_func 0x8130d28
-thumb_func 0x8130f7c
-thumb_func 0x81310a8
+thumb_func 0x8130c10 ChooseMoveOrAction_Singles
+thumb_func 0x8130d28 ChooseMoveOrAction_Doubles
+thumb_func 0x8130f7c BattleAI_DoAIProcessing
+thumb_func 0x81310a8 RecordLastUsedMoveByTarget
 thumb_func 0x8131124 ClearBattlerMoveHistory
-thumb_func 0x813114c
+thumb_func 0x813114c RecordAbilityBattle
 thumb_func 0x8131164 ClearBattlerAbilityHistory
-thumb_func 0x813117c
+thumb_func 0x813117c RecordItemEffectBattle
 thumb_func 0x8131194 ClearBattlerItemEffectHistory
-thumb_func 0x81311ac
-thumb_func 0x81311ec
-thumb_func 0x813122c
-thumb_func 0x813126c
+thumb_func 0x81311ac BattleAICmd_if_random_less_than
+thumb_func 0x81311ec BattleAICmd_if_random_greater_than
+thumb_func 0x813122c BattleAICmd_if_random_equal
+thumb_func 0x813126c BattleAICmd_if_random_not_equal
 thumb_func 0x81312ac BattleAICmd_score
-thumb_func 0x81312f0
+thumb_func 0x81312f0 BattleAICmd_if_hp_less_than
 thumb_func 0x8131358
-thumb_func 0x81313c0
-thumb_func 0x8131428
-thumb_func 0x8131490
-thumb_func 0x8131504
-thumb_func 0x8131578
-thumb_func 0x81315ec
-thumb_func 0x8131660
-thumb_func 0x81316d0
-thumb_func 0x8131740
-thumb_func 0x81317bc
-thumb_func 0x8131838
-thumb_func 0x8131874
-thumb_func 0x81318b0
-thumb_func 0x81318ec
-thumb_func 0x8131928
-thumb_func 0x813197c
-thumb_func 0x81319d0
-thumb_func 0x8131a24
-thumb_func 0x8131a78
-thumb_func 0x8131abc
-thumb_func 0x8131b00
-thumb_func 0x8131b68
+thumb_func 0x81313c0 BattleAICmd_if_hp_equal
+thumb_func 0x8131428 BattleAICmd_if_hp_not_equal
+thumb_func 0x8131490 BattleAICmd_if_status
+thumb_func 0x8131504 BattleAICmd_if_not_status
+thumb_func 0x8131578 BattleAICmd_if_status2
+thumb_func 0x81315ec BattleAICmd_if_not_status2
+thumb_func 0x8131660 DisplayBerryPowderVendorMenu
+thumb_func 0x81316d0 BattleAICmd_if_not_status3
+thumb_func 0x8131740 BattleAICmd_if_side_affecting
+thumb_func 0x81317bc BattleAICmd_if_not_side_affecting
+thumb_func 0x8131838 BattleAICmd_if_less_than
+thumb_func 0x8131874 BattleAICmd_if_more_than
+thumb_func 0x81318b0 BattleAICmd_if_equal
+thumb_func 0x81318ec BattleAICmd_if_not_equal
+thumb_func 0x8131928 BattleAICmd_if_less_than_ptr
+thumb_func 0x813197c BattleAICmd_if_more_than_ptr
+thumb_func 0x81319d0 BattleAICmd_if_equal_ptr
+thumb_func 0x8131a24 BattleAICmd_if_not_equal_ptr
+thumb_func 0x8131a78 BattleAICmd_if_move
+thumb_func 0x8131abc BattleAICmd_if_not_move
+thumb_func 0x8131b00 BattleAICmd_if_in_bytes
+thumb_func 0x8131b68 BattleAICmd_if_not_in_bytes
 thumb_func 0x8131bd4
-thumb_func 0x8131c40
-thumb_func 0x8131cb0
-thumb_func 0x8131d20
+thumb_func 0x8131c40 BattleAICmd_if_not_in_hwords
+thumb_func 0x8131cb0 BattleAICmd_if_user_has_attacking_move
+thumb_func 0x8131d20 BattleAICmd_if_user_has_no_attacking_moves
 thumb_func 0x8131d90 BattleAICmd_get_turn_count
-thumb_func 0x8131db4
-thumb_func 0x8131ea4
-thumb_func 0x8131ee8
+thumb_func 0x8131db4 BattleAICmd_get_type
+thumb_func 0x8131ea4 BattleAI_GetWantedBattler
+thumb_func 0x8131ee8 BattleAICmd_is_of_type
 thumb_func 0x8131f50 BattleAICmd_get_considered_move_power
-thumb_func 0x8131f7c
-thumb_func 0x8132180
-thumb_func 0x81321d8
-thumb_func 0x8132214
-thumb_func 0x8132250
-thumb_func 0x813229c
+thumb_func 0x8131f7c BattleAICmd_get_how_powerful_move_is
+thumb_func 0x8132180 BattleAICmd_get_last_used_battler_move
+thumb_func 0x81321d8 BattleAICmd_if_equal_
+thumb_func 0x8132214 BattleAICmd_if_not_equal_
+thumb_func 0x8132250 BattleAICmd_if_user_goes
+thumb_func 0x813229c BattleAICmd_if_user_doesnt_go
 thumb_func 0x81322e8 nullsub_23
 thumb_func 0x81322ec nullsub_241
-thumb_func 0x81322f0
+thumb_func 0x81322f0 BattleAICmd_count_usable_party_mons
 thumb_func 0x81323ec BattleAICmd_get_considered_move
 thumb_func 0x8132408 BattleAICmd_get_considered_move_effect
-thumb_func 0x8132434
-thumb_func 0x8132550
-thumb_func 0x8132648
-thumb_func 0x8132734
+thumb_func 0x8132434 BattleAICmd_get_ability
+thumb_func 0x8132550 BattleAICmd_check_ability
+thumb_func 0x8132648 BattleAICmd_get_highest_type_effectiveness
+thumb_func 0x8132734 BattleAICmd_if_type_effectiveness
 thumb_func 0x8132804 nullsub_25
 thumb_func 0x8132808 nullsub_24
-thumb_func 0x813280c
-thumb_func 0x81328ec
+thumb_func 0x813280c BattleAICmd_if_status_in_party
+thumb_func 0x81328ec BattleAICmd_if_status_not_in_party
 thumb_func 0x81329c8 BattleAICmd_get_weather
-thumb_func 0x8132a34
-thumb_func 0x8132a80
-thumb_func 0x8132acc
-thumb_func 0x8132b34
-thumb_func 0x8132b9c
-thumb_func 0x8132c04
-thumb_func 0x8132c6c
-thumb_func 0x8132d68
-thumb_func 0x8132e4c
-thumb_func 0x8132f7c
-thumb_func 0x8133054
-thumb_func 0x813314c
-thumb_func 0x8133230
-thumb_func 0x81332b8
-thumb_func 0x8133348
-thumb_func 0x813335c
-thumb_func 0x81333bc
-thumb_func 0x81333d0
-thumb_func 0x8133448
-thumb_func 0x81334c8
-thumb_func 0x8133520
-thumb_func 0x813356c
+thumb_func 0x8132a34 BattleAICmd_if_effect
+thumb_func 0x8132a80 BattleAICmd_if_not_effect
+thumb_func 0x8132acc BattleAICmd_if_stat_level_less_than
+thumb_func 0x8132b34 BattleAICmd_if_stat_level_more_than
+thumb_func 0x8132b9c BattleAICmd_if_stat_level_equal
+thumb_func 0x8132c04 BattleAICmd_if_stat_level_not_equal
+thumb_func 0x8132c6c BattleAICmd_if_can_faint
+thumb_func 0x8132d68 BattleAICmd_if_cant_faint
+thumb_func 0x8132e4c BattleAICmd_if_has_move
+thumb_func 0x8132f7c BattleAICmd_if_doesnt_have_move
+thumb_func 0x8133054 BattleAICmd_if_has_move_with_effect
+thumb_func 0x813314c BattleAICmd_if_doesnt_have_move_with_effect
+thumb_func 0x8133230 BattleAICmd_if_any_move_disabled_or_encored
+thumb_func 0x81332b8 BattleAICmd_if_curr_move_disabled_or_encored
+thumb_func 0x8133348 BattleAICmd_flee
+thumb_func 0x813335c BattleAICmd_if_random_safari_flee
+thumb_func 0x81333bc BattleAICmd_watch
+thumb_func 0x81333d0 BattleAICmd_get_hold_effect
+thumb_func 0x8133448 BattleAICmd_if_holds_item
+thumb_func 0x81334c8 BattleAICmd_get_gender
+thumb_func 0x8133520 BattleAICmd_is_first_turn_for
+thumb_func 0x813356c BattleAICmd_get_stockpile_count
 thumb_func 0x81335b8 BattleAICmd_is_double_battle
-thumb_func 0x81335e0
+thumb_func 0x81335e0 BattleAICmd_get_used_held_item
 thumb_func 0x813362c BattleAICmd_get_move_type_from_result
 thumb_func 0x8133658 BattleAICmd_get_move_power_from_result
 thumb_func 0x8133684 BattleAICmd_get_move_effect_from_result
-thumb_func 0x81336b0
+thumb_func 0x81336b0 BattleAICmd_get_protect_count
 thumb_func 0x81336fc nullsub_79
 thumb_func 0x8133700 nullsub_801
 thumb_func 0x8133704 nullsub_81
@@ -10254,288 +10254,288 @@ thumb_func 0x8133710 nullsub_841
 thumb_func 0x8133714 BattleAICmd_call
 thumb_func 0x8133744
 thumb_func 0x8133764 BattleAICmd_end
-thumb_func 0x8133788
-thumb_func 0x8133860
-thumb_func 0x81338b0
-thumb_func 0x8133900
-thumb_func 0x8133950
+thumb_func 0x8133788 BattleAICmd_if_level_cond
+thumb_func 0x8133860 BattleAICmd_if_target_taunted
+thumb_func 0x81338b0 BattleAICmd_if_target_not_taunted
+thumb_func 0x8133900 BattleAICmd_if_target_is_ally
+thumb_func 0x8133950 BattleAICmd_if_flash_fired
 thumb_func 0x81339a0
 thumb_func 0x81339c4 AIStackPushVar_cursor
 thumb_func 0x81339ec
-thumb_func 0x8133a2c
+thumb_func 0x8133a2c TraderSetup
 thumb_func 0x8133a94
-thumb_func 0x8133aac
+thumb_func 0x8133aac AnimMudSportDirt
 thumb_func 0x8133b9c
-thumb_func 0x8133c00
-thumb_func 0x8133c80
-thumb_func 0x8133c9c
+thumb_func 0x8133c00 OpponentHandleTrainerSlide
+thumb_func 0x8133c80 ScrSpecial_GetTraderTradedFlag
+thumb_func 0x8133c9c ScrSpecial_DoesPlayerHaveNoDecorations
 thumb_func 0x8133cd4
 thumb_func 0x8133d40
-thumb_func 0x8133d54
-thumb_func 0x8133dd8
-thumb_func 0x8133df4
-thumb_func 0x8133e78
+thumb_func 0x8133d54 ResetTrainerHillResults
+thumb_func 0x8133dd8 ExitTraderMenu
+thumb_func 0x8133df4 ScrSpecial_TraderDoDecorationTrade
+thumb_func 0x8133e78 ScrSpecial_TraderMenuGetDecoration
 thumb_func 0x8133e94 GetStarterPokemon
-thumb_func 0x8133eb0
-thumb_func 0x8133ec4
-thumb_func 0x8134198
-thumb_func 0x81341b4
-thumb_func 0x8134214
+thumb_func 0x8133eb0 WallClockVblankCallback
+thumb_func 0x8133ec4 CB2_ChooseStarter
+thumb_func 0x8134198 MainCallback2_StarterChoose
+thumb_func 0x81341b4 Task_StarterChoose1
+thumb_func 0x8134214 Task_StarterChoose2
 thumb_func 0x81342f8 Task_StarterChoose3
-thumb_func 0x8134348
-thumb_func 0x81343b8
+thumb_func 0x8134348 Task_StarterChoose4
+thumb_func 0x81343b8 Task_StarterChoose5
 thumb_func 0x8134464
 thumb_func 0x8134480
 thumb_func 0x813464c
 thumb_func 0x8134688 Task_MoveStarterChooseCursor
 thumb_func 0x81346b0
-thumb_func 0x81346d8
+thumb_func 0x81346d8 CreatePokemonFrontSprite
 thumb_func 0x8134724
 thumb_func 0x8134784
 thumb_func 0x81347bc StarterPokemonSpriteCallback
 thumb_func 0x81347fc
-thumb_func 0x8134810
-thumb_func 0x81349d4
-thumb_func 0x8134a3c
-thumb_func 0x8134b8c
-thumb_func 0x8134ce8
+thumb_func 0x8134810 LoadWallClockGraphics
+thumb_func 0x81349d4 WallClockInit
+thumb_func 0x8134a3c CB2_StartWallClock
+thumb_func 0x8134b8c CB2_ViewWallClock
+thumb_func 0x8134ce8 TrySetupDiveDownScript
 thumb_func 0x8134d04
-thumb_func 0x8134d34
-thumb_func 0x8134e10
-thumb_func 0x8134e84
-thumb_func 0x8134ef8
-thumb_func 0x8134f3c
+thumb_func 0x8134d34 Task_SetClock2
+thumb_func 0x8134e10 Task_SetClock3
+thumb_func 0x8134e84 Task_SetClock4
+thumb_func 0x8134ef8 Task_SetClock5
+thumb_func 0x8134f3c Task_SetClock6
 thumb_func 0x8134f64
 thumb_func 0x8134f94 Task_ViewClock2
-thumb_func 0x8134fcc
-thumb_func 0x8135004
+thumb_func 0x8134fcc Task_ViewClock3
+thumb_func 0x8135004 Task_ViewClock4
 thumb_func 0x8135028 CalcMinHandDelta
 thumb_func 0x8135050 CalcNewMinHandAngle
-thumb_func 0x81350a0
-thumb_func 0x813513c
-thumb_func 0x8135184
-thumb_func 0x8135200
-thumb_func 0x8135298
-thumb_func 0x8135330
-thumb_func 0x81353d4
-thumb_func 0x8135478
-thumb_func 0x81354cc
-thumb_func 0x81354f0
+thumb_func 0x81350a0 AdvanceClock
+thumb_func 0x813513c UpdateClockPeriod
+thumb_func 0x8135184 InitClockWithRtc
+thumb_func 0x8135200 SpriteCB_MinuteHand
+thumb_func 0x8135298 SpriteCB_HourHand
+thumb_func 0x8135330 SpriteCB_AMIndicator
+thumb_func 0x81353d4 SpriteCB_PMIndicator
+thumb_func 0x8135478 CheckObjectGraphicsInFrontOfPlayer
+thumb_func 0x81354cc oei_task_add
+thumb_func 0x81354f0 task08_080C9820
 thumb_func 0x8135580
 thumb_func 0x81355cc
 thumb_func 0x8135670
-thumb_func 0x81356a8
+thumb_func 0x81356a8 SetUpFieldMove_RockSmash
 thumb_func 0x8135718
-thumb_func 0x8135738
+thumb_func 0x8135738 FldEff_UseRockSmash
 thumb_func 0x8135768
-thumb_func 0x8135780
-thumb_func 0x81357b4
-thumb_func 0x81357d4
+thumb_func 0x8135780 SetUpFieldMove_Dig
+thumb_func 0x81357b4 hm2_dig
+thumb_func 0x81357d4 FldEff_UseDig
 thumb_func 0x8135810
 thumb_func 0x8135850
-thumb_func 0x8135944
-thumb_func 0x8135958
-thumb_func 0x813596c
-thumb_func 0x8135988
-thumb_func 0x813599c
-thumb_func 0x81359c8
+thumb_func 0x8135944 SummaryScreen_MainCB2
+thumb_func 0x8135958 OpenPokeblockCaseOnFeeder
+thumb_func 0x813596c Mailbox_DoRedrawMailboxMenuAfterReturn
+thumb_func 0x8135988 VBlankCB_PokeblockMenu
+thumb_func 0x813599c CB2_InitPokeblockMenu
+thumb_func 0x81359c8 InitPokeblockMenu
 thumb_func 0x8135c2c
-thumb_func 0x8135c88
+thumb_func 0x8135c88 LoadPokeblockMenuGfx
 thumb_func 0x8135d74
 thumb_func 0x8135dcc
 thumb_func 0x8135df8
 thumb_func 0x8135e60
 thumb_func 0x8135f30
-thumb_func 0x8135fb4
+thumb_func 0x8135fb4 MovePokeblockMenuCursor
 thumb_func 0x8136010
-thumb_func 0x8136150
+thumb_func 0x8136150 HandlePokeblockMenuCursor
 thumb_func 0x8136180 CompactPokeblockSlots
-thumb_func 0x81361f0
-thumb_func 0x813628c
-thumb_func 0x813629c
+thumb_func 0x81361f0 SwapSortPokeblocksInternalData
+thumb_func 0x813628c ResetPokeblockScrollPositions
+thumb_func 0x813629c SetMenuItemsCountAndMaxShowed
 thumb_func 0x8136320
 thumb_func 0x8136384
 thumb_func 0x81363fc
 thumb_func 0x8136458
-thumb_func 0x8136484
+thumb_func 0x8136484 CreatePokeblockCaseSprite
 thumb_func 0x81364b0
 thumb_func 0x813652c
-thumb_func 0x8136564
-thumb_func 0x8136608
-thumb_func 0x813675c
-thumb_func 0x8136894
+thumb_func 0x8136564 Task_FreeDataAndExitPokeblockCase
+thumb_func 0x8136608 Task_HandlePokeblockMenuInput
+thumb_func 0x813675c Task_HandlePokeblocksSwapInput
+thumb_func 0x8136894 HandlePokeblocksSwap
 thumb_func 0x8136978
-thumb_func 0x8136a50
-thumb_func 0x8136ac0
+thumb_func 0x8136a50 Task_HandlePokeblockOptionsInput
+thumb_func 0x8136ac0 PokeblockAction_UseOnField
 thumb_func 0x8136ae4
-thumb_func 0x8136b10
-thumb_func 0x8136b24
-thumb_func 0x8136bb8
-thumb_func 0x8136be8
-thumb_func 0x8136c30
+thumb_func 0x8136b10 ReturnToPokeblockCaseOnField
+thumb_func 0x8136b24 PokeblockAction_Toss
+thumb_func 0x8136bb8 CreateTossPokeblockYesNoMenu
+thumb_func 0x8136be8 TossPokeblockChoice_Yes
+thumb_func 0x8136c30 HandleErasePokeblock
 thumb_func 0x8136cc4
-thumb_func 0x8136cfc
-thumb_func 0x8136d9c
-thumb_func 0x8136e00
-thumb_func 0x8136e58
+thumb_func 0x8136cfc MachBikeTransition_TrySlowDown
+thumb_func 0x8136d9c PokeblockAction_UseOnPokeblockFeeder
+thumb_func 0x8136e00 PokeblockAction_GiveToContestLady
+thumb_func 0x8136e58 PokeblockAction_Cancel
 thumb_func 0x8136e90 ClearPokeblock
 thumb_func 0x8136ef8 ClearPokeblocks
 thumb_func 0x8136f14 GetHighestPokeblocksFlavorLevel
 thumb_func 0x8136f4c GetPokeblocksFeel
-thumb_func 0x8136f64
-thumb_func 0x8136f9c
-thumb_func 0x8136fd8
+thumb_func 0x8136f64 GetFirstFreePokeblockSlot
+thumb_func 0x8136f9c AddPokeblock
+thumb_func 0x8136fd8 TryClearPokeblock
 thumb_func 0x813700c GetPokeblockData
 thumb_func 0x8137054 PokeblockGetGain
-thumb_func 0x81370b4
-thumb_func 0x81370d8
+thumb_func 0x81370b4 PokeblockCopyName
+thumb_func 0x81370d8 CopyMonFavoritePokeblockName
 thumb_func 0x8137124 GetPokeblocksFlavor
-thumb_func 0x813716c
-thumb_func 0x81371e8
+thumb_func 0x813716c SetUpFieldMove_Flash
+thumb_func 0x81371e8 hm2_flash
 thumb_func 0x8137224
 thumb_func 0x8137244
 thumb_func 0x813725c
-thumb_func 0x8137270
+thumb_func 0x8137270 c2_change_map
 thumb_func 0x8137374
 thumb_func 0x81373d0
-thumb_func 0x8137418
+thumb_func 0x8137418 GetMapPairFadeFromType
 thumb_func 0x8137460
 thumb_func 0x8137474
 thumb_func 0x8137490
 thumb_func 0x8137534
 thumb_func 0x813757c
 thumb_func 0x81375e4
-thumb_func 0x8137618
+thumb_func 0x8137618 PartyMenuVBlankCallback
 thumb_func 0x813762c
 thumb_func 0x8137648
 thumb_func 0x81376e8
 thumb_func 0x813774c
-thumb_func 0x81377a4
-thumb_func 0x81378ec
-thumb_func 0x8137900
-thumb_func 0x813792c
-thumb_func 0x8137954
+thumb_func 0x81377a4 GameClear
+thumb_func 0x81378ec sp0C8_whiteout_maybe
+thumb_func 0x8137900 GetMirageRnd
+thumb_func 0x813792c SetMirageRnd
+thumb_func 0x8137954 InitMirageRnd
 thumb_func 0x8137974 UpdateMirageRnd
-thumb_func 0x81379ac
+thumb_func 0x81379ac IsMirageIslandPresent
 thumb_func 0x81379f8
 thumb_func 0x8137a48
 thumb_func 0x8137a68
-thumb_func 0x8137a7c
-thumb_func 0x8137a90
-thumb_func 0x8137abc
-thumb_func 0x8137b08
-thumb_func 0x8137c80
+thumb_func 0x8137a7c InitBirchState
+thumb_func 0x8137a90 UpdateBirchState
+thumb_func 0x8137abc ScriptGetPokedexInfo
+thumb_func 0x8137b08 GetPokedexRatingText
+thumb_func 0x8137c80 ShowPokedexRatingMessage
 thumb_func 0x8137c98
-thumb_func 0x8137cac
-thumb_func 0x8137ccc
+thumb_func 0x8137cac ReturnFromHallOfFamePC
+thumb_func 0x8137ccc ReshowPCMenuAfterHallOfFamePC
 thumb_func 0x8137d04
 thumb_func 0x8137d24
-thumb_func 0x8137d38
-thumb_func 0x8137d5c
+thumb_func 0x8137d38 Special_ViewWallClock
+thumb_func 0x8137d5c ResetCyclingRoadChallengeData
 thumb_func 0x8137d7c Special_BeginCyclingRoadChallenge
-thumb_func 0x8137da4
-thumb_func 0x8137dcc
+thumb_func 0x8137da4 GetPlayerAvatarBike
+thumb_func 0x8137dcc DetermineCyclingRoadResults
 thumb_func 0x8137edc FinishCyclingRoadChallenge
-thumb_func 0x8137f0c
-thumb_func 0x8137f6c
-thumb_func 0x8137fb4
-thumb_func 0x8138000
-thumb_func 0x8138020
-thumb_func 0x8138030
-thumb_func 0x813806c
+thumb_func 0x8137f0c RecordCyclingRoadResults
+thumb_func 0x8137f6c GetRecordedCyclingRoadResults
+thumb_func 0x8137fb4 UpdateCyclingRoadState
+thumb_func 0x8138000 SetSSTidalFlag
+thumb_func 0x8138020 ResetSSTidalFlag
+thumb_func 0x8138030 CountSSTidalStep
+thumb_func 0x813806c GetSSTidalLocation
 thumb_func 0x8138148
-thumb_func 0x8138190
-thumb_func 0x81381d8
-thumb_func 0x8138220
-thumb_func 0x8138268
-thumb_func 0x81382b0
-thumb_func 0x8138310
-thumb_func 0x813849c
-thumb_func 0x8138560
-thumb_func 0x81385b0
-thumb_func 0x81387c0
-thumb_func 0x8138954
-thumb_func 0x8138980
-thumb_func 0x81389e8
-thumb_func 0x8138b14
-thumb_func 0x8138b30
-thumb_func 0x8138b40
-thumb_func 0x8138b60
+thumb_func 0x8138190 ShouldDoWinonaCall
+thumb_func 0x81381d8 ShouldDoScottCall
+thumb_func 0x8138220 ShouldDoRoxanneCall
+thumb_func 0x8138268 c2_mystery_gift
+thumb_func 0x81382b0 GetLinkPartnerNames
+thumb_func 0x8138310 SpawnLinkPartnerEventObject
+thumb_func 0x813849c LoadLinkPartnerEventObjectSpritePalette
+thumb_func 0x8138560 MauvilleGymSpecial1
+thumb_func 0x81385b0 MauvilleGymSpecial2
+thumb_func 0x81387c0 MauvilleGymSpecial3
+thumb_func 0x8138954 PetalburgGymSpecial1
+thumb_func 0x8138980 Task_PetalburgGym
+thumb_func 0x81389e8 PetalburgGymFunc
+thumb_func 0x8138b14 PetalburgGymSpecial2
+thumb_func 0x8138b30 ShowFieldMessageStringVar4
+thumb_func 0x8138b40 StorePlayerCoordsInVars
+thumb_func 0x8138b60 GetPlayerTrainerIdOnesDigit
 thumb_func 0x8138b80
 thumb_func 0x8138bb8
 thumb_func 0x8138bf0
-thumb_func 0x8138bfc
-thumb_func 0x8138c38
-thumb_func 0x8138c4c
-thumb_func 0x8138c74
-thumb_func 0x8138cf4
-thumb_func 0x8138d04
+thumb_func 0x8138bfc CableCarWarp
+thumb_func 0x8138c38 SetFlagInVar
+thumb_func 0x8138c4c GetWeekCount
+thumb_func 0x8138c74 GetLeadMonFriendshipScore
+thumb_func 0x8138cf4 CB2_FieldShowRegionMap
+thumb_func 0x8138d04 FieldShowRegionMap
 thumb_func 0x8138d14
 thumb_func 0x8138d58
-thumb_func 0x8138d80
-thumb_func 0x8138df8
+thumb_func 0x8138d80 PCTurnOnEffect_0
+thumb_func 0x8138df8 PCTurnOnEffect_1
 thumb_func 0x8138e90
-thumb_func 0x8138e9c
+thumb_func 0x8138e9c PCTurnOffEffect
 thumb_func 0x8138f30
 thumb_func 0x8138f74
-thumb_func 0x8138f9c
-thumb_func 0x813901c
+thumb_func 0x8138f9c LotteryCornerComputerEffect
+thumb_func 0x813901c EndLotteryCornerComputerEffect
 thumb_func 0x8139044
 thumb_func 0x813905c
-thumb_func 0x8139074
-thumb_func 0x81390a0
-thumb_func 0x81390cc
-thumb_func 0x81390f8
+thumb_func 0x8139074 CheckLeadMonCool
+thumb_func 0x81390a0 CheckLeadMonBeauty
+thumb_func 0x81390cc CheckLeadMonCute
+thumb_func 0x81390f8 CheckLeadMonSmart
 thumb_func 0x8139124
-thumb_func 0x8139150
-thumb_func 0x81391c8
-thumb_func 0x813921c
-thumb_func 0x8139240
-thumb_func 0x8139270
-thumb_func 0x8139298
+thumb_func 0x8139150 IsGrassTypeInParty
+thumb_func 0x81391c8 SpawnCameraObject
+thumb_func 0x813921c RemoveCameraObject
+thumb_func 0x8139240 GetPokeblockNameByMonNature
+thumb_func 0x8139270 GetSecretBaseNearbyMapName
+thumb_func 0x8139298 GetBestBattleTowerStreak
 thumb_func 0x81392a8
-thumb_func 0x81392b8
-thumb_func 0x813931c
-thumb_func 0x8139344
+thumb_func 0x81392b8 GetSlotMachineId
+thumb_func 0x813931c FoundAbandonedShipRoom1Key
+thumb_func 0x8139344 FoundAbandonedShipRoom2Key
 thumb_func 0x8139368
-thumb_func 0x8139390
-thumb_func 0x81393b8
-thumb_func 0x81393e0
-thumb_func 0x8139438
-thumb_func 0x813946c
+thumb_func 0x8139390 FoundAbandonedShipRoom6Key
+thumb_func 0x81393b8 LeadMonHasEffortRibbon
+thumb_func 0x81393e0 GiveLeadMonEffortRibbon
+thumb_func 0x8139438 Special_AreLeadMonEVsMaxedOut
+thumb_func 0x813946c TryUpdateRusturfTunnelState
 thumb_func 0x81394cc
-thumb_func 0x81394dc
-thumb_func 0x8139548
-thumb_func 0x81395a0
+thumb_func 0x81394dc PutZigzagoonInPlayerParty
+thumb_func 0x8139548 IsStarterInParty
+thumb_func 0x81395a0 ScriptCheckFreePokemonStorageSpace
 thumb_func 0x81395b0
 thumb_func 0x81395d0
 thumb_func 0x813962c
 thumb_func 0x8139690
 thumb_func 0x81396a4
 thumb_func 0x81396b8
-thumb_func 0x81396d8
-thumb_func 0x81396f8
-thumb_func 0x8139750
+thumb_func 0x81396d8 SetRoute123Weather
+thumb_func 0x81396f8 GetLeadMonIndex
+thumb_func 0x8139750 ScriptGetPartyMonSpecies
 thumb_func 0x8139778 nullsub_85
-thumb_func 0x813977c
-thumb_func 0x81397c4
+thumb_func 0x813977c GetDaysUntilPacifidlogTMAvailable
+thumb_func 0x81397c4 SetPacifidlogTMReceivedDay
 thumb_func 0x81397e0
-thumb_func 0x8139824
+thumb_func 0x8139824 BufferLottoTicketNumber
 thumb_func 0x81398cc
 thumb_func 0x8139938
 thumb_func 0x8139980
-thumb_func 0x81399c0
+thumb_func 0x81399c0 InMultiBattleRoom
 thumb_func 0x81399f4
-thumb_func 0x8139a08
+thumb_func 0x8139a08 SetDepartmentStoreFloorVar
 thumb_func 0x8139a68
-thumb_func 0x8139aec
+thumb_func 0x8139aec ShakeScreenInElevator
 thumb_func 0x8139b68
 thumb_func 0x8139bd4
 thumb_func 0x8139c4c
 thumb_func 0x8139c68
-thumb_func 0x8139cbc
+thumb_func 0x8139cbc MoveElevatorWindowLights
 thumb_func 0x8139dd4
-thumb_func 0x8139ebc
+thumb_func 0x8139ebc warp0_in_pokecenter
 thumb_func 0x8139f0c
 thumb_func 0x8139f30
 thumb_func 0x8139f5c
@@ -10554,7 +10554,7 @@ thumb_func 0x813a740
 thumb_func 0x813a770 nullsub_84
 thumb_func 0x813a774
 thumb_func 0x813a7c0
-thumb_func 0x813a7fc
+thumb_func 0x813a7fc UpdateFrontierGambler
 thumb_func 0x813a828
 thumb_func 0x813a85c
 thumb_func 0x813a880
@@ -10569,30 +10569,30 @@ thumb_func 0x813aa90
 thumb_func 0x813aaac
 thumb_func 0x813ac20
 thumb_func 0x813ac90
-thumb_func 0x813acc8
+thumb_func 0x813acc8 IsArrowWarpMetatileBehavior
 thumb_func 0x813ad2c
 thumb_func 0x813ad6c
 thumb_func 0x813adf0
 thumb_func 0x813ae0c
 thumb_func 0x813aeec
 thumb_func 0x813af80
-thumb_func 0x813b000
-thumb_func 0x813b014
-thumb_func 0x813b0ec
-thumb_func 0x813b198
-thumb_func 0x813b1bc
+thumb_func 0x813b000 DoDeoxysRockInteraction
+thumb_func 0x813b014 Task_DeoxysRockInteraction
+thumb_func 0x813b0ec ChangeDeoxysRockLevel
+thumb_func 0x813b198 WaitForDeoxysRockMovement
+thumb_func 0x813b1bc IncrementBirthIslandRockStepCount
 thumb_func 0x813b208
 thumb_func 0x813b23c
 thumb_func 0x813b248
 thumb_func 0x813b254
 thumb_func 0x813b298
-thumb_func 0x813b31c
-thumb_func 0x813b3ac
-thumb_func 0x813b3e8
-thumb_func 0x813b4bc
+thumb_func 0x813b31c CreateUnusualWeatherEvent
+thumb_func 0x813b3ac GetUnusualWeatherMapNameAndType
+thumb_func 0x813b3e8 UnusualWeatherHasExpired
+thumb_func 0x813b4bc Unused_SetWeatherSunny
 thumb_func 0x813b4c8
 thumb_func 0x813b518
-thumb_func 0x813b54c
+thumb_func 0x813b54c StartWallClock
 thumb_func 0x813b56c
 thumb_func 0x813b5a0
 thumb_func 0x813b5b4
@@ -10611,76 +10611,76 @@ thumb_func 0x813bb14
 thumb_func 0x813bbac
 thumb_func 0x813bc38
 thumb_func 0x813bce0 GetNumMovedLilycoveFanClubMembers
-thumb_func 0x813bd20
+thumb_func 0x813bd20 UpdateMovedLilycoveFanClubMembers
 thumb_func 0x813bd98 ShouldMoveLilycoveFanClubMember
 thumb_func 0x813bdbc
-thumb_func 0x813bdec
+thumb_func 0x813bdec BufferStreakTrainerText
 thumb_func 0x813be68
 thumb_func 0x813bf34
 thumb_func 0x813bf68
 thumb_func 0x813bf84
 thumb_func 0x813bfa0
-thumb_func 0x813bfb8
-thumb_func 0x813bfe8
-thumb_func 0x813c01c
-thumb_func 0x813c02c
+thumb_func 0x813bfb8 ClearLinkBattleRecord
+thumb_func 0x813bfe8 ClearLinkBattleRecords
+thumb_func 0x813c01c GetLinkBattleRecordTotalBattles
+thumb_func 0x813c02c FindLinkBattleRecord
 thumb_func 0x813c060
 thumb_func 0x813c0dc UpdateLinkBattleRecord
-thumb_func 0x813c140
-thumb_func 0x813c17c
+thumb_func 0x813c140 UpdateLinkBattleGameStats
+thumb_func 0x813c17c UpdateLinkBattleRecords
 thumb_func 0x813c204
 thumb_func 0x813c220
 thumb_func 0x813c248
-thumb_func 0x813c270
-thumb_func 0x813c2ac
-thumb_func 0x813c300
-thumb_func 0x813c384
+thumb_func 0x813c270 UpdateTrainerCardWinsLosses
+thumb_func 0x813c2ac UpdatePlayerLinkBattleRecords
+thumb_func 0x813c300 PrintLinkBattleWinsLossesDraws
+thumb_func 0x813c384 CrackedFloorPerStepCallback
 thumb_func 0x813c4b0
-thumb_func 0x813c57c
+thumb_func 0x813c57c RemoveRecordsWindow
 thumb_func 0x813c598
-thumb_func 0x813c5c8
+thumb_func 0x813c5c8 Task_CloseTrainerHillRecordsOnButton
 thumb_func 0x813c608
-thumb_func 0x813c640
+thumb_func 0x813c640 party_menu_link_mon_pokeball_object
 thumb_func 0x813c684
-thumb_func 0x813c6b0
-thumb_func 0x813c7e8
-thumb_func 0x813c804
-thumb_func 0x813c85c
-thumb_func 0x813c86c
-thumb_func 0x813c8b4
+thumb_func 0x813c6b0 ClearVramOamPlttRegs
+thumb_func 0x813c7e8 ClearTasksAndGraphicalStructs
+thumb_func 0x813c804 ResetBgCoordinates
+thumb_func 0x813c85c SetDispcntReg
+thumb_func 0x813c86c LoadTrainerHillRecordsWindowGfx
+thumb_func 0x813c8b4 VblankCB_TrainerHillRecords
 thumb_func 0x813c8c8
-thumb_func 0x813c8e0
-thumb_func 0x813c8f8
-thumb_func 0x813ca30
-thumb_func 0x813ca44
-thumb_func 0x813cb1c
-thumb_func 0x813cce0
-thumb_func 0x813cd40
-thumb_func 0x813ce10
-thumb_func 0x813ce24
+thumb_func 0x813c8e0 ShowTrainerHillRecords
+thumb_func 0x813c8f8 CB2_ShowTrainerHillRecords
+thumb_func 0x813ca30 ResetDrawAreaGlowState
+thumb_func 0x813ca44 DrawAreaGlow
+thumb_func 0x813cb1c FindMapsWithMon
+thumb_func 0x813cce0 SetAreaHasMon
+thumb_func 0x813cd40 SetSpecialMapHasMon
+thumb_func 0x813ce10 GetRegionMapSectionId
+thumb_func 0x813ce24 MapHasMon
 thumb_func 0x813ceb0 MonListHasMon
 thumb_func 0x813cee8
-thumb_func 0x813d2cc
-thumb_func 0x813d360
-thumb_func 0x813d4dc
-thumb_func 0x813d530
-thumb_func 0x813d6a4
+thumb_func 0x813d2cc StartAreaGlow
+thumb_func 0x813d360 DoAreaGlow
+thumb_func 0x813d4dc ShowPokedexAreaScreen
+thumb_func 0x813d530 Task_PokedexAreaScreen_0
+thumb_func 0x813d6a4 Task_PokedexAreaScreen_1
 thumb_func 0x813d7b8
-thumb_func 0x813d7d4
-thumb_func 0x813d928
-thumb_func 0x813d9ac
-thumb_func 0x813d9ec
+thumb_func 0x813d7d4 CreateAreaMarkerSprites
+thumb_func 0x813d928 DestroyAreaMarkerSprites
+thumb_func 0x813d9ac LoadAreaUnknownGraphics
+thumb_func 0x813d9ec CreateAreaUnknownSprites
 thumb_func 0x813dab4
-thumb_func 0x813dac4
-thumb_func 0x813db44
-thumb_func 0x813db90
-thumb_func 0x813de80
-thumb_func 0x813e074
-thumb_func 0x813e2d8
+thumb_func 0x813dac4 Task_BeginEvolutionScene
+thumb_func 0x813db44 BeginEvolutionScene
+thumb_func 0x813db90 EvolutionScene
+thumb_func 0x813de80 CB2_EvolutionSceneLoadGraphics
+thumb_func 0x813e074 CB2_TradeEvolutionSceneLoadGraphics
+thumb_func 0x813e2d8 TradeEvolutionScene
 thumb_func 0x813e4a8
 thumb_func 0x813e4c4
 thumb_func 0x813e4e0
-thumb_func 0x813e638
+thumb_func 0x813e638 Task_EvolutionScene
 thumb_func 0x813f280
 thumb_func 0x813fda0 nullsub_87
 thumb_func 0x813fda4
@@ -10689,12 +10689,12 @@ thumb_func 0x813feb4
 thumb_func 0x813ff6c
 thumb_func 0x813ffb0
 thumb_func 0x8140088 InitMovingBgValues
-thumb_func 0x81400c8
+thumb_func 0x81400c8 InitMovingBackgroundTask
 thumb_func 0x81401c8
 thumb_func 0x81401fc
-thumb_func 0x814023c
-thumb_func 0x81402a8
-thumb_func 0x81402d0
+thumb_func 0x814023c OpenPokeblockCaseInBattle
+thumb_func 0x81402a8 EvoScene_DoMonAnimation
+thumb_func 0x81402d0 EvoScene_IsMonAnimFinished
 thumb_func 0x8140300
 thumb_func 0x814032c
 thumb_func 0x8140450
@@ -10728,7 +10728,7 @@ thumb_func 0x8141a4c
 thumb_func 0x8141ae0
 thumb_func 0x8141b88
 thumb_func 0x8141c20
-thumb_func 0x8141dd4
+thumb_func 0x8141dd4 dp01t_12_3_battle_menu
 thumb_func 0x8141eac
 thumb_func 0x8141f44
 thumb_func 0x8141fc0
@@ -10748,11 +10748,11 @@ thumb_func 0x8142a44
 thumb_func 0x8142a68
 thumb_func 0x8142ab8
 thumb_func 0x8142b50
-thumb_func 0x8142c94
+thumb_func 0x8142c94 PlayRoulette
 thumb_func 0x8142cd8
 thumb_func 0x8142d2c
 thumb_func 0x8142d9c
-thumb_func 0x8142f08
+thumb_func 0x8142f08 unref_sub_8142E3C
 thumb_func 0x8142f3c
 thumb_func 0x8143048
 thumb_func 0x8143104
@@ -10780,7 +10780,7 @@ thumb_func 0x8144070
 thumb_func 0x814411c
 thumb_func 0x81441f4
 thumb_func 0x8144234
-thumb_func 0x8144274
+thumb_func 0x8144274 prev_quest_read_x24_hm_usage
 thumb_func 0x8144330
 thumb_func 0x81444dc
 thumb_func 0x81445e0
@@ -10815,41 +10815,41 @@ thumb_func 0x8145a38
 thumb_func 0x8145bf0
 thumb_func 0x8145c20
 thumb_func 0x8145c6c
-thumb_func 0x8145cd4
+thumb_func 0x8145cd4 HideCoinsWindow
 thumb_func 0x8145cf0 GetCoins
 thumb_func 0x8145d18 SetCoins
 thumb_func 0x8145d40 GiveCoins
 thumb_func 0x8145d8c TakeCoins
-thumb_func 0x8145db4
-thumb_func 0x8145e08
-thumb_func 0x8145e84
-thumb_func 0x8145ecc
+thumb_func 0x8145db4 GetLandmarkName
+thumb_func 0x8145e08 GetLandmarks
+thumb_func 0x8145e84 SetUpFieldMove_Strength
+thumb_func 0x8145ecc FldEff_UseStrength
 thumb_func 0x8145eec
-thumb_func 0x8145f34
-thumb_func 0x8145f44
-thumb_func 0x8145f9c
+thumb_func 0x8145f34 CoordEventWeather_Clouds
+thumb_func 0x8145f44 CB2_TestBattleTransition
+thumb_func 0x8145f9c TestBattleTransition
 thumb_func 0x8145fb4 BattleTransition_StartOnField
-thumb_func 0x8145fd0
-thumb_func 0x8145fe0
-thumb_func 0x814602c
+thumb_func 0x8145fd0 BattleTransition_Start
+thumb_func 0x8145fe0 IsBattleTransitionDone
+thumb_func 0x814602c LaunchBattleTransitionTask
 thumb_func 0x8146068
-thumb_func 0x81460a0
-thumb_func 0x81460f0
-thumb_func 0x8146124
-thumb_func 0x814614c
-thumb_func 0x814617c
+thumb_func 0x81460a0 Transition_Phase1
+thumb_func 0x81460f0 Transition_WaitForPhase1
+thumb_func 0x8146124 Transition_Phase2
+thumb_func 0x814614c Transition_WaitForPhase2
+thumb_func 0x814617c Phase1Task_TransitionAll
 thumb_func 0x81461cc
-thumb_func 0x8146204
-thumb_func 0x8146238
-thumb_func 0x8146298
+thumb_func 0x8146204 Phase2_Blur_Func1
+thumb_func 0x8146238 Phase2_Blur_Func2
+thumb_func 0x8146298 Phase2_Blur_Func3
 thumb_func 0x81462c4
-thumb_func 0x81462fc
-thumb_func 0x8146368
+thumb_func 0x81462fc Phase2_Swirl_Func1
+thumb_func 0x8146368 Phase2_Swirl_Func2
 thumb_func 0x81463e0 VBlankCB_Phase2_Swirl
 thumb_func 0x8146418
 thumb_func 0x8146444
-thumb_func 0x814647c
-thumb_func 0x81464e0
+thumb_func 0x814647c Phase2_Shuffle_Func1
+thumb_func 0x81464e0 Phase2_Shuffle_Func2
 thumb_func 0x8146570 VBlankCB_Phase2_Shuffle
 thumb_func 0x81465a8
 thumb_func 0x81465d4
@@ -10860,55 +10860,55 @@ thumb_func 0x81466b4
 thumb_func 0x81466ec
 thumb_func 0x8146724
 thumb_func 0x814675c
-thumb_func 0x81467cc
-thumb_func 0x8146820
-thumb_func 0x8146874
-thumb_func 0x81468c0
+thumb_func 0x81467cc Phase2_Aqua_Func1
+thumb_func 0x8146820 Phase2_Magma_Func1
+thumb_func 0x8146874 Phase2_Regi_Func1
+thumb_func 0x81468c0 Phase2_BigPokeball_Func1
 thumb_func 0x8146914 Phase2_BigPokeball_Func2
-thumb_func 0x81469a4
-thumb_func 0x81469ec
-thumb_func 0x8146a34
-thumb_func 0x8146a8c
-thumb_func 0x8146ae4
-thumb_func 0x8146b3c
-thumb_func 0x8146b88
+thumb_func 0x81469a4 Phase2_Aqua_Func2
+thumb_func 0x81469ec Phase2_Magma_Func2
+thumb_func 0x8146a34 Phase2_Regice_Func2
+thumb_func 0x8146a8c Phase2_Registeel_Func2
+thumb_func 0x8146ae4 Phase2_Regirock_Func2
+thumb_func 0x8146b3c Phase2_Kyogre_Func3
+thumb_func 0x8146b88 Phase2_Kyogre_Func4
 thumb_func 0x8146be4
 thumb_func 0x8146c3c
-thumb_func 0x8146c68
+thumb_func 0x8146c68 Phase2_WeatherDuo_Func7
 thumb_func 0x8146cb8 Phase2_BigPokeball_Func3
 thumb_func 0x8146d4c Phase2_BigPokeball_Func4
 thumb_func 0x8146de0 Phase2_BigPokeball_Func5
 thumb_func 0x8146e50 Phase2_FramesCountdown
 thumb_func 0x8146e6c
 thumb_func 0x8146e98 Phase2_WaitPaletteFade
-thumb_func 0x8146eb8
+thumb_func 0x8146eb8 Phase2_BigPokeball_Func6
 thumb_func 0x8146f80 Transition_BigPokeball_Vblank
 thumb_func 0x8146ffc VBlankCB0_Phase2_BigPokeball
 thumb_func 0x8147028 VBlankCB1_Phase2_BigPokeball
 thumb_func 0x8147054
-thumb_func 0x814708c
-thumb_func 0x81470d8
-thumb_func 0x8147164
-thumb_func 0x8147190
-thumb_func 0x81471fc
+thumb_func 0x814708c Phase2_PokeballsTrail_Func1
+thumb_func 0x81470d8 Phase2_PokeballsTrail_Func2
+thumb_func 0x8147164 Phase2_PokeballsTrail_Func3
+thumb_func 0x8147190 FldEff_Pokeball
+thumb_func 0x81471fc berry_fix_gpu_set
 thumb_func 0x81472c4
-thumb_func 0x81472fc
+thumb_func 0x81472fc Phase2_Clockwise_BlackFade_Func1
 thumb_func 0x8147364 Phase2_Clockwise_BlackFade_Func2
-thumb_func 0x81473f4
+thumb_func 0x81473f4 Phase2_Clockwise_BlackFade_Func3
 thumb_func 0x81474e8 Phase2_Clockwise_BlackFade_Func4
-thumb_func 0x8147570
+thumb_func 0x8147570 Phase2_Clockwise_BlackFade_Func5
 thumb_func 0x8147670 Phase2_Clockwise_BlackFade_Func6
-thumb_func 0x8147708
+thumb_func 0x8147708 Phase2_Clockwise_BlackFade_Func7
 thumb_func 0x8147748 VBlankCB_Phase2_Clockwise_BlackFade
 thumb_func 0x81477d8
-thumb_func 0x8147810
-thumb_func 0x8147868
+thumb_func 0x8147810 Phase2_Ripple_Func1
+thumb_func 0x8147868 Phase2_Ripple_Func2
 thumb_func 0x8147948 VBlankCB_Phase2_Ripple
 thumb_func 0x8147980
 thumb_func 0x81479ac
-thumb_func 0x81479e4
-thumb_func 0x8147a3c
-thumb_func 0x8147ad8
+thumb_func 0x81479e4 Phase2_Wave_Func1
+thumb_func 0x8147a3c Phase2_Wave_Func2
+thumb_func 0x8147ad8 Phase2_Wave_Func3
 thumb_func 0x8147b18 VBlankCB_Phase2_Wave
 thumb_func 0x8147ba4 Phase2Task_Sidney
 thumb_func 0x8147bc4 Phase2Task_Phoebe
@@ -10916,20 +10916,20 @@ thumb_func 0x8147be4 Phase2Task_Glacia
 thumb_func 0x8147c04 Phase2Task_Drake
 thumb_func 0x8147c24 Phase2Task_Champion
 thumb_func 0x8147c44
-thumb_func 0x8147c7c
-thumb_func 0x8147ce4
-thumb_func 0x8147da4
-thumb_func 0x8147e90
+thumb_func 0x8147c7c Phase2_Mugshot_Func1
+thumb_func 0x8147ce4 Phase2_Mugshot_Func2
+thumb_func 0x8147da4 Phase2_Mugshot_Func3
+thumb_func 0x8147e90 Phase2_Mugshot_Func4
 thumb_func 0x8147f0c Phase2_Mugshot_Func5
-thumb_func 0x8147f48
+thumb_func 0x8147f48 Phase2_Mugshot_Func6
 thumb_func 0x8148000 Phase2_Mugshot_Func7
-thumb_func 0x81480c8
-thumb_func 0x8148100
-thumb_func 0x814814c
+thumb_func 0x81480c8 Phase2_Mugshot_Func8
+thumb_func 0x8148100 Phase2_Mugshot_Func9
+thumb_func 0x814814c Phase2_RectangularSpiral_Func3
 thumb_func 0x814818c VBlankCB0_Phase2_Mugshots
 thumb_func 0x8148220 VBlankCB1_Phase2_Mugshots
-thumb_func 0x81482a0
-thumb_func 0x81482d8
+thumb_func 0x81482a0 HBlankCB_Phase2_Mugshots
+thumb_func 0x81482d8 Mugshots_CreateOpponentPlayerSprites
 thumb_func 0x8148440
 thumb_func 0x8148468
 thumb_func 0x814846c
@@ -10940,68 +10940,68 @@ thumb_func 0x8148544
 thumb_func 0x814855c
 thumb_func 0x8148578
 thumb_func 0x8148590
-thumb_func 0x81485c8
-thumb_func 0x8148650
-thumb_func 0x814871c
+thumb_func 0x81485c8 Phase2_Slice_Func1
+thumb_func 0x8148650 Phase2_Slice_Func2
+thumb_func 0x814871c Phase2_Slice_Func3
 thumb_func 0x814875c VBlankCB_Phase2_Slice
 thumb_func 0x81487e8 HBlankCB_Phase2_Slice
 thumb_func 0x8148820
-thumb_func 0x8148858
-thumb_func 0x8148924
+thumb_func 0x8148858 Phase2_ShredSplit_Func1
+thumb_func 0x8148924 Phase2_ShredSplit_Func2
 thumb_func 0x8148b94 Phase2_ShredSplit_Func3
-thumb_func 0x8148bd4
+thumb_func 0x8148bd4 Phase2_ShredSplit_Func4
 thumb_func 0x8148c14
 thumb_func 0x8148c4c
-thumb_func 0x8148c84
-thumb_func 0x8148ce8
+thumb_func 0x8148c84 Phase2_Blackhole_Func1
+thumb_func 0x8148ce8 Phase2_Blackhole1_Func3
 thumb_func 0x8148da8 Phase2_Blackhole1_Func2
-thumb_func 0x8148e2c
+thumb_func 0x8148e2c Phase2_Blackhole2_Func2
 thumb_func 0x8148f14
-thumb_func 0x8148f4c
+thumb_func 0x8148f4c Phase2_RectangularSpiral_Func1
 thumb_func 0x814900c Phase2_RectangularSpiral_Func2
 thumb_func 0x81490c8
 thumb_func 0x8149108
 thumb_func 0x8149200
-thumb_func 0x8149238
+thumb_func 0x8149238 Phase2_Groudon_Func3
 thumb_func 0x8149288
 thumb_func 0x81492e4
 thumb_func 0x814933c
-thumb_func 0x8149374
-thumb_func 0x8149418
-thumb_func 0x8149448
-thumb_func 0x8149498
+thumb_func 0x8149374 Phase2_Rayquaza_Func3
+thumb_func 0x8149418 Phase2_Rayquaza_Func4
+thumb_func 0x8149448 Phase2_Rayquaza_Func5
+thumb_func 0x8149498 Phase2_Rayquaza_Func6
 thumb_func 0x81494d0 Phase2_Rayquaza_Func7
 thumb_func 0x81494fc
-thumb_func 0x814952c
-thumb_func 0x81495c8
+thumb_func 0x814952c Phase2_Rayquaza_Func9
+thumb_func 0x81495c8 VBlankCB_Phase2_Rayquaza
 thumb_func 0x8149638
-thumb_func 0x8149670
-thumb_func 0x81496e8
-thumb_func 0x814975c
-thumb_func 0x8149798
-thumb_func 0x8149800
+thumb_func 0x8149670 Phase2_WhiteFade_Func1
+thumb_func 0x81496e8 Phase2_WhiteFade_Func2
+thumb_func 0x814975c Phase2_WhiteFade_Func3
+thumb_func 0x8149798 Phase2_WhiteFade_Func4
+thumb_func 0x8149800 Phase2_WhiteFade_Func5
 thumb_func 0x8149834 VBlankCB0_Phase2_WhiteFade
 thumb_func 0x81498c4 VBlankCB1_Phase2_WhiteFade
 thumb_func 0x8149900 HBlankCB_Phase2_WhiteFade
 thumb_func 0x8149924
 thumb_func 0x8149a1c
-thumb_func 0x8149a54
-thumb_func 0x8149aa8
-thumb_func 0x8149b00
+thumb_func 0x8149a54 Phase2_GridSquares_Func1
+thumb_func 0x8149aa8 ItemId_GetImportance
+thumb_func 0x8149b00 Phase2_GridSquares_Func3
 thumb_func 0x8149b2c
-thumb_func 0x8149b64
+thumb_func 0x8149b64 Phase2_Shards_Func1
 thumb_func 0x8149bc8 Phase2_Shards_Func2
-thumb_func 0x8149c44
-thumb_func 0x8149d20
+thumb_func 0x8149c44 Phase2_Shards_Func3
+thumb_func 0x8149d20 Phase2_Shards_Func4
 thumb_func 0x8149d8c Phase2_Shards_Func5
 thumb_func 0x8149da8 VBlankCB_Phase2_Shards
 thumb_func 0x8149e38
-thumb_func 0x8149e9c
-thumb_func 0x8149ebc
+thumb_func 0x8149e9c IsPhase1Done
+thumb_func 0x8149ebc Phase2Task_Magma
 thumb_func 0x8149ef4
-thumb_func 0x8149f50
+thumb_func 0x8149f50 Phase1_TransitionAll_Func2
 thumb_func 0x8149fc8
-thumb_func 0x8149fec
+thumb_func 0x8149fec VBlankCB_BattleTransition
 thumb_func 0x814a000
 thumb_func 0x814a018
 thumb_func 0x814a044
@@ -11009,36 +11009,36 @@ thumb_func 0x814a058
 thumb_func 0x814a0d4
 thumb_func 0x814a26c
 thumb_func 0x814a2e8
-thumb_func 0x814a3e4
-thumb_func 0x814a434
+thumb_func 0x814a3e4 Phase2_29_Func1
+thumb_func 0x814a434 Phase2_29_Func2
 thumb_func 0x814a47c
 thumb_func 0x814a4b4
-thumb_func 0x814a4ec
-thumb_func 0x814a594
-thumb_func 0x814a5c0
-thumb_func 0x814a610
+thumb_func 0x814a4ec Phase2_30_Func1
+thumb_func 0x814a594 Phase2_30_Func2
+thumb_func 0x814a5c0 Phase2_30_Func3
+thumb_func 0x814a610 Phase2_30_Func4
 thumb_func 0x814a744 VBlankCB_Phase2_30
 thumb_func 0x814a78c HBlankCB_Phase2_30
-thumb_func 0x814a7b0
+thumb_func 0x814a7b0 Phase2Task_37
 thumb_func 0x814a7e8
 thumb_func 0x814a820
-thumb_func 0x814a858
-thumb_func 0x814a8e8
-thumb_func 0x814a958
-thumb_func 0x814aa20
-thumb_func 0x814aac4
-thumb_func 0x814ab44
-thumb_func 0x814ab78
-thumb_func 0x814ac60
+thumb_func 0x814a858 Phase2_31_Func1
+thumb_func 0x814a8e8 Phase2_31_Func2
+thumb_func 0x814a958 Phase2_31_Func3
+thumb_func 0x814aa20 Phase2_33_Func1
+thumb_func 0x814aac4 Phase2_33_Func2
+thumb_func 0x814ab44 Phase2_33_Func3
+thumb_func 0x814ab78 Phase2_33_Func4
+thumb_func 0x814ac60 ItemId_GetFieldFunc
 thumb_func 0x814aca4
-thumb_func 0x814acf8
-thumb_func 0x814ae08
-thumb_func 0x814ae74
-thumb_func 0x814ae98
-thumb_func 0x814af00
+thumb_func 0x814acf8 Phase2_32_Func1
+thumb_func 0x814ae08 Phase2_32_Func2
+thumb_func 0x814ae74 Phase2_32_Func3
+thumb_func 0x814ae98 Phase2_32_Func4
+thumb_func 0x814af00 Phase2_32_Func5
 thumb_func 0x814af6c nullsub_88
 thumb_func 0x814af70
-thumb_func 0x814af8c
+thumb_func 0x814af8c LinkPartnerBufferRunCommand
 thumb_func 0x814afdc
 thumb_func 0x814b014
 thumb_func 0x814b07c
@@ -11054,98 +11054,98 @@ thumb_func 0x814b5a0
 thumb_func 0x814b614
 thumb_func 0x814b668
 thumb_func 0x814b75c
-thumb_func 0x814b800
+thumb_func 0x814b800 LinkPartnerBufferExecCompleted
 thumb_func 0x814b878
 thumb_func 0x814b8a8
 thumb_func 0x814b8d8
-thumb_func 0x814b94c
+thumb_func 0x814b94c CopyLinkPartnerMonData
 thumb_func 0x814c0f8
 thumb_func 0x814c104
-thumb_func 0x814c15c
+thumb_func 0x814c15c SetLinkPartnerMonData
 thumb_func 0x814cb58
-thumb_func 0x814cbcc
+thumb_func 0x814cbcc LinkPartnerHandleLoadMonSprite
 thumb_func 0x814cce8
 thumb_func 0x814cd58
-thumb_func 0x814ced4
+thumb_func 0x814ced4 LinkPartnerHandleReturnMonToBall
 thumb_func 0x814cf64
-thumb_func 0x814cff0
-thumb_func 0x814d1a4
-thumb_func 0x814d1b0
+thumb_func 0x814cff0 LinkPartnerHandleDrawTrainerPic
+thumb_func 0x814d1a4 LinkPartnerHandleTrainerSlide
+thumb_func 0x814d1b0 LinkPartnerHandleTrainerSlideBack
 thumb_func 0x814d25c
-thumb_func 0x814d348
-thumb_func 0x814d354
-thumb_func 0x814d360
-thumb_func 0x814d36c
+thumb_func 0x814d348 LinkPartnerHandlePaletteFade
+thumb_func 0x814d354 LinkPartnerHandleSuccessBallThrowAnim
+thumb_func 0x814d360 LinkPartnerHandleBallThrowAnim
+thumb_func 0x814d36c LinkPartnerHandlePause
 thumb_func 0x814d378
 thumb_func 0x814d4cc
-thumb_func 0x814d650
-thumb_func 0x814d6a8
-thumb_func 0x814d6b4
+thumb_func 0x814d650 LinkPartnerHandlePrintString
+thumb_func 0x814d6a8 LinkPartnerHandlePrintSelectionString
+thumb_func 0x814d6b4 LinkPartnerHandleChooseAction
 thumb_func 0x814d6c0
 thumb_func 0x814d6cc
-thumb_func 0x814d6d8
-thumb_func 0x814d6e4
-thumb_func 0x814d6f0
-thumb_func 0x814d6fc
-thumb_func 0x814d7ec
+thumb_func 0x814d6d8 LinkPartnerHandleChooseItem
+thumb_func 0x814d6e4 LinkPartnerHandleChoosePokemon
+thumb_func 0x814d6f0 LinkPartnerHandleCmd23
+thumb_func 0x814d6fc LinkPartnerHandleHealthBarUpdate
+thumb_func 0x814d7ec LinkPartnerHandleExpUpdate
 thumb_func 0x814d7f8
 thumb_func 0x814d870
-thumb_func 0x814d8d8
-thumb_func 0x814d8e4
-thumb_func 0x814d8f0
-thumb_func 0x814d8fc
-thumb_func 0x814d908
-thumb_func 0x814d914
-thumb_func 0x814d920
-thumb_func 0x814d92c
-thumb_func 0x814d938
+thumb_func 0x814d8d8 LinkPartnerHandleStatusXor
+thumb_func 0x814d8e4 LinkPartnerHandleDataTransfer
+thumb_func 0x814d8f0 LinkPartnerHandleDMA3Transfer
+thumb_func 0x814d8fc LinkPartnerHandlePlayBGM
+thumb_func 0x814d908 LinkPartnerHandleCmd32
+thumb_func 0x814d914 LinkPartnerHandleTwoReturnValues
+thumb_func 0x814d920 LinkPartnerHandleChosenMonReturnValue
+thumb_func 0x814d92c LinkPartnerHandleOneReturnValue
+thumb_func 0x814d938 LinkPartnerHandleOneReturnValue_Duplicate
 thumb_func 0x814d944 LinkPartnerHandleCmd37
 thumb_func 0x814d960 LinkPartnerHandleCmd38
 thumb_func 0x814d998 LinkPartnerHandleCmd39
 thumb_func 0x814d9b0 LinkPartnerHandleCmd40
 thumb_func 0x814d9d8
-thumb_func 0x814da48
+thumb_func 0x814da48 LinkPartnerHandleCmd42
 thumb_func 0x814da54
-thumb_func 0x814da98
-thumb_func 0x814daf4
-thumb_func 0x814db34
-thumb_func 0x814db68
+thumb_func 0x814da98 LinkPartnerHandlePlayFanfareOrBGM
+thumb_func 0x814daf4 LinkPartnerHandleFaintingCry
+thumb_func 0x814db34 LinkPartnerHandleIntroSlide
+thumb_func 0x814db68 LinkPartnerHandleIntroTrainerBallThrow
 thumb_func 0x814dd8c
-thumb_func 0x814de98
+thumb_func 0x814de98 LinkPartnerHandleDrawPartyStatusSummary
 thumb_func 0x814df5c
 thumb_func 0x814dfa4 LinkPartnerHandleHidePartyStatusSummary
-thumb_func 0x814dff4
-thumb_func 0x814e000
-thumb_func 0x814e060
-thumb_func 0x814e0d4
-thumb_func 0x814e0f4
-thumb_func 0x814e100
+thumb_func 0x814dff4 LinkPartnerHandleEndBounceEffect
+thumb_func 0x814e000 LinkPartnerHandleSpriteInvisibility
+thumb_func 0x814e060 LinkPartnerHandleBattleAnimation
+thumb_func 0x814e0d4 LinkPartnerHandleLinkStandbyMsg
+thumb_func 0x814e0f4 LinkPartnerHandleResetActionMoveSelection
+thumb_func 0x814e100 LinkPartnerHandleCmd55
 thumb_func 0x814e180 nullsub_89
-thumb_func 0x814e184
-thumb_func 0x814e7a0
-thumb_func 0x814e7b0
-thumb_func 0x814f664
-thumb_func 0x814f910
-thumb_func 0x814f968
+thumb_func 0x814e184 PrintOnTrainerHillRecordsWindow
+thumb_func 0x814e7a0 BattleStringExpandPlaceholdersToDisplayedString
+thumb_func 0x814e7b0 BattleStringExpandPlaceholders
+thumb_func 0x814f664 ExpandBattleTextBuffPlaceholders
+thumb_func 0x814f910 ChooseMoveUsedParticle
+thumb_func 0x814f968 ChooseTypeOfMoveUsedString
 thumb_func 0x814fa04
 thumb_func 0x814fb80
 thumb_func 0x814fbfc GetCurrentPpToMaxPpState
-thumb_func 0x814fc4c
+thumb_func 0x814fc4c CableCarTask1
 thumb_func 0x814fc78
-thumb_func 0x814fca4
+thumb_func 0x814fca4 CableCarMainCallback_Setup
 thumb_func 0x8150218
-thumb_func 0x8150234
+thumb_func 0x8150234 CleanupCableCar
 thumb_func 0x81503c0
 thumb_func 0x815052c
 thumb_func 0x8150640
-thumb_func 0x81507dc
+thumb_func 0x81507dc CableCarVblankCallback
 thumb_func 0x8150840 nullsub_901
 thumb_func 0x8150844
 thumb_func 0x8150924
 thumb_func 0x8150a44
 thumb_func 0x8150ad0
 thumb_func 0x8150b48
-thumb_func 0x8150d04
+thumb_func 0x8150d04 LoadCableCarSprites
 thumb_func 0x8151064
 thumb_func 0x8151138
 thumb_func 0x8151194
@@ -11169,13 +11169,13 @@ thumb_func 0x8151928
 thumb_func 0x81519b8 task_tutorial_controls_fadein
 thumb_func 0x8151a24
 thumb_func 0x8151a78
-thumb_func 0x8151b18
+thumb_func 0x8151b18 InitPulseBlend
 thumb_func 0x8151b44 InitPulseBlendPaletteSettings
-thumb_func 0x8151bb0
+thumb_func 0x8151bb0 ClearPulseBlendPalettesSettings
 thumb_func 0x8151c2c UnloadUsedPulseBlendPalettes
 thumb_func 0x8151c84 MarkUsedPulseBlendPalettes
-thumb_func 0x8151d04
-thumb_func 0x8151e2c
+thumb_func 0x8151d04 UnmarkUsedPulseBlendPalettes
+thumb_func 0x8151e2c UpdatePulseBlend
 thumb_func 0x8151fe4
 thumb_func 0x8152034
 thumb_func 0x8152084
@@ -11188,116 +11188,116 @@ thumb_func 0x8152414
 thumb_func 0x8152450
 thumb_func 0x81524a0
 thumb_func 0x81525ac
-thumb_func 0x815262c
-thumb_func 0x815265c
-thumb_func 0x8152678
+thumb_func 0x815262c ClearSaveData
+thumb_func 0x815265c Save_ResetSaveCounters
+thumb_func 0x8152678 SetDamagedSectorBits
 thumb_func 0x81526dc
-thumb_func 0x815277c
-thumb_func 0x815286c
-thumb_func 0x81528e4
-thumb_func 0x8152910
+thumb_func 0x815277c HandleWriteSector
+thumb_func 0x815286c HandleWriteSectorNBytes
+thumb_func 0x81528e4 TryWriteSector
+thumb_func 0x8152910 RestoreSaveBackupVarsAndIncrement
 thumb_func 0x815296c RestoreSaveBackupVars
 thumb_func 0x81529b0
 thumb_func 0x8152a10
-thumb_func 0x8152a5c
+thumb_func 0x8152a5c ClearSaveData_2
 thumb_func 0x8152bfc
 thumb_func 0x8152c94
 thumb_func 0x8152d20
 thumb_func 0x8152d60
-thumb_func 0x8152e18
+thumb_func 0x8152e18 GetSaveValidStatus
 thumb_func 0x815302c
-thumb_func 0x815309c
+thumb_func 0x815309c DoReadFlashWholeSection
 thumb_func 0x81530b4 CalculateChecksum
 thumb_func 0x81530e0 UpdateSaveAddresses
-thumb_func 0x8153154
-thumb_func 0x8153274
+thumb_func 0x8153154 HandleSavingData
+thumb_func 0x8153274 TrySavingData
 thumb_func 0x81532bc
 thumb_func 0x81532e8
 thumb_func 0x815331c
 thumb_func 0x8153344
 thumb_func 0x815336c
-thumb_func 0x81533b0
-thumb_func 0x815340c
+thumb_func 0x81533b0 CheckSaveFile
+thumb_func 0x815340c Save_LoadGameData
 thumb_func 0x8153498
-thumb_func 0x8153518
-thumb_func 0x8153570
+thumb_func 0x8153518 TryReadSpecialSaveSection
+thumb_func 0x8153570 TryWriteSpecialSaveSection
 thumb_func 0x81535c4
 thumb_func 0x8153708 CheckCompatibility
-thumb_func 0x8153740
-thumb_func 0x815375c
-thumb_func 0x815378c
+thumb_func 0x8153740 SetIncompatible
+thumb_func 0x815375c InitMysteryEventScript
+thumb_func 0x815378c RunMysteryEventScriptCommand
 thumb_func 0x81537ac
 thumb_func 0x81537c0
 thumb_func 0x81537dc RunMysteryEventScript
-thumb_func 0x8153800
+thumb_func 0x8153800 SetMysteryEventScriptStatus
 thumb_func 0x815380c CalcRecordMixingGiftChecksum
-thumb_func 0x8153834
+thumb_func 0x8153834 IsRecordMixingGiftValid
 thumb_func 0x8153880
 thumb_func 0x81538ac SetRecordMixingGift
-thumb_func 0x8153910
+thumb_func 0x8153910 GetRecordMixingGift
 thumb_func 0x8153960
-thumb_func 0x815396c
+thumb_func 0x815396c MEScrCmd_checkcompat
 thumb_func 0x81539bc nullsub_91
-thumb_func 0x81539c0
-thumb_func 0x81539d0
-thumb_func 0x8153a08
-thumb_func 0x8153a24
-thumb_func 0x8153aec
-thumb_func 0x8153b20
+thumb_func 0x81539c0 MEScrCmd_setstatus
+thumb_func 0x81539d0 MEScrCmd_setmsg
+thumb_func 0x8153a08 MEScrCmd_runscript
+thumb_func 0x8153a24 MEScrCmd_setenigmaberry
+thumb_func 0x8153aec MEScrCmd_giveribbon
+thumb_func 0x8153b20 MEScrCmd_initramscript
 thumb_func 0x8153b88
-thumb_func 0x8153bac
-thumb_func 0x8153bd8
-thumb_func 0x8153c04
-thumb_func 0x8153d10
+thumb_func 0x8153bac MEScrCmd_addrareword
+thumb_func 0x8153bd8 MEScrCmd_setrecordmixinggift
+thumb_func 0x8153c04 MEScrCmd_givepokemon
+thumb_func 0x8153d10 MEScrCmd_addtrainer
 thumb_func 0x8153d58
-thumb_func 0x8153d7c
+thumb_func 0x8153d7c MEScrCmd_checksum
 thumb_func 0x8153dc4
-thumb_func 0x8153e10
-thumb_func 0x8153ed4
-thumb_func 0x8153ee8
-thumb_func 0x8153f58
-thumb_func 0x8153fb4
-thumb_func 0x8153fe4
-thumb_func 0x8154164
+thumb_func 0x8153e10 SetUpReflection
+thumb_func 0x8153ed4 GetReflectionVerticalOffset
+thumb_func 0x8153ee8 LoadObjectReflectionPalette
+thumb_func 0x8153f58 LoadObjectRegularReflectionPalette
+thumb_func 0x8153fb4 LoadObjectHighBridgeReflectionPalette
+thumb_func 0x8153fe4 UpdateObjectReflectionSprite
+thumb_func 0x8154164 CreateWarpArrowSprite
 thumb_func 0x81541b4 SetSpriteInvisible
-thumb_func 0x81541d4
-thumb_func 0x815427c
-thumb_func 0x8154320
-thumb_func 0x81543e8
-thumb_func 0x815448c
-thumb_func 0x8154594
-thumb_func 0x8154604
-thumb_func 0x8154694
-thumb_func 0x815473c
-thumb_func 0x8154838
-thumb_func 0x81548a8
-thumb_func 0x815494c
-thumb_func 0x8154a40
-thumb_func 0x8154ab4
-thumb_func 0x8154b28
+thumb_func 0x81541d4 ShowWarpArrowSprite
+thumb_func 0x815427c FldEff_Shadow
+thumb_func 0x8154320 UpdateShadowFieldEffect
+thumb_func 0x81543e8 FldEff_TallGrass
+thumb_func 0x815448c UpdateTallGrassFieldEffect
+thumb_func 0x8154594 FldEff_JumpTallGrass
+thumb_func 0x8154604 FindTallGrassFieldEffectSpriteId
+thumb_func 0x8154694 FldEff_LongGrass
+thumb_func 0x815473c UpdateLongGrassFieldEffect
+thumb_func 0x8154838 FldEff_JumpLongGrass
+thumb_func 0x81548a8 FldEff_ShortGrass
+thumb_func 0x815494c UpdateShortGrassFieldEffect
+thumb_func 0x8154a40 FldEff_SandFootprints
+thumb_func 0x8154ab4 FldEff_DeepSandFootprints
+thumb_func 0x8154b28 FldEff_BikeTireTracks
 thumb_func 0x8154b9c
-thumb_func 0x8154bb8
-thumb_func 0x8154bdc
-thumb_func 0x8154c28
-thumb_func 0x8154ccc
-thumb_func 0x8154d58
-thumb_func 0x8154dc8
-thumb_func 0x8154e38
-thumb_func 0x8154ef0
-thumb_func 0x8154f90
-thumb_func 0x8154ff0
-thumb_func 0x8155094
-thumb_func 0x815512c
-thumb_func 0x8155198
-thumb_func 0x8155204
-thumb_func 0x8155270
-thumb_func 0x81552dc
-thumb_func 0x8155310
-thumb_func 0x815539c
+thumb_func 0x8154bb8 FadeFootprintsTireTracks_Step0
+thumb_func 0x8154bdc FadeFootprintsTireTracks_Step1
+thumb_func 0x8154c28 FldEff_Splash
+thumb_func 0x8154ccc UpdateSplashFieldEffect
+thumb_func 0x8154d58 FldEff_JumpSmallSplash
+thumb_func 0x8154dc8 FldEff_JumpBigSplash
+thumb_func 0x8154e38 FldEff_FeetInFlowingWater
+thumb_func 0x8154ef0 UpdateFeetInFlowingWaterFieldEffect
+thumb_func 0x8154f90 FldEff_Ripple
+thumb_func 0x8154ff0 FldEff_HotSpringsWater
+thumb_func 0x8155094 UpdateHotSpringsWaterFieldEffect
+thumb_func 0x815512c FldEff_Unknown19
+thumb_func 0x8155198 FldEff_Unknown20
+thumb_func 0x8155204 FldEff_Unknown21
+thumb_func 0x8155270 FldEff_Unknown22
+thumb_func 0x81552dc StartAshFieldEffect
+thumb_func 0x8155310 FldEff_Ash
+thumb_func 0x815539c CallBattlePikeFunction
 thumb_func 0x81553b8 UpdateAshFieldEffect_Step0
-thumb_func 0x81553e8
-thumb_func 0x8155448
-thumb_func 0x8155470
+thumb_func 0x81553e8 UpdateAshFieldEffect_Step1
+thumb_func 0x8155448 UpdateAshFieldEffect_Step2
+thumb_func 0x8155470 FldEff_SurfBlob
 thumb_func 0x81554e8
 thumb_func 0x8155514
 thumb_func 0x8155540
@@ -11305,57 +11305,57 @@ thumb_func 0x8155574
 thumb_func 0x815557c
 thumb_func 0x8155588
 thumb_func 0x8155594 UpdateSurfBlobFieldEffect
-thumb_func 0x81555ec
+thumb_func 0x81555ec SynchroniseSurfAnim
 thumb_func 0x8155624
-thumb_func 0x81556b8
+thumb_func 0x81556b8 CreateBobbingEffect
 thumb_func 0x815573c
 thumb_func 0x815578c
-thumb_func 0x81557cc
-thumb_func 0x815583c
-thumb_func 0x81558f8
-thumb_func 0x81559c4
-thumb_func 0x8155a28
-thumb_func 0x8155a68
-thumb_func 0x8155adc
-thumb_func 0x8155aec
-thumb_func 0x8155afc
-thumb_func 0x8155b0c
-thumb_func 0x8155bc4
+thumb_func 0x81557cc FldEff_Dust
+thumb_func 0x815583c FldEff_SandPile
+thumb_func 0x81558f8 UpdateSandPileFieldEffect
+thumb_func 0x81559c4 FldEff_Bubbles
+thumb_func 0x8155a28 UpdateBubblesFieldEffect
+thumb_func 0x8155a68 FldEff_BerryTreeGrowthSparkle
+thumb_func 0x8155adc ShowTreeDisguiseFieldEffect
+thumb_func 0x8155aec ShowMountainDisguiseFieldEffect
+thumb_func 0x8155afc ShowSandDisguiseFieldEffect
+thumb_func 0x8155b0c ShowDisguiseFieldEffect
+thumb_func 0x8155bc4 UpdateDisguiseFieldEffect
 thumb_func 0x8155cb4
 thumb_func 0x8155cdc
-thumb_func 0x8155d18
-thumb_func 0x8155d8c
+thumb_func 0x8155d18 FldEff_Sparkle
+thumb_func 0x8155d8c UpdateSparkleFieldEffect
 thumb_func 0x8155ddc
 thumb_func 0x8155de4
 thumb_func 0x8155ebc
 thumb_func 0x81560d0
-thumb_func 0x815610c
+thumb_func 0x815610c WaitFieldEffectSpriteAnim
 thumb_func 0x8156138
-thumb_func 0x8156200
-thumb_func 0x8156260
-thumb_func 0x81562ec
+thumb_func 0x8156200 ContestAI_ResetAI
+thumb_func 0x8156260 ContestAI_GetActionToUse
+thumb_func 0x81562ec ContestAI_DoAIProcessing
 thumb_func 0x81563e8
-thumb_func 0x8156418
+thumb_func 0x8156418 ContestAICmd_score
 thumb_func 0x815646c ContestAICmd_get_turn
-thumb_func 0x815648c
-thumb_func 0x81564d0
-thumb_func 0x8156514
-thumb_func 0x8156558
+thumb_func 0x815648c ContestAICmd_if_turn_less_than
+thumb_func 0x81564d0 ContestAICmd_if_turn_more_than
+thumb_func 0x8156514 ContestAICmd_if_turn_eq
+thumb_func 0x8156558 ContestAICmd_if_turn_not_eq
 thumb_func 0x815659c ContestAICmd_get_excitement
-thumb_func 0x81565c0
-thumb_func 0x8156604
-thumb_func 0x8156648
-thumb_func 0x815668c
+thumb_func 0x81565c0 ContestAICmd_if_excitement_less_than
+thumb_func 0x8156604 ContestAICmd_if_excitement_more_than
+thumb_func 0x8156648 ContestAICmd_if_excitement_eq
+thumb_func 0x815668c ContestAICmd_if_excitement_not_eq
 thumb_func 0x81566d0 ContestAICmd_get_user_order
-thumb_func 0x81566f8
-thumb_func 0x815673c
-thumb_func 0x8156780
-thumb_func 0x81567c4
-thumb_func 0x8156808
-thumb_func 0x8156848
-thumb_func 0x815688c
-thumb_func 0x81568d0
-thumb_func 0x8156914
+thumb_func 0x81566f8 ContestAICmd_if_user_order_less_than
+thumb_func 0x815673c ContestAICmd_if_user_order_more_than
+thumb_func 0x8156780 ContestAICmd_if_user_order_eq
+thumb_func 0x81567c4 ContestAICmd_if_user_order_not_eq
+thumb_func 0x8156808 ContestAICmd_get_user_condition
+thumb_func 0x8156848 ContestAICmd_if_user_condition_less_than
+thumb_func 0x815688c ContestAICmd_if_user_condition_more_than
+thumb_func 0x81568d0 ContestAICmd_if_user_condition_eq
+thumb_func 0x8156914 ContestAICmd_if_user_condition_not_eq
 thumb_func 0x8156958 ContestAICmd_unk_15
 thumb_func 0x8156984
 thumb_func 0x81569d4
@@ -11367,112 +11367,112 @@ thumb_func 0x8156b40
 thumb_func 0x8156b90
 thumb_func 0x8156be0
 thumb_func 0x8156c30 ContestAICmd_get_contest_type
-thumb_func 0x8156c54
-thumb_func 0x8156c98
-thumb_func 0x8156cdc
-thumb_func 0x8156d20
-thumb_func 0x8156d68
-thumb_func 0x8156db0
-thumb_func 0x8156df8
+thumb_func 0x8156c54 ContestAICmd_if_contest_type_eq
+thumb_func 0x8156c98 ContestAICmd_if_contest_type_not_eq
+thumb_func 0x8156cdc ContestAICmd_get_move_excitement
+thumb_func 0x8156d20 ContestAICmd_if_move_excitement_less_than
+thumb_func 0x8156d68 ContestAICmd_if_move_excitement_greater_than
+thumb_func 0x8156db0 ContestAICmd_if_move_excitement_eq
+thumb_func 0x8156df8 ContestAICmd_if_move_excitement_not_eq
 thumb_func 0x8156e40 ContestAICmd_get_move_effect
-thumb_func 0x8156e80
-thumb_func 0x8156ec4
+thumb_func 0x8156e80 PrintPlayerBerryPowderAmount
+thumb_func 0x8156ec4 ContestAICmd_if_move_effect_not_eq
 thumb_func 0x8156f08 ContestAICmd_get_move_effect_type
-thumb_func 0x8156f54
-thumb_func 0x8156f98
-thumb_func 0x8156fdc
-thumb_func 0x8157068
-thumb_func 0x81570b0
-thumb_func 0x815713c
-thumb_func 0x8157184
+thumb_func 0x8156f54 ContestAICmd_if_move_effect_type_eq
+thumb_func 0x8156f98 ContestAICmd_if_move_effect_type_not_eq
+thumb_func 0x8156fdc ContestAICmd_check_most_appealing_move
+thumb_func 0x8157068 ContestAICmd_if_most_appealing_move
+thumb_func 0x81570b0 ContestAICmd_unk_2F
+thumb_func 0x815713c ContestAICmd_unk_30
+thumb_func 0x8157184 ContestAICmd_unk_31
 thumb_func 0x81571e0
 thumb_func 0x8157224
 thumb_func 0x8157268
 thumb_func 0x81572ac
-thumb_func 0x81572f0
+thumb_func 0x81572f0 ContestAICmd_unk_36
 thumb_func 0x815734c
 thumb_func 0x8157390
 thumb_func 0x81573d4
 thumb_func 0x8157418
-thumb_func 0x815745c
-thumb_func 0x81574b4
-thumb_func 0x81574f8
-thumb_func 0x815753c
-thumb_func 0x8157580
-thumb_func 0x81575c4
+thumb_func 0x815745c ContestAICmd_get_move_used_count
+thumb_func 0x81574b4 ContestAICmd_if_most_used_count_less_than
+thumb_func 0x81574f8 ContestAICmd_if_most_used_count_more_than
+thumb_func 0x815753c ContestAICmd_if_most_used_count_eq
+thumb_func 0x8157580 ContestAICmd_if_most_used_count_not_eq
+thumb_func 0x81575c4 ContestAICmd_check_combo_starter
 thumb_func 0x815763c
 thumb_func 0x8157684
-thumb_func 0x81576cc
+thumb_func 0x81576cc ContestAICmd_check_combo_finisher
 thumb_func 0x8157744
 thumb_func 0x815778c
-thumb_func 0x81577d4
-thumb_func 0x8157834
-thumb_func 0x815787c
-thumb_func 0x81578c4
-thumb_func 0x8157908
-thumb_func 0x815794c
-thumb_func 0x8157990
-thumb_func 0x81579d4
-thumb_func 0x8157a18
+thumb_func 0x81577d4 ContestAICmd_check_would_finish_combo
+thumb_func 0x8157834 ContestAICmd_if_would_finish_combo
+thumb_func 0x815787c ContestAICmd_if_would_not_finish_combo
+thumb_func 0x81578c4 ContestAICmd_get_condition
+thumb_func 0x8157908 ContestAICmd_if_condition_less_than
+thumb_func 0x815794c ContestAICmd_if_condition_more_than
+thumb_func 0x8157990 ContestAICmd_if_condition_eq
+thumb_func 0x81579d4 ContestAICmd_if_condition_not_eq
+thumb_func 0x8157a18 ContestAICmd_get_used_combo_starter
 thumb_func 0x8157a74
 thumb_func 0x8157ab8
 thumb_func 0x8157afc
 thumb_func 0x8157b40
-thumb_func 0x8157b84
-thumb_func 0x8157bd0
-thumb_func 0x8157c18
+thumb_func 0x8157b84 ContestAICmd_check_can_participate
+thumb_func 0x8157bd0 ContestAICmd_if_can_participate
+thumb_func 0x8157c18 ContestAICmd_if_cannot_participate
 thumb_func 0x8157c60 ContestAICmd_get_val_812A188
-thumb_func 0x8157c9c
-thumb_func 0x8157ce4
+thumb_func 0x8157c9c ContestAICmd_unk_57
+thumb_func 0x8157ce4 ContestAICmd_contest_58
 thumb_func 0x8157d2c ContestAICmd_unk_59
-thumb_func 0x8157d78
+thumb_func 0x8157d78 ContestAICmd_unk_5A
 thumb_func 0x8157dc0
-thumb_func 0x8157e08
-thumb_func 0x8157e50
+thumb_func 0x8157e08 ContestAICmd_unk_5C
+thumb_func 0x8157e50 ContestAICmd_unk_5D
 thumb_func 0x8157e98 ContestAICmd_unk_5E
-thumb_func 0x8157edc
-thumb_func 0x8157f24
-thumb_func 0x8157f6c
-thumb_func 0x8157fb4
+thumb_func 0x8157edc ContestAICmd_unk_5F
+thumb_func 0x8157f24 ContestAICmd_unk_60
+thumb_func 0x8157f6c ContestAICmd_unk_61
+thumb_func 0x8157fb4 ContestAICmd_unk_62
 thumb_func 0x8157ffc ContestAICmd_unk_63
-thumb_func 0x8158044
-thumb_func 0x8158088
-thumb_func 0x81580cc
-thumb_func 0x8158110
+thumb_func 0x8158044 ContestAICmd_unk_64
+thumb_func 0x8158088 ContestAICmd_unk_65
+thumb_func 0x81580cc ContestAICmd_unk_66
+thumb_func 0x8158110 ContestAICmd_unk_67
 thumb_func 0x8158154 ContestAICmd_unk_68
-thumb_func 0x8158190
-thumb_func 0x81581d4
-thumb_func 0x8158218
-thumb_func 0x815825c
+thumb_func 0x8158190 ContestAICmd_unk_69
+thumb_func 0x81581d4 ContestAICmd_unk_6A
+thumb_func 0x8158218 ContestAICmd_unk_6B
+thumb_func 0x815825c ContestAICmd_unk_6C
 thumb_func 0x81582a0 ContestAICmd_unk_6D
-thumb_func 0x81582f4
-thumb_func 0x8158338
+thumb_func 0x81582f4 ContestAICmd_unk_6E
+thumb_func 0x8158338 ContestAICmd_unk_6F
 thumb_func 0x815837c ContestAICmd_unk_70
 thumb_func 0x81583a8 ContestAICmd_unk_71
 thumb_func 0x81583d8 ContestAICmd_unk_72
 thumb_func 0x8158410
 thumb_func 0x8158444
-thumb_func 0x8158478
-thumb_func 0x81584c8
-thumb_func 0x8158518
-thumb_func 0x8158568
-thumb_func 0x81585b8
-thumb_func 0x815860c
-thumb_func 0x8158660
-thumb_func 0x81586b4
-thumb_func 0x8158708
-thumb_func 0x8158758
+thumb_func 0x8158478 ContestAICmd_unk_75
+thumb_func 0x81584c8 ContestAICmd_unk_76
+thumb_func 0x8158518 ContestAICmd_unk_77
+thumb_func 0x8158568 ContestAICmd_unk_78
+thumb_func 0x81585b8 ContestAICmd_unk_79
+thumb_func 0x815860c ContestAICmd_unk_7A
+thumb_func 0x8158660 ContestAICmd_unk_7B
+thumb_func 0x81586b4 ContestAICmd_unk_7C
+thumb_func 0x8158708 ContestAICmd_if_random
+thumb_func 0x8158758 ContestAICmd_unk_7E
 thumb_func 0x81587a8
 thumb_func 0x81587c8 ContestAICmd_call
 thumb_func 0x81587f8 ContestAICmd_end
 thumb_func 0x815881c AIStackPushVar
-thumb_func 0x8158844
-thumb_func 0x8158884
-thumb_func 0x81588e0
-thumb_func 0x8158928
-thumb_func 0x8158970
-thumb_func 0x81589dc
-thumb_func 0x8158a24
+thumb_func 0x8158844 AIStackPop
+thumb_func 0x8158884 ContestAICmd_check_user_has_exciting_move
+thumb_func 0x81588e0 ContestAICmd_if_user_has_exciting_move
+thumb_func 0x8158928 ContestAICmd_if_user_doesnt_have_exciting_move
+thumb_func 0x8158970 ContestAICmd_unk_85
+thumb_func 0x81589dc ContestAICmd_unk_86
+thumb_func 0x8158a24 ContestAICmd_if_effect_in_user_moveset
 thumb_func 0x8158a6c
 thumb_func 0x8158ad4
 thumb_func 0x8158b40
@@ -11492,82 +11492,82 @@ thumb_func 0x815922c
 thumb_func 0x8159244
 thumb_func 0x81592a4 nullsub_90
 thumb_func 0x81592a8
-thumb_func 0x81592c4
-thumb_func 0x8159314
+thumb_func 0x81592c4 SafariBufferRunCommand
+thumb_func 0x8159314 HandleInputChooseAction
 thumb_func 0x8159498
 thumb_func 0x81594d0
 thumb_func 0x81594e8 CompleteOnHealthboxSpriteCallbackDummy
 thumb_func 0x8159520
 thumb_func 0x8159560 CompleteOnSpecialAnimDone
-thumb_func 0x815959c
+thumb_func 0x815959c SafariOpenPokeblockCase
 thumb_func 0x81595d4
 thumb_func 0x8159610
-thumb_func 0x8159640
+thumb_func 0x8159640 SafariBufferExecCompleted
 thumb_func 0x81596b8
-thumb_func 0x81596e8
-thumb_func 0x81596f4
-thumb_func 0x8159700
-thumb_func 0x815970c
+thumb_func 0x81596e8 SafariHandleGetMonData
+thumb_func 0x81596f4 SafariHandleGetRawMonData
+thumb_func 0x8159700 SafariHandleSetMonData
+thumb_func 0x815970c SafariHandleSetRawMonData
 thumb_func 0x8159718
-thumb_func 0x8159724
-thumb_func 0x8159730
-thumb_func 0x815973c
-thumb_func 0x815981c
-thumb_func 0x8159828
-thumb_func 0x8159834
-thumb_func 0x8159840
+thumb_func 0x8159724 SafariHandleSwitchInAnim
+thumb_func 0x8159730 SafariHandleReturnMonToBall
+thumb_func 0x815973c SafariHandleDrawTrainerPic
+thumb_func 0x815981c SafariHandleTrainerSlide
+thumb_func 0x8159828 SafariHandleTrainerSlideBack
+thumb_func 0x8159834 SafariHandleFaintAnimation
+thumb_func 0x8159840 SafariHandlePaletteFade
 thumb_func 0x815984c
 thumb_func 0x81598a0
-thumb_func 0x8159900
-thumb_func 0x815990c
+thumb_func 0x8159900 SafariHandlePause
+thumb_func 0x815990c SafariHandleMoveAnimation
 thumb_func 0x8159918
-thumb_func 0x815996c
+thumb_func 0x815996c SafariHandlePrintSelectionString
 thumb_func 0x8159990
-thumb_func 0x81599d0
-thumb_func 0x8159a38
-thumb_func 0x8159a44
-thumb_func 0x8159a50
-thumb_func 0x8159a90
-thumb_func 0x8159a9c
-thumb_func 0x8159aa8
-thumb_func 0x8159ab4
-thumb_func 0x8159ac0
+thumb_func 0x81599d0 SafariHandleChooseAction
+thumb_func 0x8159a38 SafariHandleUnknownYesNoBox
+thumb_func 0x8159a44 SafariHandleChooseMove
+thumb_func 0x8159a50 SafariHandleChooseItem
+thumb_func 0x8159a90 SafariHandleChoosePokemon
+thumb_func 0x8159a9c SafariHandleCmd23
+thumb_func 0x8159aa8 SafariHandleHealthBarUpdate
+thumb_func 0x8159ab4 SafariHandleExpUpdate
+thumb_func 0x8159ac0 SafariHandleStatusIconUpdate
 thumb_func 0x8159afc
-thumb_func 0x8159b08
-thumb_func 0x8159b14
-thumb_func 0x8159b20
-thumb_func 0x8159b2c
-thumb_func 0x8159b38
-thumb_func 0x8159b44
-thumb_func 0x8159b50
-thumb_func 0x8159b5c
-thumb_func 0x8159b68
-thumb_func 0x8159b74
-thumb_func 0x8159b80
-thumb_func 0x8159b8c
-thumb_func 0x8159b98
-thumb_func 0x8159ba4
-thumb_func 0x8159bb0
-thumb_func 0x8159bbc
+thumb_func 0x8159b08 SafariHandleStatusXor
+thumb_func 0x8159b14 SafariHandleDataTransfer
+thumb_func 0x8159b20 SafariHandleDMA3Transfer
+thumb_func 0x8159b2c SafariHandlePlayBGM
+thumb_func 0x8159b38 SafariHandleCmd32
+thumb_func 0x8159b44 SafariHandleTwoReturnValues
+thumb_func 0x8159b50 SafariHandleChosenMonReturnValue
+thumb_func 0x8159b5c SafariHandleOneReturnValue
+thumb_func 0x8159b68 SafariHandleOneReturnValue_Duplicate
+thumb_func 0x8159b74 SafariHandleCmd37
+thumb_func 0x8159b80 SafariHandleCmd38
+thumb_func 0x8159b8c SafariHandleCmd39
+thumb_func 0x8159b98 SafariHandleCmd40
+thumb_func 0x8159ba4 SafariHandleHitAnimation
+thumb_func 0x8159bb0 SafariHandleCmd42
+thumb_func 0x8159bbc SafariHandlePlaySE
 thumb_func 0x8159c00
-thumb_func 0x8159c5c
-thumb_func 0x8159c98
-thumb_func 0x8159ccc
+thumb_func 0x8159c5c SafariHandleFaintingCry
+thumb_func 0x8159c98 SafariHandleIntroSlide
+thumb_func 0x8159ccc SafariHandleIntroTrainerBallThrow
 thumb_func 0x8159d28
-thumb_func 0x8159d34
-thumb_func 0x8159d40
-thumb_func 0x8159d4c
-thumb_func 0x8159d58
-thumb_func 0x8159db4
-thumb_func 0x8159dc0
+thumb_func 0x8159d34 SafariHandleHidePartyStatusSummary
+thumb_func 0x8159d40 SafariHandleEndBounceEffect
+thumb_func 0x8159d4c SafariHandleSpriteInvisibility
+thumb_func 0x8159d58 SafariHandleBattleAnimation
+thumb_func 0x8159db4 SafariHandleLinkStandbyMsg
+thumb_func 0x8159dc0 SafariHandleResetActionMoveSelection
 thumb_func 0x8159dcc
 thumb_func 0x8159e28 nullsub_93
-thumb_func 0x8159e2c
-thumb_func 0x8159e4c
-thumb_func 0x8159e68
+thumb_func 0x8159e2c SetUpFieldMove_SweetScent
+thumb_func 0x8159e4c FieldCallback_SweetScent
+thumb_func 0x8159e68 FldEff_SweetScent
 thumb_func 0x8159e98
-thumb_func 0x8159f28
-thumb_func 0x8159fcc
+thumb_func 0x8159f28 TrySweetScentEncounter
+thumb_func 0x8159fcc FailSweetScentEncounter
 thumb_func 0x815a010
 thumb_func 0x815a050
 thumb_func 0x815a09c
@@ -11590,15 +11590,15 @@ thumb_func 0x815a6a8
 thumb_func 0x815a6ec
 thumb_func 0x815a728
 thumb_func 0x815a7e8
-thumb_func 0x815a804
-thumb_func 0x815a840
+thumb_func 0x815a804 AnimTask_IsTargetPlayerSide
+thumb_func 0x815a840 AnimTask_IsHealingMove
 thumb_func 0x815a870
 thumb_func 0x815a8dc
 thumb_func 0x815a9a8
 thumb_func 0x815a9e0
 thumb_func 0x815aa98
 thumb_func 0x815ab0c
-thumb_func 0x815ab28
+thumb_func 0x815ab28 StartSweetScentFieldEffect
 thumb_func 0x815abc8
 thumb_func 0x815ac0c
 thumb_func 0x815ac88
@@ -11612,10 +11612,10 @@ thumb_func 0x815b274
 thumb_func 0x815b2d0
 thumb_func 0x815b3d8
 thumb_func 0x815b410
-thumb_func 0x815b4ac
+thumb_func 0x815b4ac AnimMiniTwinklingStar
 thumb_func 0x815b50c
 thumb_func 0x815b598
-thumb_func 0x815b5f0
+thumb_func 0x815b5f0 AnimTask_StrongFrustrationGrowAndShrink
 thumb_func 0x815b648
 thumb_func 0x815b6b4
 thumb_func 0x815b70c
@@ -11628,106 +11628,106 @@ thumb_func 0x815bf30
 thumb_func 0x815bf8c
 thumb_func 0x815bfe0
 thumb_func 0x815c2e4
-thumb_func 0x815c33c
-thumb_func 0x815c3b4
-thumb_func 0x815c484
-thumb_func 0x815c5ec
-thumb_func 0x815c63c
-thumb_func 0x815c6ac
-thumb_func 0x815c700
-thumb_func 0x815c898
-thumb_func 0x815c95c
-thumb_func 0x815cac4
-thumb_func 0x815cb70
-thumb_func 0x815cbd0
-thumb_func 0x815cc48
-thumb_func 0x815ccf0
-thumb_func 0x815cd38
-thumb_func 0x815ce14
-thumb_func 0x815d09c
-thumb_func 0x815d0f8
-thumb_func 0x815d17c
-thumb_func 0x815d2d4
-thumb_func 0x815d588
-thumb_func 0x815d5d0
-thumb_func 0x815d668
+thumb_func 0x815c33c AnimWeakFrustrationAngerMark
+thumb_func 0x815c3b4 AnimTask_RockMonBackAndForth
+thumb_func 0x815c484 AnimTask_RockMonBackAndForthStep
+thumb_func 0x815c5ec AnimSweetScentPetal
+thumb_func 0x815c63c AnimSweetScentPetalStep
+thumb_func 0x815c6ac AnimTask_FlailMovement
+thumb_func 0x815c700 AnimTask_FlailMovementStep
+thumb_func 0x815c898 AnimPainSplitProjectile
+thumb_func 0x815c95c AnimTask_PainSplitMovement
+thumb_func 0x815cac4 AnimFlatterConfetti
+thumb_func 0x815cb70 AnimFlatterConfettiStep
+thumb_func 0x815cbd0 AnimFlatterSpotlight
+thumb_func 0x815cc48 AnimFlatterSpotlightStep
+thumb_func 0x815ccf0 AnimReversalOrb
+thumb_func 0x815cd38 AnimReversalOrbStep
+thumb_func 0x815ce14 AnimTask_RolePlaySilhouette
+thumb_func 0x815d09c AnimTask_RolePlaySilhouetteStep1
+thumb_func 0x815d0f8 AnimTask_RolePlaySilhouetteStep2
+thumb_func 0x815d17c AnimTask_AcidArmor
+thumb_func 0x815d2d4 AnimTask_AcidArmorStep
+thumb_func 0x815d588 AnimTask_DeepInhale
+thumb_func 0x815d5d0 AnimTask_DeepInhaleStep
+thumb_func 0x815d668 InitYawnCloudPosition
 thumb_func 0x815d6d0 UpdateYawnCloudPosition
-thumb_func 0x815d6f0
-thumb_func 0x815d740
-thumb_func 0x815d7ac
+thumb_func 0x815d6f0 AnimYawnCloud
+thumb_func 0x815d740 AnimYawnCloudStep
+thumb_func 0x815d7ac AnimSmokeBallEscapeCloud
 thumb_func 0x815d814
 thumb_func 0x815d95c
 thumb_func 0x815dacc
-thumb_func 0x815dbe0
-thumb_func 0x815dc84
-thumb_func 0x815dd1c
+thumb_func 0x815dbe0 AnimTask_SquishAndSweatDroplets
+thumb_func 0x815dc84 AnimTask_SquishAndSweatDropletsStep
+thumb_func 0x815dd1c CreateSweatDroplets
 thumb_func 0x815ddf8
-thumb_func 0x815de48
-thumb_func 0x815dea0
+thumb_func 0x815de48 AnimTask_FacadeColorBlend
+thumb_func 0x815dea0 AnimTask_FacadeColorBlendStep
 thumb_func 0x815df08
-thumb_func 0x815df54
-thumb_func 0x815e014
-thumb_func 0x815e04c
-thumb_func 0x815e144
-thumb_func 0x815e284
-thumb_func 0x815e33c
-thumb_func 0x815e37c
-thumb_func 0x815e3b4
-thumb_func 0x815e504
-thumb_func 0x815e610
+thumb_func 0x815df54 AnimRoarNoiseLine
+thumb_func 0x815e014 AnimRoarNoiseLineStep
+thumb_func 0x815e04c AnimTask_GlareEyeDots
+thumb_func 0x815e144 AnimTask_GlareEyeDotsStep
+thumb_func 0x815e284 GetGlareEyeDotCoords
+thumb_func 0x815e33c AnimGlareEyeDot
+thumb_func 0x815e37c AnimAssistPawprint
+thumb_func 0x815e3b4 AnimTask_BarrageBall
+thumb_func 0x815e504 AnimTask_BarrageBallStep
+thumb_func 0x815e610 AnimSmellingSaltsHand
 thumb_func 0x815e6bc
-thumb_func 0x815e778
-thumb_func 0x815e7d0
-thumb_func 0x815e88c
-thumb_func 0x815e8f4
-thumb_func 0x815e94c
-thumb_func 0x815e998
-thumb_func 0x815eb80
-thumb_func 0x815ec1c
-thumb_func 0x815edbc
-thumb_func 0x815ee40
-thumb_func 0x815f044
-thumb_func 0x815f0c4
-thumb_func 0x815f144
-thumb_func 0x815f268
-thumb_func 0x815f3c4
-thumb_func 0x815f428
-thumb_func 0x815f558
-thumb_func 0x815f6d4
-thumb_func 0x815f6fc
-thumb_func 0x815f7d8
-thumb_func 0x815f82c
+thumb_func 0x815e778 AnimTask_SmellingSaltsSquish
+thumb_func 0x815e7d0 AnimTask_SmellingSaltsSquishStep
+thumb_func 0x815e88c AnimSmellingSaltExclamation
+thumb_func 0x815e8f4 AnimSmellingSaltExclamationStep
+thumb_func 0x815e94c AnimHelpingHandClap
+thumb_func 0x815e998 AnimHelpingHandClapStep
+thumb_func 0x815eb80 AnimTask_HelpingHandAttackerMovement
+thumb_func 0x815ec1c AnimTask_HelpingHandAttackerMovementStep
+thumb_func 0x815edbc AnimForesightMagnifyingGlass
+thumb_func 0x815ee40 AnimForesightMagnifyingGlassStep
+thumb_func 0x815f044 AnimMeteorMashStarStep
+thumb_func 0x815f0c4 AnimMeteorMashStar
+thumb_func 0x815f144 AnimTask_MonToSubstitute
+thumb_func 0x815f268 AnimTask_MonToSubstituteDoll
+thumb_func 0x815f3c4 AnimBlockX
+thumb_func 0x815f428 AnimBlockXStep
+thumb_func 0x815f558 AnimTask_OdorSleuthMovement
+thumb_func 0x815f6d4 AnimTask_OdorSleuthMovementWaitFinish
+thumb_func 0x815f6fc MoveOdorSleuthClone
+thumb_func 0x815f7d8 AnimTask_GetReturnPowerLevel
+thumb_func 0x815f82c AnimTask_SnatchOpposingMonMove
 thumb_func 0x815fdb8
-thumb_func 0x815fefc
-thumb_func 0x816009c
-thumb_func 0x8160114
-thumb_func 0x8160218
-thumb_func 0x8160270
-thumb_func 0x81602e0
-thumb_func 0x816032c
-thumb_func 0x8160428
+thumb_func 0x815fefc AnimTask_SnatchPartnerMove
+thumb_func 0x816009c AnimTask_TeeterDanceMovement
+thumb_func 0x8160114 AnimTask_TeeterDanceMovementStep
+thumb_func 0x8160218 AnimKnockOffStrikeStep
+thumb_func 0x8160270 AnimKnockOffStrike
+thumb_func 0x81602e0 AnimRecycle
+thumb_func 0x816032c AnimRecycleStep
+thumb_func 0x8160428 AnimTask_GetWeather
 thumb_func 0x816047c
-thumb_func 0x81604c4
-thumb_func 0x816055c
-thumb_func 0x8160570
+thumb_func 0x81604c4 AnimTask_SlackOffSquishStep
+thumb_func 0x816055c VBlankCB_MoveRelearner
+thumb_func 0x8160570 TeachMoveRelearnerMove
 thumb_func 0x816059c
-thumb_func 0x81605d8
-thumb_func 0x8160678
-thumb_func 0x8160724
+thumb_func 0x81605d8 CB2_InitLearnMove
+thumb_func 0x8160678 CB2_InitLearnMoveReturnFromSelectMove
+thumb_func 0x8160724 InitMoveRelearnerBackgroundLayers
 thumb_func 0x8160764
-thumb_func 0x8160784
+thumb_func 0x8160784 FormatAndPrintText
 thumb_func 0x81607a0
-thumb_func 0x8160dc8
-thumb_func 0x8160e08
+thumb_func 0x8160dc8 FreeMoveRelearnerResources
+thumb_func 0x8160e08 HideHeartSpritesAndShowTeachMoveText
 thumb_func 0x8160e70
 thumb_func 0x8160f74 GetCurrentSelectedMove
 thumb_func 0x8160f94
-thumb_func 0x8160fd0
-thumb_func 0x81610c4
-thumb_func 0x816114c
+thumb_func 0x8160fd0 CreateUISprites
+thumb_func 0x81610c4 AddScrollArrows
+thumb_func 0x816114c RemoveScrollArrows
 thumb_func 0x8161198
-thumb_func 0x8161280
-thumb_func 0x816140c
+thumb_func 0x8161280 MoveRelearnerShowHideHearts
+thumb_func 0x816140c SetUpFieldMove_SoftBoiled
 thumb_func 0x8161464
 thumb_func 0x81614ac
 thumb_func 0x8161570
@@ -11735,66 +11735,66 @@ thumb_func 0x81615c4
 thumb_func 0x8161628
 thumb_func 0x8161688
 thumb_func 0x81616bc
-thumb_func 0x81616f8
+thumb_func 0x81616f8 SetDecorationInventoriesPointers
 thumb_func 0x8161784 ClearDecorationInventory
 thumb_func 0x81617b8 ClearDecorationInventories
-thumb_func 0x81617d4
+thumb_func 0x81617d4 GetFirstEmptyDecorSlot
 thumb_func 0x816181c
 thumb_func 0x8161868
 thumb_func 0x81618b4
-thumb_func 0x81618ec
+thumb_func 0x81618ec DecorationRemove
 thumb_func 0x816194c CondenseDecorationsInCategory
 thumb_func 0x81619e4 GetNumOwnedDecorationsInCategory
 thumb_func 0x8161a24 GetNumOwnedDecorations
-thumb_func 0x8161a48
+thumb_func 0x8161a48 ClearRoamerData
 thumb_func 0x8161a74 ClearRoamerLocationData
-thumb_func 0x8161aa8
+thumb_func 0x8161aa8 CreateInitialRoamerMon
 thumb_func 0x8161bd0 InitRoamer
 thumb_func 0x8161bec UpdateLocationHistoryForRoamer
-thumb_func 0x8161c14
-thumb_func 0x8161c68
-thumb_func 0x8161cfc
-thumb_func 0x8161d3c
-thumb_func 0x8161df0
-thumb_func 0x8161e2c
-thumb_func 0x8161e60
-thumb_func 0x8161e78
+thumb_func 0x8161c14 RoamerMoveToOtherLocationSet
+thumb_func 0x8161c68 RoamerMove
+thumb_func 0x8161cfc IsRoamerAt
+thumb_func 0x8161d3c CreateRoamerMonInstance
+thumb_func 0x8161df0 TryStartRoamerEncounter
+thumb_func 0x8161e2c UpdateRoamerHPStatus
+thumb_func 0x8161e60 SetRoamerInactive
+thumb_func 0x8161e78 GetRoamerLocation
 thumb_func 0x8161e88
 thumb_func 0x8161e9c nullsub_941
 thumb_func 0x8161ea8
 thumb_func 0x8161f68
 thumb_func 0x8162008
 thumb_func 0x81620d4
-thumb_func 0x8162140
-thumb_func 0x8162304
+thumb_func 0x8162140 ChooseSpecialBattleTowerTrainer
+thumb_func 0x8162304 ChooseNextBattleTowerTrainer
 thumb_func 0x816245c
 thumb_func 0x81624c8
 thumb_func 0x8162528
-thumb_func 0x81626a0
-thumb_func 0x81626b0
-thumb_func 0x81627a4
-thumb_func 0x81629a4
-thumb_func 0x8162adc
+thumb_func 0x81626a0 SetEReaderTrainerGfxId
+thumb_func 0x81626b0 IsFrontierTrainerFemale
+thumb_func 0x81627a4 PutNewBattleTowerRecord
+thumb_func 0x81629a4 GetFrontierTrainerFrontSpriteId
+thumb_func 0x8162adc GetFrontierOpponentClass
 thumb_func 0x8162c38
 thumb_func 0x8162d24
 thumb_func 0x8162e90
-thumb_func 0x8162f68
-thumb_func 0x8162f8c
-thumb_func 0x8162fc0
-thumb_func 0x8162fe4
-thumb_func 0x8163364
-thumb_func 0x8163444
-thumb_func 0x81634b0
-thumb_func 0x81634f4
-thumb_func 0x81636bc
-thumb_func 0x81637cc
+thumb_func 0x8162f68 FillFrontierTrainerParty
+thumb_func 0x8162f8c FillFrontierTrainersParties
+thumb_func 0x8162fc0 FillTentTrainerParty
+thumb_func 0x8162fe4 FillTrainerParty
+thumb_func 0x8163364 Unused_CreateApprenticeMons
+thumb_func 0x8163444 RandomizeFacilityTrainerMonSet
+thumb_func 0x81634b0 FillFactoryTrainerParty
+thumb_func 0x81634f4 FillFactoryFrontierTrainerParty
+thumb_func 0x81636bc FillFactoryTentTrainerParty
+thumb_func 0x81637cc FrontierSpeechToString
 thumb_func 0x816383c
-thumb_func 0x81638d4
-thumb_func 0x81639b4
-thumb_func 0x81639ec
-thumb_func 0x8163db8
+thumb_func 0x81638d4 HandleSpecialTrainerBattleEnd
+thumb_func 0x81639b4 Task_StartBattleAfterTransition
+thumb_func 0x81639ec DoSpecialTrainerBattle
+thumb_func 0x8163db8 SaveCurrentWinStreak
 thumb_func 0x8163e0c
-thumb_func 0x8163f68
+thumb_func 0x8163f68 SaveBattleTowerProgress
 thumb_func 0x8164000 nullsub_95
 thumb_func 0x8164004 nullsub_94
 thumb_func 0x8164008
@@ -11809,39 +11809,39 @@ thumb_func 0x8164ce4
 thumb_func 0x8164da4 ValidateBattleTowerRecordChecksums
 thumb_func 0x8164e3c CalcEmeraldBattleTowerChecksum
 thumb_func 0x8164e60 CalcRubyBattleTowerChecksum
-thumb_func 0x8164e84
+thumb_func 0x8164e84 ClearBattleTowerRecord
 thumb_func 0x8164e98 GetCurrentBattleTowerWinStreak
 thumb_func 0x8164ec8
-thumb_func 0x8164fd8
+thumb_func 0x8164fd8 FillEReaderTrainerWithPlayerData
 thumb_func 0x81650c0
 thumb_func 0x81650e0
 thumb_func 0x8165100 GetEreaderTrainerName
-thumb_func 0x8165130
+thumb_func 0x8165130 ValidateEReaderTrainer
 thumb_func 0x81651a4 SetEReaderTrainerChecksum
-thumb_func 0x81651c8
-thumb_func 0x81651dc
-thumb_func 0x81651f8
+thumb_func 0x81651c8 ClearEReaderTrainer
+thumb_func 0x81651dc CopyEReaderTrainerGreeting
+thumb_func 0x81651f8 CopyEReaderTrainerFarewellMessage
 thumb_func 0x8165248
-thumb_func 0x8165280
+thumb_func 0x8165280 FillPartnerParty
 thumb_func 0x81656c8
 thumb_func 0x8165820
 thumb_func 0x8165924 CalcApprenticeChecksum
-thumb_func 0x8165944
+thumb_func 0x8165944 ClearApprentice
 thumb_func 0x816595c ValidateApprenticesChecksums
-thumb_func 0x81659c4
-thumb_func 0x8165a4c
+thumb_func 0x81659c4 GetBattleTowerTrainerLanguage
+thumb_func 0x8165a4c SetFacilityPtrsGetLevel
 thumb_func 0x8165a9c GetFrontierEnemyMonLevel
-thumb_func 0x8165ac0
+thumb_func 0x8165ac0 GetHighestLevelInPlayerParty
 thumb_func 0x8165b14
 thumb_func 0x8165b4c
-thumb_func 0x8165b84
+thumb_func 0x8165b84 SetTentPtrsGetLevel
 thumb_func 0x8165c24
-thumb_func 0x8165cb0
-thumb_func 0x8165ec4
-thumb_func 0x8165f30
+thumb_func 0x8165cb0 FillTentTrainerParty_
+thumb_func 0x8165ec4 FacilityClassToGraphicsId
+thumb_func 0x8165f30 ValidateBattleTowerRecord
 thumb_func 0x8165f94
-thumb_func 0x8166010
-thumb_func 0x8166058
+thumb_func 0x8166010 ChooseMonToGivePokeblock
+thumb_func 0x8166058 CB2_ReturnAndChooseMonToGivePokeblock
 thumb_func 0x81660cc
 thumb_func 0x81660dc
 thumb_func 0x8166110
@@ -11862,13 +11862,13 @@ thumb_func 0x8166c30
 thumb_func 0x8166ce8
 thumb_func 0x8166d5c
 thumb_func 0x8166d98
-thumb_func 0x8166db4
-thumb_func 0x8166dd8
-thumb_func 0x8166e28
+thumb_func 0x8166db4 Pokeblock_MenuWindowTextPrint
+thumb_func 0x8166dd8 Pokeblock_BufferEnhancedStatText
+thumb_func 0x8166e28 Pokeblock_GetMonContestStats
 thumb_func 0x8166e58
 thumb_func 0x8166f08
 thumb_func 0x8166f88
-thumb_func 0x816706c
+thumb_func 0x816706c IsSheenMaxed
 thumb_func 0x81670a8
 thumb_func 0x81670e8
 thumb_func 0x8167128
@@ -11896,143 +11896,143 @@ thumb_func 0x816817c
 thumb_func 0x81681bc nullsub_97
 thumb_func 0x81681c0 SetControllerToWally
 thumb_func 0x81681fc
-thumb_func 0x816824c
+thumb_func 0x816824c WallyHandleActions
 thumb_func 0x8168374
 thumb_func 0x81683ac
-thumb_func 0x81683c4
-thumb_func 0x81683dc
-thumb_func 0x8168418
+thumb_func 0x81683c4 CompleteOnFinishedAnimation
+thumb_func 0x81683dc OpenBagAfterPaletteFade
+thumb_func 0x8168418 CompleteOnChosenItem
 thumb_func 0x8168454
 thumb_func 0x8168620
-thumb_func 0x816873c
-thumb_func 0x81687ac
+thumb_func 0x816873c CompleteOnHealthbarDone
+thumb_func 0x81687ac DoHitAnimBlinkSpriteEffect
 thumb_func 0x8168828
 thumb_func 0x8168898
 thumb_func 0x81688d0
-thumb_func 0x8168900
+thumb_func 0x8168900 WallyBufferExecCompleted
 thumb_func 0x8168978
-thumb_func 0x81689a8
-thumb_func 0x8168a1c
+thumb_func 0x81689a8 WallyHandleGetMonData
+thumb_func 0x8168a1c CopyWallyMonData
 thumb_func 0x81691c8
-thumb_func 0x81691d4
-thumb_func 0x816922c
-thumb_func 0x8169c28
-thumb_func 0x8169c34
-thumb_func 0x8169c40
-thumb_func 0x8169c4c
-thumb_func 0x8169cd0
-thumb_func 0x8169d9c
-thumb_func 0x8169e68
-thumb_func 0x8169e74
-thumb_func 0x8169e80
-thumb_func 0x8169e8c
-thumb_func 0x8169ee0
-thumb_func 0x8169f40
-thumb_func 0x8169f4c
-thumb_func 0x816a074
-thumb_func 0x816a1c0
-thumb_func 0x816a214
-thumb_func 0x816a238
-thumb_func 0x816a278
-thumb_func 0x816a2e0
-thumb_func 0x816a2ec
-thumb_func 0x816a384
-thumb_func 0x816a3c4
-thumb_func 0x816a3d0
-thumb_func 0x816a3dc
-thumb_func 0x816a4dc
+thumb_func 0x81691d4 WallyHandleSetMonData
+thumb_func 0x816922c SetWallyMonData
+thumb_func 0x8169c28 WallyHandleSetRawMonData
+thumb_func 0x8169c34 WallyHandleLoadMonSprite
+thumb_func 0x8169c40 WallyHandleSwitchInAnim
+thumb_func 0x8169c4c WallyHandleReturnMonToBall
+thumb_func 0x8169cd0 WallyHandleDrawTrainerPic
+thumb_func 0x8169d9c WallyHandleTrainerSlide
+thumb_func 0x8169e68 WallyHandleTrainerSlideBack
+thumb_func 0x8169e74 WallyHandleFaintAnimation
+thumb_func 0x8169e80 WallyHandlePaletteFade
+thumb_func 0x8169e8c WallyHandleSuccessBallThrowAnim
+thumb_func 0x8169ee0 WallyHandleBallThrowAnim
+thumb_func 0x8169f40 WallyHandlePause
+thumb_func 0x8169f4c WallyHandleMoveAnimation
+thumb_func 0x816a074 WallyDoMoveAnimation
+thumb_func 0x816a1c0 WallyHandlePrintString
+thumb_func 0x816a214 WallyHandlePrintSelectionString
+thumb_func 0x816a238 HandleChooseActionAfterDma3
+thumb_func 0x816a278 WallyHandleChooseAction
+thumb_func 0x816a2e0 WallyHandleUnknownYesNoBox
+thumb_func 0x816a2ec WallyHandleChooseMove
+thumb_func 0x816a384 WallyHandleChooseItem
+thumb_func 0x816a3c4 WallyHandleChoosePokemon
+thumb_func 0x816a3d0 WallyHandleCmd23
+thumb_func 0x816a3dc WallyHandleHealthBarUpdate
+thumb_func 0x816a4dc WallyHandleExpUpdate
 thumb_func 0x816a4e8
-thumb_func 0x816a4f4
-thumb_func 0x816a500
-thumb_func 0x816a50c
-thumb_func 0x816a518
-thumb_func 0x816a524
-thumb_func 0x816a530
+thumb_func 0x816a4f4 WallyHandleStatusAnimation
+thumb_func 0x816a500 WallyHandleStatusXor
+thumb_func 0x816a50c WallyHandleDataTransfer
+thumb_func 0x816a518 WallyHandleDMA3Transfer
+thumb_func 0x816a524 WallyHandlePlayBGM
+thumb_func 0x816a530 WallyHandleCmd32
 thumb_func 0x816a53c
 thumb_func 0x816a548
 thumb_func 0x816a554
 thumb_func 0x816a560
-thumb_func 0x816a56c
+thumb_func 0x816a56c WallyHandleCmd37
 thumb_func 0x816a578
 thumb_func 0x816a584
 thumb_func 0x816a590
-thumb_func 0x816a59c
-thumb_func 0x816a60c
-thumb_func 0x816a618
+thumb_func 0x816a59c WallyHandleHitAnimation
+thumb_func 0x816a60c WallyHandleCmd42
+thumb_func 0x816a618 WallyHandlePlaySE
 thumb_func 0x816a648
 thumb_func 0x816a6a4
 thumb_func 0x816a6e0
-thumb_func 0x816a714
+thumb_func 0x816a714 WallyHandleIntroTrainerBallThrow
 thumb_func 0x816a888
 thumb_func 0x816aa0c
-thumb_func 0x816aa80
-thumb_func 0x816ab04
-thumb_func 0x816ab10
-thumb_func 0x816ab1c
-thumb_func 0x816ab28
-thumb_func 0x816ab84
-thumb_func 0x816ab90
-thumb_func 0x816ab9c
+thumb_func 0x816aa80 WallyHandleDrawPartyStatusSummary
+thumb_func 0x816ab04 WallyHandleHidePartyStatusSummary
+thumb_func 0x816ab10 WallyHandleEndBounceEffect
+thumb_func 0x816ab1c WallyHandleSpriteInvisibility
+thumb_func 0x816ab28 WallyHandleBattleAnimation
+thumb_func 0x816ab84 WallyHandleLinkStandbyMsg
+thumb_func 0x816ab90 WallyHandleResetActionMoveSelection
+thumb_func 0x816ab9c WallyHandleCmd55
 thumb_func 0x816abf8 nullsub_98
-thumb_func 0x816abfc
-thumb_func 0x816ac60
-thumb_func 0x816aca0
+thumb_func 0x816abfc NewGameInitPCItems
+thumb_func 0x816ac60 BedroomPC
+thumb_func 0x816aca0 PlayerPC
 thumb_func 0x816ace0
-thumb_func 0x816adb0
-thumb_func 0x816ae78
+thumb_func 0x816adb0 PlayerPCProcessMenuInput
+thumb_func 0x816ae78 ReshowPlayerPC
 thumb_func 0x816ae94 PlayerPC_ItemStorage
-thumb_func 0x816aec0
-thumb_func 0x816af50
-thumb_func 0x816af60
+thumb_func 0x816aec0 PlayerPC_Mailbox
+thumb_func 0x816af50 PlayerPC_Decoration
+thumb_func 0x816af60 PlayerPC_TurnOff
 thumb_func 0x816afa8
-thumb_func 0x816b040
-thumb_func 0x816b06c
-thumb_func 0x816b0ec
-thumb_func 0x816b114
+thumb_func 0x816b040 ItemStorageMenuPrint
+thumb_func 0x816b06c ItemStorageMenuProcessInput
+thumb_func 0x816b0ec ItemStorage_Deposit
+thumb_func 0x816b114 Task_ItemStorage_Deposit
 thumb_func 0x816b140
 thumb_func 0x816b160
 thumb_func 0x816b18c
-thumb_func 0x816b1bc
-thumb_func 0x816b208
-thumb_func 0x816b254
-thumb_func 0x816b2c8
-thumb_func 0x816b2e4
+thumb_func 0x816b1bc ItemStorage_Withdraw
+thumb_func 0x816b208 ItemStorage_Toss
+thumb_func 0x816b254 ItemStorage_WithdrawToss_Helper
+thumb_func 0x816b2c8 ItemStorage_Exit
+thumb_func 0x816b2e4 ItemStorage_SetItemAndMailCount
 thumb_func 0x816b300
 thumb_func 0x816b334 GetMailboxMailCount
 thumb_func 0x816b370 Mailbox_UpdateMailList
 thumb_func 0x816b41c
-thumb_func 0x816b488
+thumb_func 0x816b488 Mailbox_ProcessInput
 thumb_func 0x816b544
-thumb_func 0x816b5a4
+thumb_func 0x816b5a4 Mailbox_ReturnToPlayerPC
 thumb_func 0x816b5e8
-thumb_func 0x816b66c
-thumb_func 0x816b6b8
-thumb_func 0x816b6e4
+thumb_func 0x816b66c Mailbox_MailOptionsProcessInput
+thumb_func 0x816b6b8 Mailbox_DoMailRead
+thumb_func 0x816b6e4 Mailbox_FadeAndReadMail
 thumb_func 0x816b740
-thumb_func 0x816b760
+thumb_func 0x816b760 pal_fill_for_maplights_or_black
 thumb_func 0x816b7a4
 thumb_func 0x816b7d4
-thumb_func 0x816b7f0
-thumb_func 0x816b818
-thumb_func 0x816b858
-thumb_func 0x816b8ec
-thumb_func 0x816b8fc
+thumb_func 0x816b7f0 Mailbox_DrawYesNoBeforeMove
+thumb_func 0x816b818 Mailbox_MoveToBagYesNoPrompt
+thumb_func 0x816b858 Mailbox_DoMailMoveToBag
+thumb_func 0x816b8ec Mailbox_CancelMoveToBag
+thumb_func 0x816b8fc Mailbox_Give
 thumb_func 0x816b938
 thumb_func 0x816b968
-thumb_func 0x816b988
+thumb_func 0x816b988 Mailbox_UpdateMailListAfterDeposit
 thumb_func 0x816b9f8
-thumb_func 0x816ba14
+thumb_func 0x816ba14 Mailbox_Cancel
 thumb_func 0x816ba54
-thumb_func 0x816ba98
+thumb_func 0x816ba98 AnimTask_LoadPokeblockGfx
 thumb_func 0x816babc
 thumb_func 0x816bb04
-thumb_func 0x816bb44
-thumb_func 0x816bc08
-thumb_func 0x816bc1c
-thumb_func 0x816bc84
+thumb_func 0x816bb44 ItemStorage_RefreshListMenu
+thumb_func 0x816bc08 CopyItemName_PlayerPC
+thumb_func 0x816bc1c ItemStorage_MoveCursor
+thumb_func 0x816bc84 fish4_goto_x5_or_x6
 thumb_func 0x816bd24
-thumb_func 0x816bd94
-thumb_func 0x816bdd0
+thumb_func 0x816bd94 ItemStorage_StartScrollIndicator
+thumb_func 0x816bdd0 ItemStorage_RemoveScrollIndicator
 thumb_func 0x816bdec
 thumb_func 0x816be14
 thumb_func 0x816be94
@@ -12040,77 +12040,77 @@ thumb_func 0x816befc
 thumb_func 0x816bf44
 thumb_func 0x816bf74
 thumb_func 0x816bf8c
-thumb_func 0x816c070
-thumb_func 0x816c108
-thumb_func 0x816c154
+thumb_func 0x816c070 ItemStorage_GetItemPcResponse
+thumb_func 0x816c108 ItemStorage_PrintItemPcResponse
+thumb_func 0x816c154 ItemStorage_ProcessInput
 thumb_func 0x816c1ec
-thumb_func 0x816c268
+thumb_func 0x816c268 ItemStorage_ItemSwapChoosePrompt
 thumb_func 0x816c314
-thumb_func 0x816c3b8
+thumb_func 0x816c3b8 ItemStorage_DoItemSwap
 thumb_func 0x816c4a8
 thumb_func 0x816c4d4
-thumb_func 0x816c534
+thumb_func 0x816c534 ItemStorage_DoItemAction
 thumb_func 0x816c630
-thumb_func 0x816c70c
-thumb_func 0x816c7c8
-thumb_func 0x816c8a4
-thumb_func 0x816c8d8
-thumb_func 0x816c914
-thumb_func 0x816c984
+thumb_func 0x816c70c ItemStorage_DoItemWithdraw
+thumb_func 0x816c7c8 ItemStorage_DoItemToss
+thumb_func 0x816c8a4 ItemStorage_ResumeInputFromYesToss
+thumb_func 0x816c8d8 ItemStorage_ResumeInputFromNoToss
+thumb_func 0x816c914 ItemStorage_HandleRemoveItem
+thumb_func 0x816c984 ItemStorage_WaitPressHandleResumeProcessInput
 thumb_func 0x816c9d0
-thumb_func 0x816c9f8
-thumb_func 0x816ca10
-thumb_func 0x816ca64
-thumb_func 0x816ca80
+thumb_func 0x816c9f8 VBlankCB_Intro
+thumb_func 0x816ca10 MainCB2_Intro
+thumb_func 0x816ca64 MainCB2_EndIntro
+thumb_func 0x816ca80 LoadCopyrightGraphics
 thumb_func 0x816cac8
-thumb_func 0x816cad8
-thumb_func 0x816cc90
+thumb_func 0x816cad8 task00_08081A90
+thumb_func 0x816cc90 CB2_InitCopyrightScreenAfterBootup
 thumb_func 0x816ccf0
-thumb_func 0x816ccfc
-thumb_func 0x816cf10
-thumb_func 0x816cf74
-thumb_func 0x816d084
+thumb_func 0x816ccfc Task_IntroLoadPart1Graphics
+thumb_func 0x816cf10 Task_IntroFadeIn
+thumb_func 0x816cf74 Task_IntroWaterDrops
+thumb_func 0x816d084 Task_IntroWaterDrops_3
 thumb_func 0x816d11c
-thumb_func 0x816d138
+thumb_func 0x816d138 Task_IntroScrollDownAndShowFlygon
 thumb_func 0x816d23c
-thumb_func 0x816d270
-thumb_func 0x816d2c8
-thumb_func 0x816d434
+thumb_func 0x816d270 Task_IntroLoadPart2Graphics
+thumb_func 0x816d2c8 Task_IntroStartBikeRide
+thumb_func 0x816d434 Task_IntroHandleBikeAndFlygonMovement
 thumb_func 0x816d5cc
 thumb_func 0x816d600
 thumb_func 0x816d7a4
 thumb_func 0x816d8cc
-thumb_func 0x816d990
-thumb_func 0x816da48
+thumb_func 0x816d990 Task_IntroLoadPart3Graphics
+thumb_func 0x816da48 Task_IntroSpinAndZoomPokeball
 thumb_func 0x816dae0 Task_IntroWaitToSetupPart3LegendsFight
-thumb_func 0x816db0c
-thumb_func 0x816dbbc
-thumb_func 0x816dc60
+thumb_func 0x816db0c Task_IntroLoadGroudonScene
+thumb_func 0x816dbbc Task_IntroLoadPart3Graphics1
+thumb_func 0x816dc60 Task_IntroLoadPart3Graphics2
 thumb_func 0x816dcb4
-thumb_func 0x816dcd0
-thumb_func 0x816dd10
-thumb_func 0x816df74
-thumb_func 0x816dfdc
-thumb_func 0x816e084
-thumb_func 0x816e13c
-thumb_func 0x816e4b8
-thumb_func 0x816e530
-thumb_func 0x816e598
-thumb_func 0x816e66c
-thumb_func 0x816e738
-thumb_func 0x816e77c
-thumb_func 0x816e7c0
-thumb_func 0x816e89c
-thumb_func 0x816e928
-thumb_func 0x816ea50
-thumb_func 0x816eb04
-thumb_func 0x816eb98
-thumb_func 0x816ec74
-thumb_func 0x816ec8c
-thumb_func 0x816eea4
-thumb_func 0x816ef0c
+thumb_func 0x816dcd0 Task_IntroLoadPart3Graphics4
+thumb_func 0x816dd10 Task_IntroGroudonScene
+thumb_func 0x816df74 CreateGroudonRockSprites
+thumb_func 0x816dfdc SpriteCB_IntroGroudonRocks
+thumb_func 0x816e084 Task_IntroLoadKyogreScene
+thumb_func 0x816e13c Task_IntroKyogreScene
+thumb_func 0x816e4b8 CreateKyogreBubbleSprites_0
+thumb_func 0x816e530 CreateKyogreBubbleSprites_1
+thumb_func 0x816e598 SpriteCB_IntroKyogreBubbles
+thumb_func 0x816e66c Task_IntroLoadClouds1
+thumb_func 0x816e738 Task_IntroLoadClouds2
+thumb_func 0x816e77c Task_IntroLoadClouds3
+thumb_func 0x816e7c0 Task_IntroCloudScene
+thumb_func 0x816e89c Task_IntroLoadRayquazaLightningScene
+thumb_func 0x816e928 Task_IntroRayquazaLightningScene
+thumb_func 0x816ea50 SpriteCB_IntroRayquazaLightning
+thumb_func 0x816eb04 Task_IntroLoadRayquazaGlowScene
+thumb_func 0x816eb98 Task_IntroRayquazaGlowScene_0
+thumb_func 0x816ec74 Task_EndIntroMovie
+thumb_func 0x816ec8c Task_IntroRayquazaGlowScene_1
+thumb_func 0x816eea4 intro_reset_and_hide_bgs
+thumb_func 0x816ef0c Task_IntroWaterDrops_1
 thumb_func 0x816efc4
-thumb_func 0x816f08c
+thumb_func 0x816f08c PanFadeAndZoomScreen
 thumb_func 0x816f0fc
 thumb_func 0x816f188
 thumb_func 0x816f238
@@ -12119,22 +12119,22 @@ thumb_func 0x816f398
 thumb_func 0x816f444
 thumb_func 0x816f4b4
 thumb_func 0x816f534
-thumb_func 0x816f5b4
-thumb_func 0x816f7b8
-thumb_func 0x816f894
+thumb_func 0x816f5b4 CreateWaterDrop
+thumb_func 0x816f7b8 SpriteCB_IntroGraphicsBicycle
+thumb_func 0x816f894 SpriteCB_IntroGraphicsFlygon
 thumb_func 0x816f91c
 thumb_func 0x816fb3c
-thumb_func 0x816fbb0
+thumb_func 0x816fbb0 CreatePart1Animations
 thumb_func 0x816fcd4
-thumb_func 0x816fe38
+thumb_func 0x816fe38 SpriteCB_IntroRayquazaHyperbeam
 thumb_func 0x816fef0
-thumb_func 0x816ff84
-thumb_func 0x816ffbc
-thumb_func 0x8170058
-thumb_func 0x817006c
+thumb_func 0x816ff84 FieldInitRegionMap
+thumb_func 0x816ffbc MCB2_InitRegionMapRegisters
+thumb_func 0x8170058 VBCB_FieldUpdateRegionMap
+thumb_func 0x817006c MCB2_FieldUpdateRegionMap
 thumb_func 0x8170088
-thumb_func 0x8170214
-thumb_func 0x817025c
+thumb_func 0x8170214 StartMirageTowerShake
+thumb_func 0x817025c unref_sub_8170478
 thumb_func 0x8170444
 thumb_func 0x8170618
 thumb_func 0x8170704
@@ -12146,8 +12146,8 @@ thumb_func 0x81708e8
 thumb_func 0x8170994
 thumb_func 0x8170ae0
 thumb_func 0x8170b08
-thumb_func 0x8170b30
-thumb_func 0x8170b68
+thumb_func 0x8170b30 AnimTask_IsBallBlockedByTrainer
+thumb_func 0x8170b68 ItemIdToBallId
 thumb_func 0x8170be8
 thumb_func 0x8170cd4
 thumb_func 0x8170d10
@@ -12173,88 +12173,88 @@ thumb_func 0x8171990
 thumb_func 0x8171a90
 thumb_func 0x8171acc
 thumb_func 0x8171b44
-thumb_func 0x8171b7c
+thumb_func 0x8171b7c AnimateBallOpenParticles
 thumb_func 0x8171c04
-thumb_func 0x8171c34
-thumb_func 0x8171d4c
-thumb_func 0x8171d6c
+thumb_func 0x8171c34 PokeBallOpenParticleAnimation
+thumb_func 0x8171d4c PokeBallOpenParticleAnimation_Step1
+thumb_func 0x8171d6c PokeBallOpenParticleAnimation_Step2
 thumb_func 0x8171da8
-thumb_func 0x8171eac
-thumb_func 0x8171fb0
-thumb_func 0x81720b0
-thumb_func 0x81721b8
-thumb_func 0x81722ec
-thumb_func 0x8172344
-thumb_func 0x8172440
-thumb_func 0x81724a0
-thumb_func 0x81725cc
-thumb_func 0x81726c4
-thumb_func 0x8172728
-thumb_func 0x81727cc
+thumb_func 0x8171eac DiveBallOpenParticleAnimation
+thumb_func 0x8171fb0 SafariBallOpenParticleAnimation
+thumb_func 0x81720b0 UltraBallOpenParticleAnimation
+thumb_func 0x81721b8 GreatBallOpenParticleAnimation
+thumb_func 0x81722ec FanOutBallOpenParticles_Step1
+thumb_func 0x8172344 RepeatBallOpenParticleAnimation
+thumb_func 0x8172440 RepeatBallOpenParticleAnimation_Step1
+thumb_func 0x81724a0 MasterBallOpenParticleAnimation
+thumb_func 0x81725cc PremierBallOpenParticleAnimation
+thumb_func 0x81726c4 PremierBallOpenParticleAnimation_Step1
+thumb_func 0x8172728 DestroyBallOpenAnimationParticle
+thumb_func 0x81727cc LaunchBallFadeMonTask
 thumb_func 0x8172894
 thumb_func 0x8172924
 thumb_func 0x8172974
 thumb_func 0x81729d4
 thumb_func 0x8172b7c
-thumb_func 0x8172c80
-thumb_func 0x8172cb4
+thumb_func 0x8172c80 AnimTask_IsAttackerBehindSubstitute
+thumb_func 0x8172cb4 AnimTask_TargetToEffectBattler
 thumb_func 0x8172cd4
 thumb_func 0x8172dd0
 thumb_func 0x8172f94
 thumb_func 0x8172fe0
 thumb_func 0x8173034
 thumb_func 0x8173094
-thumb_func 0x81730c8
+thumb_func 0x81730c8 AnimTask_FreePokeblockGfx
 thumb_func 0x81730f0
 thumb_func 0x8173180
 thumb_func 0x81731b8
 thumb_func 0x81731e4
 thumb_func 0x8173240
-thumb_func 0x8173298
-thumb_func 0x8173300
-thumb_func 0x8173330
-thumb_func 0x8173344
-thumb_func 0x8173360
-thumb_func 0x8173478
-thumb_func 0x81734bc
-thumb_func 0x8173500
-thumb_func 0x81736a0
-thumb_func 0x81737a8
-thumb_func 0x8173840
+thumb_func 0x8173298 AnimTask_GetTrappedMoveAnimId
+thumb_func 0x8173300 AnimTask_GetBattlersFromArg
+thumb_func 0x8173330 VBlankCB_HallOfFame
+thumb_func 0x8173344 CB2_HallOfFame
+thumb_func 0x8173360 InitHallOfFameScreen
+thumb_func 0x8173478 CB2_DoHallOfFameScreen
+thumb_func 0x81734bc CB2_DoHallOfFameScreenDontSaveData
+thumb_func 0x8173500 Task_Hof_InitMonData
+thumb_func 0x81736a0 Task_Hof_InitTeamSaveData
+thumb_func 0x81737a8 Task_Hof_TrySaveData
+thumb_func 0x8173840 Task_Hof_WaitForFrames
 thumb_func 0x8173870
-thumb_func 0x817388c
-thumb_func 0x81739a4
-thumb_func 0x8173a18
-thumb_func 0x8173b08
+thumb_func 0x817388c Task_Hof_DisplayMon
+thumb_func 0x81739a4 Task_Hof_PrintMonInfoAfterAnimating
+thumb_func 0x8173a18 Task_Hof_TryDisplayAnotherMon
+thumb_func 0x8173b08 Task_Hof_PaletteFadeAndPrintWelcomeText
 thumb_func 0x8173ba4
 thumb_func 0x8173c88
 thumb_func 0x8173cc8
-thumb_func 0x8173d68
-thumb_func 0x8173e0c
-thumb_func 0x8173e44
-thumb_func 0x8173e94
-thumb_func 0x8173f68
-thumb_func 0x8173f78
-thumb_func 0x8174108
-thumb_func 0x81741d0
-thumb_func 0x81743e0
-thumb_func 0x817450c
-thumb_func 0x817467c
-thumb_func 0x81746d4
-thumb_func 0x8174784
+thumb_func 0x8173d68 Task_Hof_WaitAndPrintPlayerInfo
+thumb_func 0x8173e0c Task_Hof_ExitOnKeyPressed
+thumb_func 0x8173e44 Task_Hof_HandlePaletteOnExit
+thumb_func 0x8173e94 Task_Hof_HandleExit
+thumb_func 0x8173f68 SetCallback2AfterHallOfFameDisplay
+thumb_func 0x8173f78 CB2_DoHallOfFamePC
+thumb_func 0x8174108 Task_HofPC_CopySaveData
+thumb_func 0x81741d0 Task_HofPC_DrawSpritesPrintText
+thumb_func 0x81743e0 Task_HofPC_PrintMonInfo
+thumb_func 0x817450c Task_HofPC_HandleInput
+thumb_func 0x817467c Task_HofPC_HandlePaletteOnExit
+thumb_func 0x81746d4 Task_HofPC_HandleExit
+thumb_func 0x8174784 Task_HofPC_PrintDataIsCorrupted
 thumb_func 0x81747ec Task_HofPC_ExitOnButtonPress
 thumb_func 0x817481c
 thumb_func 0x817487c
-thumb_func 0x8174b74
-thumb_func 0x8174dc8
+thumb_func 0x8174b74 NewGameBirchSpeech_CreateDialogueWindowBorder
+thumb_func 0x8174dc8 ClearVramOamPltt_LoadHofPal
 thumb_func 0x8174e74
 thumb_func 0x8174eb0
 thumb_func 0x8174f28
-thumb_func 0x8175024
+thumb_func 0x8175024 SpriteCB_GetOnScreenAndAnimate
 thumb_func 0x81750a8
 thumb_func 0x8175100
 thumb_func 0x8175184
-thumb_func 0x81751c4
+thumb_func 0x81751c4 Task_RayDescendsEnd
 thumb_func 0x81751f8
 thumb_func 0x8175268
 thumb_func 0x81753cc
@@ -12266,7 +12266,7 @@ thumb_func 0x817553c
 thumb_func 0x817564c
 thumb_func 0x817567c
 thumb_func 0x8175710
-thumb_func 0x8175750
+thumb_func 0x8175750 c2_080C9BFC
 thumb_func 0x81757ac
 thumb_func 0x81757ec
 thumb_func 0x81759a4
@@ -12277,7 +12277,7 @@ thumb_func 0x8175ae4
 thumb_func 0x8175b40
 thumb_func 0x8175bd4
 thumb_func 0x8175bf0
-thumb_func 0x8175cac
+thumb_func 0x8175cac EvolutionRenameMon
 thumb_func 0x8175f1c
 thumb_func 0x8176024
 thumb_func 0x817615c
@@ -12295,126 +12295,126 @@ thumb_func 0x8176edc
 thumb_func 0x81770b0
 thumb_func 0x8177144
 thumb_func 0x8177214
-thumb_func 0x81773e4
-thumb_func 0x8177410
-thumb_func 0x8177458
-thumb_func 0x817746c
-thumb_func 0x8177618
-thumb_func 0x81776a0
-thumb_func 0x81776c8
-thumb_func 0x81776f0
-thumb_func 0x8177700
-thumb_func 0x8177714
-thumb_func 0x8177894
+thumb_func 0x81773e4 ResetLotteryCorner
+thumb_func 0x8177410 SetRandomLotteryNumber
+thumb_func 0x8177458 RetrieveLotteryNumber
+thumb_func 0x817746c PickLotteryCornerTicket
+thumb_func 0x8177618 GetMatchingDigits
+thumb_func 0x81776a0 SetLotteryNumber
+thumb_func 0x81776c8 GetLotteryNumber
+thumb_func 0x81776f0 SetLotteryNumber16_Unused
+thumb_func 0x8177700 VblankCB
+thumb_func 0x8177714 CB2_ShowDiploma
+thumb_func 0x8177894 LinkPartnerHandleUnknownYesNoBox
 thumb_func 0x81778ac
-thumb_func 0x81778dc
-thumb_func 0x8177924
+thumb_func 0x81778dc Task_DiplomaWaitForKeyPress
+thumb_func 0x8177924 Task_DiplomaFadeOut
 thumb_func 0x8177960
-thumb_func 0x8177a2c
-thumb_func 0x8177a84
-thumb_func 0x8177ab4
-thumb_func 0x8177afc
+thumb_func 0x8177a2c InitDiplomaBg
+thumb_func 0x8177a84 InitDiplomaWindow
+thumb_func 0x8177ab4 PrintDiplomaText
+thumb_func 0x8177afc DoBerryTagScreen
 thumb_func 0x8177b3c
 thumb_func 0x8177b58
-thumb_func 0x8177b6c
-thumb_func 0x8177b98
+thumb_func 0x8177b6c CB2_InitBerryTagScreen
+thumb_func 0x8177b98 InitBerryTagScreen
 thumb_func 0x8177cfc
-thumb_func 0x8177d70
+thumb_func 0x8177d70 LoadBerryTagGfx
 thumb_func 0x8177ef0
-thumb_func 0x8177f34
+thumb_func 0x8177f34 PrintTextInBerryTagScreen
 thumb_func 0x8177f78
-thumb_func 0x8177fcc
-thumb_func 0x8177fe8
+thumb_func 0x8177fcc PrintAllBerryData
+thumb_func 0x8177fe8 PrintBerryNumberAndName
 thumb_func 0x817804c
-thumb_func 0x8178108
-thumb_func 0x8178188
-thumb_func 0x81781bc
-thumb_func 0x81781f0
-thumb_func 0x8178224
-thumb_func 0x8178254
-thumb_func 0x81782bc
-thumb_func 0x817844c
-thumb_func 0x8178488
-thumb_func 0x81784c8
-thumb_func 0x817850c
-thumb_func 0x8178564
-thumb_func 0x81785e0
-thumb_func 0x8178664
+thumb_func 0x8178108 PrintBerryFirmness
+thumb_func 0x8178188 PrintBerryDescription1
+thumb_func 0x81781bc PrintBerryDescription2
+thumb_func 0x81781f0 CreateBerrySprite
+thumb_func 0x8178224 DestroyBerrySprite
+thumb_func 0x8178254 CreateFlavorCircleSprites
+thumb_func 0x81782bc SetFlavorCirclesVisiblity
+thumb_func 0x817844c DestroyFlavorCircleSprites
+thumb_func 0x8178488 PrepareToCloseBerryTagScreen
+thumb_func 0x81784c8 Task_CloseBerryTagScreen
+thumb_func 0x817850c Task_HandleInput
+thumb_func 0x8178564 TryChangeDisplayedBerry
+thumb_func 0x81785e0 HandleBagCursorPositionChange
+thumb_func 0x8178664 Task_DisplayAnotherBerry
 thumb_func 0x81787fc
 thumb_func 0x8178810 CheckLanguageMatch
-thumb_func 0x817882c
-thumb_func 0x81788f8
-thumb_func 0x8178930
-thumb_func 0x8178d7c
-thumb_func 0x8178dfc
-thumb_func 0x8178e48
+thumb_func 0x817882c CB2_InitMysteryEventMenu
+thumb_func 0x81788f8 GetEventLoadMessage
+thumb_func 0x8178930 CB2_MysteryEventMenu
+thumb_func 0x8178d7c PrintMysteryMenuText
+thumb_func 0x8178dfc SaveFailedScreenTextPrint
+thumb_func 0x8178e48 DoSaveFailedScreen
 thumb_func 0x8178e80
-thumb_func 0x8178e94
-thumb_func 0x8179140
-thumb_func 0x8179248
-thumb_func 0x8179298
-thumb_func 0x81792e0
-thumb_func 0x817930c
-thumb_func 0x81793cc
-thumb_func 0x817940c
+thumb_func 0x8178e94 CB2_SaveFailedScreen
+thumb_func 0x8179140 CB2_WipeSave
+thumb_func 0x8179248 CB2_GameplayCannotBeContinued
+thumb_func 0x8179298 CB2_FadeAndReturnToTitleScreen
+thumb_func 0x81792e0 CB2_ReturnToTitleScreen
+thumb_func 0x817930c VBlankCB_UpdateClockGraphics
+thumb_func 0x81793cc VerifySectorWipe
+thumb_func 0x817940c WipeSector
 thumb_func 0x8179464 WipeSectors
-thumb_func 0x81794a0
-thumb_func 0x81794f4
-thumb_func 0x8179564
+thumb_func 0x81794a0 ShouldDoBrailleDigEffect
+thumb_func 0x81794f4 DoBrailleDigEffect
+thumb_func 0x8179564 CheckRelicanthWailord
 thumb_func 0x81795b4 nullsub_17
-thumb_func 0x81795b8
-thumb_func 0x81795f4
-thumb_func 0x8179630
-thumb_func 0x8179694
+thumb_func 0x81795b8 DoSealedChamberShakingEffect1
+thumb_func 0x81795f4 DoSealedChamberShakingEffect2
+thumb_func 0x8179630 SealedChamberShakingEffect
+thumb_func 0x8179694 ShouldDoBrailleRegirockEffect
 thumb_func 0x81796ec
 thumb_func 0x8179708
-thumb_func 0x8179718
-thumb_func 0x8179788
+thumb_func 0x8179718 DoBrailleRegirockEffect
+thumb_func 0x8179788 ShouldDoBrailleRegisteelEffect
 thumb_func 0x81797d0
 thumb_func 0x81797ec
-thumb_func 0x81797fc
+thumb_func 0x81797fc DoBrailleRegisteelEffect
 thumb_func 0x817986c nullsub_99
-thumb_func 0x8179870
-thumb_func 0x81798bc
-thumb_func 0x8179a20
-thumb_func 0x8179a3c
-thumb_func 0x8179a50
-thumb_func 0x8179c28
-thumb_func 0x8179c54
-thumb_func 0x8179cac
-thumb_func 0x8179e64
-thumb_func 0x8179ea4
-thumb_func 0x8179ee8
-thumb_func 0x817a020
-thumb_func 0x817a04c
-thumb_func 0x817a07c
-thumb_func 0x817a178
-thumb_func 0x817a1d8
-thumb_func 0x817a210
+thumb_func 0x8179870 FldEff_UsePuzzleEffect
+thumb_func 0x81798bc ShouldDoBrailleRegicePuzzle
+thumb_func 0x8179a20 CB2_PokeblockFeed
+thumb_func 0x8179a3c VBlankCB_PokeblockFeed
+thumb_func 0x8179a50 TransitionToPokeblockFeedScene
+thumb_func 0x8179c28 CB2_PreparePokeblockFeedScene
+thumb_func 0x8179c54 HandleInitBackgrounds
+thumb_func 0x8179cac LoadMonAndSceneGfx
+thumb_func 0x8179e64 HandleInitWindows
+thumb_func 0x8179ea4 SetPokeblockSpritePal
+thumb_func 0x8179ee8 Task_HandlePokeblockFeed
+thumb_func 0x817a020 LaunchPokeblockFeedTask
+thumb_func 0x817a04c Task_WaitForAtePokeblockText
+thumb_func 0x817a07c Task_HandleMonAtePokeblock
+thumb_func 0x817a178 Task_ReturnAfterPaletteFade
+thumb_func 0x817a1d8 Task_PaletteFadeToReturn
+thumb_func 0x817a210 CreateMonSprite
 thumb_func 0x817a2ec PrepareMonToMoveToPokeblock
 thumb_func 0x817a320
-thumb_func 0x817a35c
-thumb_func 0x817a3b0
-thumb_func 0x817a424
-thumb_func 0x817a458
+thumb_func 0x817a35c CreatePokeblockCaseSpriteForFeeding
+thumb_func 0x817a3b0 DoPokeblockCaseThrowEffect
+thumb_func 0x817a424 CreatePokeblockSprite
+thumb_func 0x817a458 SpriteCB_ThrownPokeblock
 thumb_func 0x817a484
 thumb_func 0x817a4ec
 thumb_func 0x817a7d4
 thumb_func 0x817a89c
-thumb_func 0x817a8f4
+thumb_func 0x817a8f4 FreeMonSpriteOamMatrix
 thumb_func 0x817a90c
 thumb_func 0x817aa20
-thumb_func 0x817ab80
+thumb_func 0x817ab80 CB2_InitClearSaveDataScreen
 thumb_func 0x817ab9c
-thumb_func 0x817ac00
-thumb_func 0x817ac80
+thumb_func 0x817ac00 Task_ClearSaveDataScreenYesNoChoice
+thumb_func 0x817ac80 Task_ClearSaveData
 thumb_func 0x817aca4
-thumb_func 0x817acb4
-thumb_func 0x817acc0
-thumb_func 0x817ae94
-thumb_func 0x817aeec
-thumb_func 0x817af24
-thumb_func 0x817b010
+thumb_func 0x817acb4 VBlankCB
+thumb_func 0x817acc0 SetupClearSaveDataScreen
+thumb_func 0x817ae94 CB2_FadeAndDoReset
+thumb_func 0x817aeec InitClearSaveDataScreenWindows
+thumb_func 0x817af24 load_intro_part2_graphics
+thumb_func 0x817b010 LinkPartnerHandleChooseMove
 thumb_func 0x817b088
 thumb_func 0x817b268
 thumb_func 0x817b29c
@@ -12434,77 +12434,77 @@ thumb_func 0x817b7a8
 thumb_func 0x817b808
 thumb_func 0x817b884
 thumb_func 0x817b900 nullsub_100
-thumb_func 0x817b904
-thumb_func 0x817b93c
-thumb_func 0x817b9f8
-thumb_func 0x817ba54
-thumb_func 0x817bac8
-thumb_func 0x817bb30
-thumb_func 0x817bb78
-thumb_func 0x817bbe0
-thumb_func 0x817bcb0
-thumb_func 0x817bd38
-thumb_func 0x817bd54
-thumb_func 0x817bd84
-thumb_func 0x817bdd4
-thumb_func 0x817be44
+thumb_func 0x817b904 SetEvoSparklesMatrices
+thumb_func 0x817b93c SpriteCB_PreEvoSparkleSet1
+thumb_func 0x817b9f8 CreatePreEvoSparkleSet1
+thumb_func 0x817ba54 SpriteCB_PreEvoSparkleSet2
+thumb_func 0x817bac8 CreatePreEvoSparkleSet2
+thumb_func 0x817bb30 SpriteCB_PostEvoSparkleSet1
+thumb_func 0x817bb78 CreatePostEvoSparkleSet1
+thumb_func 0x817bbe0 SpriteCB_PostEvoSparkleSet2
+thumb_func 0x817bcb0 CreatePostEvoSparkleSet2
+thumb_func 0x817bd38 LoadEvoSparkleSpriteAndPal
+thumb_func 0x817bd54 LaunchTask_PreEvoSparklesSet1
+thumb_func 0x817bd84 EvoTask_BeginPreSet1_FadeAndPlaySE
+thumb_func 0x817bdd4 EvoTask_CreatePreEvoSparkleSet1
+thumb_func 0x817be44 EvoTask_WaitForPre1SparklesToGoUp
 thumb_func 0x817be74
-thumb_func 0x817be8c
-thumb_func 0x817bec0
+thumb_func 0x817be8c EvoTask_BeginPreSparklesSet2
+thumb_func 0x817bec0 EvoTask_CreatePreEvoSparklesSet2
 thumb_func 0x817bf18
 thumb_func 0x817bf28
-thumb_func 0x817bf40
-thumb_func 0x817bf74
-thumb_func 0x817bff4
+thumb_func 0x817bf40 EvoTask_BeginPostSparklesSet1
+thumb_func 0x817bf74 EvoTask_CreatePostEvoSparklesSet1
+thumb_func 0x817bff4 EvoTask_DestroyPostSet1Task
 thumb_func 0x817c004
-thumb_func 0x817c034
-thumb_func 0x817c094
-thumb_func 0x817c120
+thumb_func 0x817c034 EvoTask_BeginPostSparklesSet2_AndFlash
+thumb_func 0x817c094 EvoTask_CreatePostEvoSparklesSet2_AndFlash
+thumb_func 0x817c120 EvoTask_DestroyPostSet2AndFlashTask
 thumb_func 0x817c140
-thumb_func 0x817c170
-thumb_func 0x817c1d0
+thumb_func 0x817c170 EvoTask_BeginPostSparklesSet2_AndFlash_Trade
+thumb_func 0x817c1d0 EvoTask_CreatePostEvoSparklesSet2_AndFlash_Trade
 thumb_func 0x817c25c nullsub_103
 thumb_func 0x817c260
 thumb_func 0x817c3ac
 thumb_func 0x817c3d0
 thumb_func 0x817c420
-thumb_func 0x817c53c
-thumb_func 0x817c5ec
+thumb_func 0x817c53c PreEvoInvisible_PostEvoVisible_KillTask
+thumb_func 0x817c5ec PreEvoVisible_PostEvoInvisible_KillTask
 thumb_func 0x817c69c
 thumb_func 0x817c6b0
 thumb_func 0x817c704
-thumb_func 0x817c768
-thumb_func 0x817c7a8
-thumb_func 0x817c7c8
-thumb_func 0x817c7f8
-thumb_func 0x817c808
+thumb_func 0x817c768 SetUpFieldMove_Teleport
+thumb_func 0x817c7a8 FieldCallback_Teleport
+thumb_func 0x817c7c8 FldEff_UseTeleport
+thumb_func 0x817c7f8 StartTeleportFieldEffect
+thumb_func 0x817c808 BattleTv_SetDataBasedOnString
 thumb_func 0x817df64
-thumb_func 0x817dfa8
-thumb_func 0x817e1d8
-thumb_func 0x817e2a0
+thumb_func 0x817dfa8 BattleTv_SetDataBasedOnMove
+thumb_func 0x817e1d8 BattleTv_SetDataBasedOnAnimation
+thumb_func 0x817e2a0 TryPutLinkBattleTvShowOnAir
 thumb_func 0x817e530 AddMovePoints
 thumb_func 0x817e92c AddPointsOnFainting
-thumb_func 0x817ed78
-thumb_func 0x817f0c8
+thumb_func 0x817ed78 TrySetBattleSeminarShow
+thumb_func 0x817f0c8 ShouldCalculateDamage
 thumb_func 0x817f154 BattleTv_ClearExplosionFaintCause
-thumb_func 0x817f1e8
+thumb_func 0x817f1e8 GetBattlerMoveSlotId
 thumb_func 0x817f240 AddPointsBasedOnWeather
 thumb_func 0x817f298 nullsub_27
 thumb_func 0x817f29c
-thumb_func 0x817f320
-thumb_func 0x817f344
-thumb_func 0x817f3f0
+thumb_func 0x817f320 GetSpeciesBackAnimSet
+thumb_func 0x817f344 Task_HandleMonAnimation
+thumb_func 0x817f3f0 LaunchAnimationTaskForFrontSprite
 thumb_func 0x817f424 StartMonSummaryAnimation
-thumb_func 0x817f440
+thumb_func 0x817f440 LaunchAnimationTaskForBackSprite
 thumb_func 0x817f4b8
-thumb_func 0x817f4c4
-thumb_func 0x817f51c
+thumb_func 0x817f4c4 SetAffineData
+thumb_func 0x817f51c HandleStartAffineAnim
 thumb_func 0x817f580 HandleSetAffineData
 thumb_func 0x817f5b8
 thumb_func 0x817f5d0
 thumb_func 0x817f604
 thumb_func 0x817f628
-thumb_func 0x817f6b4
+thumb_func 0x817f6b4 pokemonanimfunc_01
 thumb_func 0x817f744
 thumb_func 0x817f7a8
 thumb_func 0x817f808
@@ -12512,33 +12512,33 @@ thumb_func 0x817f824
 thumb_func 0x817f884
 thumb_func 0x817f8a0
 thumb_func 0x817f918 pokemonanimfunc_1E
-thumb_func 0x817f934
-thumb_func 0x817fa10
+thumb_func 0x817f934 pokemonanimfunc_06
+thumb_func 0x817fa10 pokemonanimfunc_09
 thumb_func 0x817facc
-thumb_func 0x817fb70
+thumb_func 0x817fb70 pokemonanimfunc_0A
 thumb_func 0x817fb88
 thumb_func 0x817fbd0 pokemonanimfunc_0F
 thumb_func 0x817fbf0
 thumb_func 0x817fc34 pokemonanimfunc_10
-thumb_func 0x817fc50
+thumb_func 0x817fc50 pokemonanimfunc_11
 thumb_func 0x817fcdc
 thumb_func 0x817fdac pokemonanimfunc_12
 thumb_func 0x817fde8
 thumb_func 0x817fe64 pokemonanimfunc_1F
 thumb_func 0x817fe9c
 thumb_func 0x817ff3c pokemonanimfunc_14
-thumb_func 0x817ff7c
-thumb_func 0x817ffe0
-thumb_func 0x81800bc
+thumb_func 0x817ff7c pokemonanimfunc_15
+thumb_func 0x817ffe0 pokemonanimfunc_16
+thumb_func 0x81800bc pokemonanimfunc_17
 thumb_func 0x81801c8
 thumb_func 0x818024c pokemonanimfunc_19
-thumb_func 0x8180268
-thumb_func 0x8180320
+thumb_func 0x8180268 pokemonanimfunc_1A
+thumb_func 0x8180320 pokemonanimfunc_1B
 thumb_func 0x81803a4
 thumb_func 0x8180440 pokemonanimfunc_1C
 thumb_func 0x818045c
 thumb_func 0x8180500 pokemonanimfunc_18
-thumb_func 0x818051c
+thumb_func 0x818051c pokemonanimfunc_1D
 thumb_func 0x81805c0
 thumb_func 0x81806b8 pokemonanimfunc_00
 thumb_func 0x81806d4
@@ -12546,11 +12546,11 @@ thumb_func 0x8180784 pokemonanimfunc_13
 thumb_func 0x81807ac
 thumb_func 0x81808fc pokemonanimfunc_05
 thumb_func 0x8180938
-thumb_func 0x81809a4
-thumb_func 0x8180a08
+thumb_func 0x81809a4 pokemonanimfunc_21
+thumb_func 0x8180a08 pokemonanimfunc_22
 thumb_func 0x8180a70
-thumb_func 0x8180adc
-thumb_func 0x8180b48
+thumb_func 0x8180adc pokemonanimfunc_24
+thumb_func 0x8180b48 pokemonanimfunc_25
 thumb_func 0x8180b60
 thumb_func 0x8180b94
 thumb_func 0x8180bf0
@@ -12561,11 +12561,11 @@ thumb_func 0x8180d24
 thumb_func 0x8180d7c
 thumb_func 0x8180dd8
 thumb_func 0x8180e54 pokemonanimfunc_27
-thumb_func 0x8180eb8
+thumb_func 0x8180eb8 pokemonanimfunc_28
 thumb_func 0x8180ed0
 thumb_func 0x8180f14
 thumb_func 0x8180f70
-thumb_func 0x8180fa4
+thumb_func 0x8180fa4 pokemonanimfunc_29
 thumb_func 0x8180fbc
 thumb_func 0x8180ff0
 thumb_func 0x8181050
@@ -12573,40 +12573,40 @@ thumb_func 0x818108c pokemonanimfunc_2A
 thumb_func 0x81810c0
 thumb_func 0x8181200 pokemonanimfunc_2B
 thumb_func 0x818121c
-thumb_func 0x81812c4
+thumb_func 0x81812c4 pokemonanimfunc_2C
 thumb_func 0x8181380
 thumb_func 0x818144c pokemonanimfunc_2D
 thumb_func 0x8181480
 thumb_func 0x818154c pokemonanimfunc_2E
-thumb_func 0x8181580
+thumb_func 0x8181580 pokemonanimfunc_2F
 thumb_func 0x81815b4
 thumb_func 0x818161c
 thumb_func 0x8181640
 thumb_func 0x81816bc
 thumb_func 0x818180c pokemonanimfunc_30
-thumb_func 0x8181840
+thumb_func 0x8181840 pokemonanimfunc_31
 thumb_func 0x8181924 pokemonanimfunc_32
 thumb_func 0x8181968
 thumb_func 0x81819f8
 thumb_func 0x8181ad8
 thumb_func 0x8181b94
 thumb_func 0x8181c5c pokemonanimfunc_33
-thumb_func 0x8181c90
+thumb_func 0x8181c90 pokemonanimfunc_34
 thumb_func 0x8181d3c pokemonanimfunc_35
 thumb_func 0x8181da4 pokemonanimfunc_36
 thumb_func 0x8181dc0
 thumb_func 0x8181dfc
 thumb_func 0x8181e6c
-thumb_func 0x8181ec8
+thumb_func 0x8181ec8 pokemonanimfunc_37
 thumb_func 0x8181f8c pokemonanimfunc_38
 thumb_func 0x8181fa8
 thumb_func 0x8182018
 thumb_func 0x8182078
 thumb_func 0x81820f4
-thumb_func 0x818215c
-thumb_func 0x818221c
-thumb_func 0x818234c
-thumb_func 0x81823f4
+thumb_func 0x818215c pokemonanimfunc_39
+thumb_func 0x818221c pokemonanimfunc_3A
+thumb_func 0x818234c pokemonanimfunc_3B
+thumb_func 0x81823f4 pokemonanimfunc_3C
 thumb_func 0x8182488 pokemonanimfunc_3D
 thumb_func 0x81824a4
 thumb_func 0x81824f4
@@ -12615,17 +12615,17 @@ thumb_func 0x8182610
 thumb_func 0x81826a8 pokemonanimfunc_3E
 thumb_func 0x81826dc
 thumb_func 0x8182774 pokemonanimfunc_3F
-thumb_func 0x81827a8
-thumb_func 0x8182858
-thumb_func 0x8182918
-thumb_func 0x81829d0
-thumb_func 0x8182ac4
+thumb_func 0x81827a8 pokemonanimfunc_40
+thumb_func 0x8182858 pokemonanimfunc_41
+thumb_func 0x8182918 pokemonanimfunc_42
+thumb_func 0x81829d0 pokemonanimfunc_43
+thumb_func 0x8182ac4 pokemonanimfunc_44
 thumb_func 0x8182bd0 pokemonanimfunc_45
 thumb_func 0x8182bec pokemonanimfunc_46
 thumb_func 0x8182c08 pokemonanimfunc_47
 thumb_func 0x8182c24 pokemonanimfunc_48
 thumb_func 0x8182c60
-thumb_func 0x8182c70
+thumb_func 0x8182c70 pokemonanimfunc_4A
 thumb_func 0x8182c80 pokemonanimfunc_4B
 thumb_func 0x8182cac pokemonanimfunc_4C
 thumb_func 0x8182ccc pokemonanimfunc_4D
@@ -12647,7 +12647,7 @@ thumb_func 0x8182fb4 pokemonanimfunc_0E
 thumb_func 0x8182fec
 thumb_func 0x8183040 pokemonanimfunc_57
 thumb_func 0x8183060 pokemonanimfunc_58
-thumb_func 0x8183080
+thumb_func 0x8183080 pokemonanimfunc_66
 thumb_func 0x8183174
 thumb_func 0x8183294 pokemonanimfunc_5A
 thumb_func 0x81832c4
@@ -12657,7 +12657,7 @@ thumb_func 0x81834c4 pokemonanimfunc_5C
 thumb_func 0x81834e4 pokemonanimfunc_5D
 thumb_func 0x8183504 pokemonanimfunc_5E
 thumb_func 0x8183520
-thumb_func 0x8183584
+thumb_func 0x8183584 pokemonanimfunc_60
 thumb_func 0x81835e8 pokemonanimfunc_61
 thumb_func 0x8183608 pokemonanimfunc_62
 thumb_func 0x8183628 pokemonanimfunc_63
@@ -12665,7 +12665,7 @@ thumb_func 0x8183648 pokemonanimfunc_64
 thumb_func 0x8183688
 thumb_func 0x81837e8 pokemonanimfunc_65
 thumb_func 0x8183818
-thumb_func 0x818390c
+thumb_func 0x818390c pokemonanimfunc_67
 thumb_func 0x81839f8
 thumb_func 0x8183ab8 pokemonanimfunc_68
 thumb_func 0x8183ad8 pokemonanimfunc_69
@@ -12697,9 +12697,9 @@ thumb_func 0x81840c0 pokemonanimfunc_7F
 thumb_func 0x81840e8 pokemonanimfunc_80
 thumb_func 0x8184110 pokemonanimfunc_81
 thumb_func 0x818413c
-thumb_func 0x8184188
-thumb_func 0x818420c
-thumb_func 0x8184290
+thumb_func 0x8184188 pokemonanimfunc_82
+thumb_func 0x818420c pokemonanimfunc_83
+thumb_func 0x8184290 pokemonanimfunc_84
 thumb_func 0x8184314
 thumb_func 0x81843fc pokemonanimfunc_85
 thumb_func 0x8184428 pokemonanimfunc_86
@@ -12713,11 +12713,11 @@ thumb_func 0x8184598 pokemonanimfunc_88
 thumb_func 0x81845c4 pokemonanimfunc_89
 thumb_func 0x81845f0 pokemonanimfunc_8A
 thumb_func 0x818461c
-thumb_func 0x8184644
+thumb_func 0x8184644 BackAnimBlendYellow
 thumb_func 0x81846e0 pokemonanimfunc_8B
 thumb_func 0x8184718 pokemonanimfunc_8C
 thumb_func 0x8184750 pokemonanimfunc_8D
-thumb_func 0x818478c
+thumb_func 0x818478c BackAnimBlend
 thumb_func 0x81847e0
 thumb_func 0x8184880 pokemonanimfunc_8E
 thumb_func 0x81848e8 pokemonanimfunc_8F
@@ -12733,33 +12733,33 @@ thumb_func 0x8184c50
 thumb_func 0x8184d04
 thumb_func 0x8184e1c RecordedBattle_SetBattlerAction
 thumb_func 0x8184e68 RecordedBattle_ClearBattlerAction
-thumb_func 0x8184eb4
+thumb_func 0x8184eb4 RecordedBattle_GetBattlerAction
 thumb_func 0x8184f30
 thumb_func 0x8184f3c
 thumb_func 0x8185008
 thumb_func 0x81850d8
-thumb_func 0x81850f0
-thumb_func 0x8185110
-thumb_func 0x8185150
-thumb_func 0x8185198
-thumb_func 0x8185810
-thumb_func 0x8185844
-thumb_func 0x818586c
-thumb_func 0x81858d8
+thumb_func 0x81850f0 CanCopyRecordedBattleSaveData
+thumb_func 0x8185110 IsRecordedBattleSaveValid
+thumb_func 0x8185150 RecordedBattleToSave
+thumb_func 0x8185198 MoveRecordedBattleToSaveData
+thumb_func 0x8185810 TryCopyRecordedBattleSaveData
+thumb_func 0x8185844 CopyRecordedBattleFromSave
+thumb_func 0x818586c CB2_RecordedBattleEnd
+thumb_func 0x81858d8 Task_StartAfterCountdown
 thumb_func 0x818591c
-thumb_func 0x8185b7c
-thumb_func 0x8185be4
+thumb_func 0x8185b7c PlayRecordedBattle
+thumb_func 0x8185be4 CB2_RecordedBattle
 thumb_func 0x8185bf8
 thumb_func 0x8185c04
 thumb_func 0x8185c10
 thumb_func 0x8185c54
-thumb_func 0x8185c98
+thumb_func 0x8185c98 GetActiveBattlerLinkPlayerGender
 thumb_func 0x8185cdc
 thumb_func 0x8185ce8
 thumb_func 0x8185d04
 thumb_func 0x8185d10
 thumb_func 0x8185d1c
-thumb_func 0x8185d28
+thumb_func 0x8185d28 RecordedBattle_CopyBattlerMoves
 thumb_func 0x8185d94
 thumb_func 0x8186190
 thumb_func 0x818619c
@@ -12790,71 +12790,71 @@ thumb_func 0x8186cc0
 thumb_func 0x8186db0
 thumb_func 0x8186e78
 thumb_func 0x8186ea8
-thumb_func 0x8186ed8
-thumb_func 0x8186f50
+thumb_func 0x8186ed8 RecordedOpponentBufferExecCompleted
+thumb_func 0x8186f50 RecordedOpponentHandleGetMonData
 thumb_func 0x8186fc4
 thumb_func 0x8187770
 thumb_func 0x818777c
-thumb_func 0x81877d4
+thumb_func 0x81877d4 SetRecordedOpponentMonData
 thumb_func 0x81880f4
-thumb_func 0x8188168
+thumb_func 0x8188168 RecordedOpponentHandleLoadMonSprite
 thumb_func 0x81882b8
 thumb_func 0x8188304
 thumb_func 0x8188494
 thumb_func 0x818852c
-thumb_func 0x81885b8
-thumb_func 0x818876c
-thumb_func 0x8188778
-thumb_func 0x8188824
-thumb_func 0x81888d0
-thumb_func 0x81888dc
-thumb_func 0x81888e8
-thumb_func 0x81888f4
-thumb_func 0x8188900
+thumb_func 0x81885b8 RecordedOpponentHandleDrawTrainerPic
+thumb_func 0x818876c RecordedOpponentHandleTrainerSlide
+thumb_func 0x8188778 RecordedOpponentHandleTrainerSlideBack
+thumb_func 0x8188824 RecordedOpponentHandleFaintAnimation
+thumb_func 0x81888d0 RecordedOpponentHandlePaletteFade
+thumb_func 0x81888dc RecordedOpponentHandleSuccessBallThrowAnim
+thumb_func 0x81888e8 RecordedOpponentHandleBallThrowAnim
+thumb_func 0x81888f4 RecordedOpponentHandlePause
+thumb_func 0x8188900 RecordedOpponentHandleMoveAnimation
 thumb_func 0x8188a38
-thumb_func 0x8188bbc
-thumb_func 0x8188c10
-thumb_func 0x8188c1c
-thumb_func 0x8188c40
-thumb_func 0x8188c4c
-thumb_func 0x8188ca8
-thumb_func 0x8188cb4
-thumb_func 0x8188cf0
-thumb_func 0x8188cfc
+thumb_func 0x8188bbc RecordedOpponentHandlePrintString
+thumb_func 0x8188c10 RecordedOpponentHandlePrintSelectionString
+thumb_func 0x8188c1c RecordedOpponentHandleChooseAction
+thumb_func 0x8188c40 RecordedOpponentHandleUnknownYesNoBox
+thumb_func 0x8188c4c RecordedOpponentHandleChooseMove
+thumb_func 0x8188ca8 RecordedOpponentHandleChooseItem
+thumb_func 0x8188cb4 RecordedOpponentHandleChoosePokemon
+thumb_func 0x8188cf0 RecordedOpponentHandleCmd23
+thumb_func 0x8188cfc RecordedOpponentHandleHealthBarUpdate
 thumb_func 0x8188dec
-thumb_func 0x8188df8
-thumb_func 0x8188e70
-thumb_func 0x8188ed8
-thumb_func 0x8188ee4
+thumb_func 0x8188df8 RecordedOpponentHandleStatusIconUpdate
+thumb_func 0x8188e70 RecordedOpponentHandleStatusAnimation
+thumb_func 0x8188ed8 RecordedOpponentHandleStatusXor
+thumb_func 0x8188ee4 RecordedOpponentHandleDataTransfer
 thumb_func 0x8188ef0
-thumb_func 0x8188efc
-thumb_func 0x8188f08
-thumb_func 0x8188f14
-thumb_func 0x8188f20
-thumb_func 0x8188f2c
-thumb_func 0x8188f38
+thumb_func 0x8188efc RecordedOpponentHandlePlayBGM
+thumb_func 0x8188f08 RecordedOpponentHandleCmd32
+thumb_func 0x8188f14 RecordedOpponentHandleTwoReturnValues
+thumb_func 0x8188f20 RecordedOpponentHandleChosenMonReturnValue
+thumb_func 0x8188f2c RecordedOpponentHandleOneReturnValue
+thumb_func 0x8188f38 RecordedOpponentHandleOneReturnValue_Duplicate
 thumb_func 0x8188f44 RecordedOpponentHandleCmd37
 thumb_func 0x8188f60 RecordedOpponentHandleCmd38
 thumb_func 0x8188f98 RecordedOpponentHandleCmd39
 thumb_func 0x8188fb0 RecordedOpponentHandleCmd40
-thumb_func 0x8188fd8
-thumb_func 0x8189048
-thumb_func 0x8189054
-thumb_func 0x8189098
-thumb_func 0x81890f4
+thumb_func 0x8188fd8 RecordedOpponentHandleHitAnimation
+thumb_func 0x8189048 RecordedOpponentHandleCmd42
+thumb_func 0x8189054 RecordedOpponentHandlePlaySE
+thumb_func 0x8189098 RecordedOpponentHandlePlayFanfareOrBGM
+thumb_func 0x81890f4 RecordedOpponentHandleFaintingCry
 thumb_func 0x8189130
-thumb_func 0x8189164
+thumb_func 0x8189164 RecordedOpponentHandleIntroTrainerBallThrow
 thumb_func 0x8189274
 thumb_func 0x8189358
 thumb_func 0x8189374
 thumb_func 0x8189488
 thumb_func 0x81894d0 RecordedOpponentHandleHidePartyStatusSummary
-thumb_func 0x8189520
+thumb_func 0x8189520 RecordedOpponentHandleEndBounceEffect
 thumb_func 0x818952c
-thumb_func 0x818958c
-thumb_func 0x81895f4
-thumb_func 0x8189600
-thumb_func 0x818960c
+thumb_func 0x818958c RecordedOpponentHandleBattleAnimation
+thumb_func 0x81895f4 RecordedOpponentHandleLinkStandbyMsg
+thumb_func 0x8189600 RecordedOpponentHandleResetActionMoveSelection
+thumb_func 0x818960c RecordedOpponentHandleCmd55
 thumb_func 0x8189670 nullsub_105
 thumb_func 0x8189674 nullsub_104
 thumb_func 0x8189678
@@ -12874,47 +12874,47 @@ thumb_func 0x8189fe0
 thumb_func 0x818a054
 thumb_func 0x818a0a8
 thumb_func 0x818a19c
-thumb_func 0x818a240
+thumb_func 0x818a240 RecordedPlayerBufferExecCompleted
 thumb_func 0x818a2b8 CompleteOnFinishedStatusAnimation
 thumb_func 0x818a2e8 CompleteOnFinishedBattleAnimation
-thumb_func 0x818a318
+thumb_func 0x818a318 RecordedPlayerHandleGetMonData
 thumb_func 0x818a38c
 thumb_func 0x818ab38
 thumb_func 0x818ab44
-thumb_func 0x818ab9c
+thumb_func 0x818ab9c SetRecordedPlayerMonData
 thumb_func 0x818b598
-thumb_func 0x818b60c
-thumb_func 0x818b728
+thumb_func 0x818b60c RecordedPlayerHandleLoadMonSprite
+thumb_func 0x818b728 RecordedPlayerHandleSwitchInAnim
 thumb_func 0x818b798
 thumb_func 0x818b914
-thumb_func 0x818b9a4
-thumb_func 0x818ba30
-thumb_func 0x818bcd8
+thumb_func 0x818b9a4 DoSwitchOutAnimation
+thumb_func 0x818ba30 RecordedPlayerHandleDrawTrainerPic
+thumb_func 0x818bcd8 RecordedPlayerHandleTrainerSlide
 thumb_func 0x818bce4
-thumb_func 0x818bd90
+thumb_func 0x818bd90 RecordedPlayerHandleFaintAnimation
 thumb_func 0x818be7c
 thumb_func 0x818be88
 thumb_func 0x818be94
 thumb_func 0x818bea0
-thumb_func 0x818beac
-thumb_func 0x818bfe4
+thumb_func 0x818beac RecordedPlayerHandleMoveAnimation
+thumb_func 0x818bfe4 RecordedPlayerDoMoveAnimation
 thumb_func 0x818c168
-thumb_func 0x818c1bc
-thumb_func 0x818c1c8
-thumb_func 0x818c204
+thumb_func 0x818c1bc RecordedPlayerHandlePrintSelectionString
+thumb_func 0x818c1c8 ChooseActionInBattlePalace
+thumb_func 0x818c204 RecordedPlayerHandleChooseAction
 thumb_func 0x818c258
-thumb_func 0x818c264
-thumb_func 0x818c2c0
-thumb_func 0x818c2cc
-thumb_func 0x818c308
-thumb_func 0x818c314
-thumb_func 0x818c414
-thumb_func 0x818c420
-thumb_func 0x818c498
-thumb_func 0x818c500
-thumb_func 0x818c50c
-thumb_func 0x818c518
-thumb_func 0x818c524
+thumb_func 0x818c264 RecordedPlayerHandleChooseMove
+thumb_func 0x818c2c0 RecordedPlayerHandleChooseItem
+thumb_func 0x818c2cc RecordedPlayerHandleChoosePokemon
+thumb_func 0x818c308 RecordedPlayerHandleCmd23
+thumb_func 0x818c314 RecordedPlayerHandleHealthBarUpdate
+thumb_func 0x818c414 RecordedPlayerHandleExpUpdate
+thumb_func 0x818c420 RecordedPlayerHandleStatusIconUpdate
+thumb_func 0x818c498 RecordedPlayerHandleStatusAnimation
+thumb_func 0x818c500 RecordedPlayerHandleStatusXor
+thumb_func 0x818c50c RecordedPlayerHandleDataTransfer
+thumb_func 0x818c518 RecordedPlayerHandleDMA3Transfer
+thumb_func 0x818c524 RecordedPlayerHandlePlayBGM
 thumb_func 0x818c530
 thumb_func 0x818c53c
 thumb_func 0x818c548
@@ -12925,51 +12925,51 @@ thumb_func 0x818c588 RecordedPlayerHandleCmd38
 thumb_func 0x818c5c0 RecordedPlayerHandleCmd39
 thumb_func 0x818c5d8 RecordedPlayerHandleCmd40
 thumb_func 0x818c600
-thumb_func 0x818c670
+thumb_func 0x818c670 RecordedPlayerHandleCmd42
 thumb_func 0x818c67c
-thumb_func 0x818c6c0
-thumb_func 0x818c71c
+thumb_func 0x818c6c0 RecordedPlayerHandlePlayFanfareOrBGM
+thumb_func 0x818c71c RecordedPlayerHandleFaintingCry
 thumb_func 0x818c75c
-thumb_func 0x818c790
+thumb_func 0x818c790 RecordedPlayerHandleIntroTrainerBallThrow
 thumb_func 0x818c950
-thumb_func 0x818ca5c
+thumb_func 0x818ca5c RecordedPlayerHandleDrawPartyStatusSummary
 thumb_func 0x818cb20
 thumb_func 0x818cb68 RecordedPlayerHandleHidePartyStatusSummary
-thumb_func 0x818cbb8
-thumb_func 0x818cbc4
-thumb_func 0x818cc24
-thumb_func 0x818cc8c
-thumb_func 0x818cc98
-thumb_func 0x818cca4
+thumb_func 0x818cbb8 RecordedPlayerHandleEndBounceEffect
+thumb_func 0x818cbc4 RecordedPlayerHandleSpriteInvisibility
+thumb_func 0x818cc24 RecordedPlayerHandleBattleAnimation
+thumb_func 0x818cc8c RecordedPlayerHandleLinkStandbyMsg
+thumb_func 0x818cc98 RecordedPlayerHandleResetActionMoveSelection
+thumb_func 0x818cca4 RecordedPlayerHandleCmd55
 thumb_func 0x818ccf0 nullsub_107
 thumb_func 0x818ccf4 nullsub_108
 thumb_func 0x818ccf8 ResetAllPicSprites
-thumb_func 0x818cd20
+thumb_func 0x818cd20 DecompressPic
 thumb_func 0x818cdc8 DecompressPic_HandleDeoxys
-thumb_func 0x818cdf0
-thumb_func 0x818ceac
-thumb_func 0x818ceec
-thumb_func 0x818cf18
+thumb_func 0x818cdf0 LoadPicPaletteByTagOrSlot
+thumb_func 0x818ceac LoadPicPaletteBySlot
+thumb_func 0x818ceec AssignSpriteAnimsTable
+thumb_func 0x818cf18 CreatePicSprite
 thumb_func 0x818d0b0 CreatePicSprite_HandleDeoxys
-thumb_func 0x818d110
-thumb_func 0x818d2dc
+thumb_func 0x818d110 CreatePicSprite2
+thumb_func 0x818d2dc FreeAndDestroyPicSpriteInternal
 thumb_func 0x818d388
 thumb_func 0x818d3f8
 thumb_func 0x818d4a4 CreateMonPicSprite
 thumb_func 0x818d504 CreateMonPicSprite_HandleDeoxys
-thumb_func 0x818d54c
+thumb_func 0x818d54c FreeAndDestroyMonPicSprite
 thumb_func 0x818d560
 thumb_func 0x818d590
 thumb_func 0x818d5d8 CreateTrainerPicSprite
-thumb_func 0x818d61c
+thumb_func 0x818d61c FreeAndDestroyTrainerPicSprite
 thumb_func 0x818d630
 thumb_func 0x818d664
-thumb_func 0x818d6a8
+thumb_func 0x818d6a8 PlayerGenderToFrontTrainerPicId_Debug
 thumb_func 0x818d6d8
 thumb_func 0x818d6ec
-thumb_func 0x818d75c
+thumb_func 0x818d75c SetLilycoveLady
 thumb_func 0x818d7a4
-thumb_func 0x818d7d8
+thumb_func 0x818d7d8 SetLilycoveLadyRandomly
 thumb_func 0x818d818
 thumb_func 0x818d830
 thumb_func 0x818d84c
@@ -12982,7 +12982,7 @@ thumb_func 0x818d98c
 thumb_func 0x818d9c8
 thumb_func 0x818d9e4
 thumb_func 0x818da10
-thumb_func 0x818da30
+thumb_func 0x818da30 SetRainStrengthFromSoundEffect
 thumb_func 0x818da60
 thumb_func 0x818da84
 thumb_func 0x818da90
@@ -12991,7 +12991,7 @@ thumb_func 0x818db68
 thumb_func 0x818db94
 thumb_func 0x818dbac
 thumb_func 0x818dbe8
-thumb_func 0x818dc00
+thumb_func 0x818dc00 CB2_ReturnToField
 thumb_func 0x818dc0c
 thumb_func 0x818dc74 SetLilycoveQuizLady
 thumb_func 0x818dd10
@@ -13017,13 +13017,13 @@ thumb_func 0x818e0ec
 thumb_func 0x818e100
 thumb_func 0x818e16c
 thumb_func 0x818e194
-thumb_func 0x818e1c0
+thumb_func 0x818e1c0 MainCB2
 thumb_func 0x818e1cc
 thumb_func 0x818e260
 thumb_func 0x818e294 SetLilycoveContestLady
 thumb_func 0x818e2d0
 thumb_func 0x818e30c
-thumb_func 0x818e360
+thumb_func 0x818e360 GivePokeblockToContestLady
 thumb_func 0x818e3f0
 thumb_func 0x818e43c
 thumb_func 0x818e478
@@ -13040,72 +13040,72 @@ thumb_func 0x818e5ec
 thumb_func 0x818e608
 thumb_func 0x818e61c nullsub_109
 thumb_func 0x818e628
-thumb_func 0x818e6e0
-thumb_func 0x818e984
-thumb_func 0x818ec88
-thumb_func 0x818f37c
+thumb_func 0x818e6e0 GetDomeData
+thumb_func 0x818e984 SetDomeData
+thumb_func 0x818ec88 InitDomeTrainers
+thumb_func 0x818f37c CalcDomeMonStats
 thumb_func 0x818f560 SwapDomeTrainers
-thumb_func 0x818f60c
-thumb_func 0x818f63c
-thumb_func 0x818f67c
-thumb_func 0x818f6d0
-thumb_func 0x818f838
-thumb_func 0x818f8d4
+thumb_func 0x818f60c BufferDomeRoundText
+thumb_func 0x818f63c BufferDomeOpponentName
+thumb_func 0x818f67c InitDomeOpponentParty
+thumb_func 0x818f6d0 CreateDomeOpponentMon
+thumb_func 0x818f838 CreateDomeOpponentMons
+thumb_func 0x818f8d4 GetDomeTrainerMonCountInBits
 thumb_func 0x818f918
 thumb_func 0x818fa14
 thumb_func 0x818fb10
-thumb_func 0x818fc1c
+thumb_func 0x818fc1c GetTypeEffectivenessPoints
 thumb_func 0x818fdc4
-thumb_func 0x818fdfc
-thumb_func 0x818fef4
+thumb_func 0x818fdfc TournamentIdOfOpponent
+thumb_func 0x818fef4 SetDomeOpponentId
 thumb_func 0x818ff08 TrainerIdOfPlayerOpponent
-thumb_func 0x818ff40
+thumb_func 0x818ff40 SetDomeOpponentGraphicsId
 thumb_func 0x818ff54
-thumb_func 0x818ff98
-thumb_func 0x8190014
-thumb_func 0x819005c
-thumb_func 0x81903ec
-thumb_func 0x8190454
-thumb_func 0x81904bc
-thumb_func 0x8190528
-thumb_func 0x8190594
-thumb_func 0x81905ac
-thumb_func 0x8190628
-thumb_func 0x81906a4
-thumb_func 0x8190720
+thumb_func 0x818ff98 UpdateDomeStreaks
+thumb_func 0x8190014 ShowDomeOpponentInfo
+thumb_func 0x819005c Task_ShowOpponentInfo
+thumb_func 0x81903ec SpriteCb_TrainerIconCardScrollUp
+thumb_func 0x8190454 SpriteCb_TrainerIconCardScrollDown
+thumb_func 0x81904bc SpriteCb_TrainerIconCardScrollLeft
+thumb_func 0x8190528 SpriteCb_TrainerIconCardScrollRight
+thumb_func 0x8190594 SpriteCb_MonIcon
+thumb_func 0x81905ac SpriteCb_MonIconCardScrollUp
+thumb_func 0x8190628 SpriteCb_MonIconCardScrollDown
+thumb_func 0x81906a4 SpriteCb_MonIconCardScrollLeft
+thumb_func 0x8190720 SpriteCb_MonIconCardScrollRight
 thumb_func 0x819079c
 thumb_func 0x81908c8
 thumb_func 0x8190930
 thumb_func 0x8191e78
-thumb_func 0x819213c
+thumb_func 0x819213c DisplayTrainerInfoOnCard
 thumb_func 0x8192b3c
-thumb_func 0x8192d7c
-thumb_func 0x8193484
-thumb_func 0x81934c0
+thumb_func 0x8192d7c DisplayMatchInfoOnCard
+thumb_func 0x8193484 ShowDomeTourneyTree
+thumb_func 0x81934c0 ShowPreviousDomeResultsTourneyTree
 thumb_func 0x819353c
-thumb_func 0x81937bc
-thumb_func 0x8193920
-thumb_func 0x819395c
-thumb_func 0x8193ab0
-thumb_func 0x8193e00
+thumb_func 0x81937bc UpdateTourneyTreeCursor
+thumb_func 0x8193920 ShowNonInteractiveDomeTourneyTree
+thumb_func 0x819395c ResolveDomeRoundWinners
+thumb_func 0x8193ab0 GetWinningMove
+thumb_func 0x8193e00 Task_ShowTourneyTree
 thumb_func 0x8194490
 thumb_func 0x81944f4
-thumb_func 0x8194754
-thumb_func 0x8194770
+thumb_func 0x8194754 CB2_BattleDome
+thumb_func 0x8194770 VblankCb0_BattleDome
 thumb_func 0x81947ec HblankCb_BattleDome
-thumb_func 0x81948e4
-thumb_func 0x8194948
-thumb_func 0x8194968
-thumb_func 0x8194a44
+thumb_func 0x81948e4 VblankCb1_BattleDome
+thumb_func 0x8194948 InitDomeFacilityTrainersAndMons
+thumb_func 0x8194968 RestoreDomePlayerParty
+thumb_func 0x8194a44 RestoreDomePlayerPartyHeldItems
 thumb_func 0x8194ab4
-thumb_func 0x8194ac0
+thumb_func 0x8194ac0 GetPlayerSeededBeforeOpponent
 thumb_func 0x8194af8 BufferLastDomeWinnerName
 thumb_func 0x8194b58
 thumb_func 0x8194f58
 thumb_func 0x8194fa0
 thumb_func 0x8194fe8
-thumb_func 0x8195038
-thumb_func 0x8195498
+thumb_func 0x8195038 DecideRoundWinners
+thumb_func 0x8195498 CopyDomeTrainerName
 thumb_func 0x8195510
 thumb_func 0x8195524
 thumb_func 0x8195538 CopyDomeBrainTrainerName
@@ -13121,84 +13121,84 @@ thumb_func 0x819587c
 thumb_func 0x81958e4
 thumb_func 0x8195928
 thumb_func 0x81959b8
-thumb_func 0x8195a10
+thumb_func 0x8195a10 InitMatchCallCounters
 thumb_func 0x8195a34 GetCurrentTotalMinutes
-thumb_func 0x8195a58
-thumb_func 0x8195a8c
-thumb_func 0x8195ad8
-thumb_func 0x8195b40
-thumb_func 0x8195b68
-thumb_func 0x8195bcc
-thumb_func 0x8195bf8
-thumb_func 0x8195c34
-thumb_func 0x8195c80
+thumb_func 0x8195a58 UpdateMatchCallMinutesCounter
+thumb_func 0x8195a8c CheckMatchCallChance
+thumb_func 0x8195ad8 MapAllowsMatchCall
+thumb_func 0x8195b40 UpdateMatchCallStepCounter
+thumb_func 0x8195b68 SelectMatchCallTrainer
+thumb_func 0x8195bcc GetNumRegisteredNPCs
+thumb_func 0x8195bf8 GetActiveMatchCallTrainerId
+thumb_func 0x8195c34 TryStartMatchCall
+thumb_func 0x8195c80 StartMatchCallFromScript
 thumb_func 0x8195c94
-thumb_func 0x8195ca8
-thumb_func 0x8195ce0
-thumb_func 0x8195d2c
-thumb_func 0x8195df0
-thumb_func 0x8195e74
+thumb_func 0x8195ca8 StartMatchCall
+thumb_func 0x8195ce0 ExecuteMatchCall
+thumb_func 0x8195d2c LoadMatchCallWindowGfx
+thumb_func 0x8195df0 MoveMatchCallWindowToVram
+thumb_func 0x8195e74 PrintMatchCallIntroEllipsis
 thumb_func 0x8195eb0
 thumb_func 0x8195ed8
 thumb_func 0x8195f30
 thumb_func 0x8195f90
 thumb_func 0x8195ff0
-thumb_func 0x819605c
-thumb_func 0x81961d8
-thumb_func 0x8196248
+thumb_func 0x819605c DrawMatchCallTextBoxBorder
+thumb_func 0x81961d8 InitMatchCallTextPrinter
+thumb_func 0x8196248 ExecuteMatchCallTextPrinter
 thumb_func 0x8196294
 thumb_func 0x8196310 TrainerIsEligibleForRematch
-thumb_func 0x819632c
-thumb_func 0x8196348
+thumb_func 0x819632c GetRematchTrainerLocation
+thumb_func 0x8196348 GetNumRematchTrainersFought
 thumb_func 0x8196374
-thumb_func 0x81963ac
-thumb_func 0x8196444
+thumb_func 0x81963ac SelectMatchCallMessage
+thumb_func 0x8196444 GetTrainerMatchCallId
 thumb_func 0x8196464 GetSameRouteMatchCallText
 thumb_func 0x8196490 GetDifferentRouteMatchCallText
-thumb_func 0x81964bc
-thumb_func 0x8196510
-thumb_func 0x81965e0
+thumb_func 0x81964bc GetBattleMatchCallText
+thumb_func 0x8196510 GetGeneralMatchCallText
+thumb_func 0x81965e0 BuildMatchCallString
 thumb_func 0x81965fc PopulateMatchCallStringVars
-thumb_func 0x819662c
-thumb_func 0x8196644
-thumb_func 0x8196698
-thumb_func 0x81966b4
-thumb_func 0x819674c
-thumb_func 0x8196794
-thumb_func 0x819686c
-thumb_func 0x81968e8
-thumb_func 0x8196908
-thumb_func 0x8196940
+thumb_func 0x819662c PopulateMatchCallStringVar
+thumb_func 0x8196644 PopulateTrainerName
+thumb_func 0x8196698 PopulateMapName
+thumb_func 0x81966b4 GetLandEncounterSlot
+thumb_func 0x819674c GetWaterEncounterSlot
+thumb_func 0x8196794 PopulateSpeciesFromTrainerLocation
+thumb_func 0x819686c atk50_openpartyscreen
+thumb_func 0x81968e8 PopulateBattleFrontierFacilityName
+thumb_func 0x8196908 PopulateBattleFrontierStreak
+thumb_func 0x8196940 GetNumOwnedBadges
 thumb_func 0x8196968
-thumb_func 0x81969f8
-thumb_func 0x8196b84
+thumb_func 0x81969f8 GetFrontierStreakInfo
+thumb_func 0x8196b84 GetPokedexRatingLevel
 thumb_func 0x8196c74
 thumb_func 0x8196d78
 thumb_func 0x8196db8
-thumb_func 0x8196dc4
+thumb_func 0x8196dc4 InitStandardTextBoxWindows
 thumb_func 0x8196de8
 thumb_func 0x8196df4
-thumb_func 0x8196e18
-thumb_func 0x8196e2c
-thumb_func 0x8196eb8
-thumb_func 0x8196f04
+thumb_func 0x8196e18 RunTextPrintersAndIsPrinter0Active
+thumb_func 0x8196e2c AddTextPrinterParameterized2
+thumb_func 0x8196eb8 AddTextPrinterForMessage
+thumb_func 0x8196f04 AddTextPrinterForMessage_2
 thumb_func 0x8196f50 AddTextPrinterWithCustomSpeedForMessage
 thumb_func 0x8196f98
 thumb_func 0x8196fb8
 thumb_func 0x8196ff0
 thumb_func 0x8197028
 thumb_func 0x8197060
-thumb_func 0x8197098
+thumb_func 0x8197098 WindowFunc_DrawStandardFrame
 thumb_func 0x81971e8
-thumb_func 0x81975a0
-thumb_func 0x81975e8
-thumb_func 0x8197638
+thumb_func 0x81975a0 WindowFunc_ClearStdWindowAndFrame
+thumb_func 0x81975e8 WindowFunc_ClearDialogWindowAndFrame
+thumb_func 0x8197638 SetStandardWindowBorderStyle
 thumb_func 0x8197650
 thumb_func 0x8197680
-thumb_func 0x8197694
+thumb_func 0x8197694 Menu_LoadStdPalAt
 thumb_func 0x81976ac
 thumb_func 0x81976b4
-thumb_func 0x81976d0
+thumb_func 0x81976d0 DisplayItemMessageOnField
 thumb_func 0x8197714
 thumb_func 0x819773c
 thumb_func 0x8197768
@@ -13208,21 +13208,21 @@ thumb_func 0x819780c
 thumb_func 0x8197818
 thumb_func 0x8197834
 thumb_func 0x819783c
-thumb_func 0x8197844
+thumb_func 0x8197844 AddMapNamePopUpWindow
 thumb_func 0x819787c
 thumb_func 0x8197888
-thumb_func 0x81978a4
+thumb_func 0x81978a4 AddTextPrinterWithCallbackForMessage
 thumb_func 0x81978f0
-thumb_func 0x8197924
-thumb_func 0x819796c
+thumb_func 0x8197924 DrawDialogFrameWithCustomTileAndPalette
+thumb_func 0x819796c DrawDialogFrameWithCustomTile
 thumb_func 0x81979bc
 thumb_func 0x8197ebc
-thumb_func 0x8197ef4
-thumb_func 0x8197f44
+thumb_func 0x8197ef4 WindowFunc_ClearDialogWindowAndFrameNullPalette
+thumb_func 0x8197f44 DrawStdFrameWithCustomTileAndPalette
 thumb_func 0x8197f8c
-thumb_func 0x8197fdc
+thumb_func 0x8197fdc WindowFunc_DrawStdFrameWithCustomTileAndPalette
 thumb_func 0x8198134
-thumb_func 0x819816c
+thumb_func 0x819816c WindowFunc_ClearStdWindowAndFrameToTransparent
 thumb_func 0x81981b4
 thumb_func 0x8198244
 thumb_func 0x81982e8
@@ -13233,17 +13233,17 @@ thumb_func 0x819844c
 thumb_func 0x81984b0
 thumb_func 0x81984f0
 thumb_func 0x819854c
-thumb_func 0x81985e8
-thumb_func 0x819862c
-thumb_func 0x8198670
-thumb_func 0x819867c
-thumb_func 0x81986e8
-thumb_func 0x8198768
-thumb_func 0x81987d4
-thumb_func 0x8198850
+thumb_func 0x81985e8 Menu_MoveCursor
+thumb_func 0x819862c Menu_MoveCursorNoWrapAround
+thumb_func 0x8198670 Menu_GetCursorPos
+thumb_func 0x819867c Menu_ProcessInput
+thumb_func 0x81986e8 Menu_ProcessInputNoWrap
+thumb_func 0x8198768 ProcessMenuInput_other
+thumb_func 0x81987d4 Menu_ProcessInputNoWrapAround_other
+thumb_func 0x8198850 PrintTextArray
 thumb_func 0x81988cc
 thumb_func 0x8198964
-thumb_func 0x81989b4
+thumb_func 0x81989b4 AddItemMenuActionTextPrinters
 thumb_func 0x8198ac8
 thumb_func 0x8198b34 SetWindowTemplateFields
 thumb_func 0x8198b60 CreateWindowTemplate
@@ -13251,7 +13251,7 @@ thumb_func 0x8198bb4
 thumb_func 0x8198c08
 thumb_func 0x8198d44
 thumb_func 0x8198d68 Menu_ProcessInputNoWrapClearOnChoose
-thumb_func 0x8198d88
+thumb_func 0x8198d88 MovementType_WalkSequenceUpLeftDownRight_callback
 thumb_func 0x8198da4
 thumb_func 0x8198e64
 thumb_func 0x8198ecc
@@ -13262,157 +13262,157 @@ thumb_func 0x8199170
 thumb_func 0x8199250
 thumb_func 0x8199314
 thumb_func 0x81993a0
-thumb_func 0x8199450
+thumb_func 0x8199450 Menu_ProcessInputGridLayout
 thumb_func 0x81994f4
 thumb_func 0x81995a0
 thumb_func 0x8199640
-thumb_func 0x8199654
-thumb_func 0x8199668
+thumb_func 0x8199654 schedule_bg_copy_tilemap_to_vram
+thumb_func 0x8199668 do_scheduled_bg_tilemap_copies_to_vram
 thumb_func 0x81996b8 reset_temp_tile_data_buffers
-thumb_func 0x81996dc
-thumb_func 0x8199728
-thumb_func 0x81997a0
-thumb_func 0x819981c
-thumb_func 0x8199858
-thumb_func 0x8199888
+thumb_func 0x81996dc free_temp_tile_data_buffers_if_possible
+thumb_func 0x8199728 decompress_and_copy_tile_data_to_vram
+thumb_func 0x81997a0 DecompressAndLoadBgGfxUsingHeap
+thumb_func 0x819981c task_free_buf_after_copying_tile_data_to_vram
+thumb_func 0x8199858 malloc_and_decompress
+thumb_func 0x8199888 copy_decompressed_tile_data_to_vram
 thumb_func 0x81998c8
 thumb_func 0x8199954
 thumb_func 0x81999d4
 thumb_func 0x8199a30
 thumb_func 0x8199a88
-thumb_func 0x8199afc
-thumb_func 0x8199b84
-thumb_func 0x8199c0c
-thumb_func 0x8199cbc
+thumb_func 0x8199afc AddTextPrinterParameterized3
+thumb_func 0x8199b84 AddTextPrinterParameterized4
+thumb_func 0x8199c0c AddTextPrinterParameterized5
+thumb_func 0x8199cbc PrintPlayerNameOnWindow
 thumb_func 0x8199d18
 thumb_func 0x8199ef4
 thumb_func 0x8199f14
 thumb_func 0x8199f54
-thumb_func 0x8199f90
+thumb_func 0x8199f90 blit_move_info_icon
 thumb_func 0x8199fdc
 thumb_func 0x819a0ec
-thumb_func 0x819a168
+thumb_func 0x819a168 Select_CB2
 thumb_func 0x819a184
-thumb_func 0x819a198
-thumb_func 0x819a1b4
-thumb_func 0x819a64c
-thumb_func 0x819a6b8
-thumb_func 0x819a7e0
-thumb_func 0x819a848
-thumb_func 0x819a8b0
-thumb_func 0x819a918
-thumb_func 0x819a980
-thumb_func 0x819aa4c
-thumb_func 0x819aaa8
-thumb_func 0x819ac08
-thumb_func 0x819accc
-thumb_func 0x819adc4
-thumb_func 0x819b018
-thumb_func 0x819b124
-thumb_func 0x819b2dc
-thumb_func 0x819b404
-thumb_func 0x819b4e4
-thumb_func 0x819b574
+thumb_func 0x819a198 DoBattleFactorySelectScreen
+thumb_func 0x819a1b4 CB2_InitSelectScreen
+thumb_func 0x819a64c Select_InitMonsData
+thumb_func 0x819a6b8 Select_InitAllSprites
+thumb_func 0x819a7e0 Select_DestroyAllSprites
+thumb_func 0x819a848 Select_UpdateBallCursorPosition
+thumb_func 0x819a8b0 Select_UpdateMenuCursorPosition
+thumb_func 0x819a918 Select_UpdateYesNoCursorPosition
+thumb_func 0x819a980 Select_HandleMonSelectionChange
+thumb_func 0x819aa4c Select_SetBallSpritePaletteNum
+thumb_func 0x819aaa8 Task_FromSelectScreenToSummaryScreen
+thumb_func 0x819ac08 Task_CloseSelectionScreen
+thumb_func 0x819accc Task_HandleSelectionScreenYesNo
+thumb_func 0x819adc4 Task_HandleSelectionScreenMenu
+thumb_func 0x819b018 Task_HandleSelectionScreenChooseMons
+thumb_func 0x819b124 CreateFrontierFactorySelectableMons
+thumb_func 0x819b2dc CreateTentFactorySelectableMons
+thumb_func 0x819b404 Select_CopyMonsToPlayerParty
+thumb_func 0x819b4e4 Select_ShowMenuOptions
+thumb_func 0x819b574 Select_ShowYesNoOptions
 thumb_func 0x819b5f8
 thumb_func 0x819b654
-thumb_func 0x819b688
-thumb_func 0x819b708
-thumb_func 0x819b76c
-thumb_func 0x819b7a0
-thumb_func 0x819b84c
-thumb_func 0x819b8a8
+thumb_func 0x819b688 Select_PrintMonSpecies
+thumb_func 0x819b708 Select_PrintSelectMonString
+thumb_func 0x819b76c Select_PrintCantSelectSameMon
+thumb_func 0x819b7a0 Select_PrintMenuOptions
+thumb_func 0x819b84c Select_PrintYesNoOptions
+thumb_func 0x819b8a8 Select_RunMenuOptionFunc
 thumb_func 0x819b8c0
-thumb_func 0x819b8d4
+thumb_func 0x819b8d4 Select_OptionRentDeselect
 thumb_func 0x819b940
 thumb_func 0x819b970
-thumb_func 0x819b974
-thumb_func 0x819b99c
-thumb_func 0x819ba58
+thumb_func 0x819b974 Select_OptionOthers
+thumb_func 0x819b99c Select_PrintMonCategory
+thumb_func 0x819ba58 Summary_ShowMonSprite
 thumb_func 0x819bb08
-thumb_func 0x819bb1c
-thumb_func 0x819bc14
+thumb_func 0x819bb1c Select_ShowSummaryMonSprite
+thumb_func 0x819bc14 Select_ShowChosenMonsSprites
 thumb_func 0x819bd28
 thumb_func 0x819bde8
 thumb_func 0x819beb8
 thumb_func 0x819bfbc
 thumb_func 0x819c19c
 thumb_func 0x819c250
-thumb_func 0x819c2b8
-thumb_func 0x819c31c
-thumb_func 0x819c384
-thumb_func 0x819c4c8
-thumb_func 0x819c4e4
-thumb_func 0x819c4f8
-thumb_func 0x819c5f4
-thumb_func 0x819c6f0
-thumb_func 0x819c804
+thumb_func 0x819c2b8 Select_SetWinRegs
+thumb_func 0x819c31c Select_AreSpeciesValid
+thumb_func 0x819c384 Task_SelectFadeSpeciesName
+thumb_func 0x819c4c8 Swap_CB2
+thumb_func 0x819c4e4 FldEff_UseCutOnTree
+thumb_func 0x819c4f8 CopySwappedMonData
+thumb_func 0x819c5f4 Task_FromSwapScreenToSummaryScreen
+thumb_func 0x819c6f0 Task_CloseSwapScreen
+thumb_func 0x819c804 Task_HandleSwapScreenYesNo
 thumb_func 0x819c8c4
 thumb_func 0x819c90c
 thumb_func 0x819c95c
 thumb_func 0x819c9bc
-thumb_func 0x819ca1c
-thumb_func 0x819cb28
-thumb_func 0x819cc3c
-thumb_func 0x819cd4c
+thumb_func 0x819ca1c Task_HandleSwapScreenMenu
+thumb_func 0x819cb28 Task_HandleSwapScreenChooseMons
+thumb_func 0x819cc3c Task_SwapFadeSpeciesName
+thumb_func 0x819cd4c Task_SwapFadeSpeciesName2
 thumb_func 0x819ce14
 thumb_func 0x819d00c
 thumb_func 0x819d270
 thumb_func 0x819d458
 thumb_func 0x819d6d4
-thumb_func 0x819d8c0
+thumb_func 0x819d8c0 Swap_InitStruct
 thumb_func 0x819d8e8
-thumb_func 0x819d904
-thumb_func 0x819ddc8
-thumb_func 0x819e240
-thumb_func 0x819e310
-thumb_func 0x819e39c
-thumb_func 0x819e3f0
-thumb_func 0x819e460
-thumb_func 0x819e4c8
+thumb_func 0x819d904 CB2_InitSwapScreen
+thumb_func 0x819ddc8 Swap_InitAllSprites
+thumb_func 0x819e240 Swap_DestroyAllSprites
+thumb_func 0x819e310 Swap_HandleActionCursorChange
+thumb_func 0x819e39c Swap_UpdateBallCursorPosition
+thumb_func 0x819e3f0 Swap_UpdateActionCursorPosition
+thumb_func 0x819e460 Swap_UpdateYesNoCursorPosition
+thumb_func 0x819e4c8 Swap_UpdateMenuCursorPosition
 thumb_func 0x819e540
 thumb_func 0x819e5f4
-thumb_func 0x819e64c
-thumb_func 0x819e6e8
+thumb_func 0x819e64c Swap_ShowMenuOptions
+thumb_func 0x819e6e8 Swap_ShowYesNoOptions
 thumb_func 0x819e76c
 thumb_func 0x819e7c8
 thumb_func 0x819e7fc
 thumb_func 0x819e844
-thumb_func 0x819e864
-thumb_func 0x819e898
-thumb_func 0x819e93c
-thumb_func 0x819e970
-thumb_func 0x819e9e4
+thumb_func 0x819e864 Swap_PrintPkmnSwap
+thumb_func 0x819e898 Swap_PrintMonSpecies
+thumb_func 0x819e93c Swap_PrintOnInfoWindow
+thumb_func 0x819e970 Swap_PrintMenuOptions
+thumb_func 0x819e9e4 Swap_PrintYesNoOptions
 thumb_func 0x819ea40
 thumb_func 0x819eab0
 thumb_func 0x819eb18
 thumb_func 0x819eb80
-thumb_func 0x819ebf0
+thumb_func 0x819ebf0 Swap_PrintMonSpecies2
 thumb_func 0x819ed38
-thumb_func 0x819ee50
-thumb_func 0x819ef34
-thumb_func 0x819ef8c
+thumb_func 0x819ee50 Swap_PrintMonCategory
+thumb_func 0x819ef34 Swap_InitActions
+thumb_func 0x819ef8c Swap_RunMenuOptionFunc
 thumb_func 0x819efb8
 thumb_func 0x819f000
 thumb_func 0x819f020
-thumb_func 0x819f070
+thumb_func 0x819f070 Swap_RunActionFunc
 thumb_func 0x819f098 Swap_ActionCancel
 thumb_func 0x819f0c8 Swap_ActionPkmnForSwap
-thumb_func 0x819f0f8
+thumb_func 0x819f0f8 Swap_ActionMon
 thumb_func 0x819f1a0
-thumb_func 0x819f1f0
+thumb_func 0x819f1f0 Swap_ShowSummaryMonSprite
 thumb_func 0x819f2e4
 thumb_func 0x819f330
-thumb_func 0x819f374
-thumb_func 0x819f488
+thumb_func 0x819f374 Task_SwapCantHaveSameMons
+thumb_func 0x819f488 Swap_AlreadyHasSameSpecies
 thumb_func 0x819f4ec
 thumb_func 0x819f540
 thumb_func 0x819f588
 thumb_func 0x819f6a0
-thumb_func 0x819f7cc
-thumb_func 0x819f888
+thumb_func 0x819f7cc Swap_ShowMonSprite
+thumb_func 0x819f888 CopyFriendsApprenticeChallengeText
 thumb_func 0x819f928
 thumb_func 0x819f934 ResetApprenticeStruct
-thumb_func 0x819f978
+thumb_func 0x819f978 ResetAllApprenticeData
 thumb_func 0x819fa88 IsPlayersApprenticeActive
 thumb_func 0x819faa0
 thumb_func 0x819fb18 SetPlayersApprenticeLvlMode
@@ -13425,13 +13425,13 @@ thumb_func 0x81a00c4 GetLatestLearnedMoves
 thumb_func 0x81a0160
 thumb_func 0x81a026c
 thumb_func 0x81a03c4
-thumb_func 0x81a05d4
-thumb_func 0x81a064c
-thumb_func 0x81a06b0
-thumb_func 0x81a06cc
+thumb_func 0x81a05d4 Task_ChooseAnswer
+thumb_func 0x81a064c CreateAndShowWindow
+thumb_func 0x81a06b0 RemoveAndHideWindow
+thumb_func 0x81a06cc CreateChooseAnswerTask
 thumb_func 0x81a0724
 thumb_func 0x81a0738 nullsub_111
-thumb_func 0x81a0744
+thumb_func 0x81a0744 Script_ResetPlayerApprentice
 thumb_func 0x81a0804
 thumb_func 0x81a082c
 thumb_func 0x81a0840
@@ -13440,27 +13440,27 @@ thumb_func 0x81a0858
 thumb_func 0x81a087c
 thumb_func 0x81a0898
 thumb_func 0x81a08e8
-thumb_func 0x81a08fc
-thumb_func 0x81a0938
-thumb_func 0x81a0b64
+thumb_func 0x81a08fc Task_WaitForPrintingMessage
+thumb_func 0x81a0938 PrintMessage
+thumb_func 0x81a0b64 Script_PrintMessage
 thumb_func 0x81a0b88
 thumb_func 0x81a0c08
 thumb_func 0x81a0c48
 thumb_func 0x81a0c9c
 thumb_func 0x81a0ebc
-thumb_func 0x81a0ed4
+thumb_func 0x81a0ed4 AtkCanceller_UnableToUseMove
 thumb_func 0x81a1104
 thumb_func 0x81a1124
 thumb_func 0x81a1130
 thumb_func 0x81a127c
 thumb_func 0x81a1344
 thumb_func 0x81a1418
-thumb_func 0x81a14b0
+thumb_func 0x81a14b0 Script_SetPlayerApprenticeTrainerGfxId
 thumb_func 0x81a1544
 thumb_func 0x81a1550
 thumb_func 0x81a155c
-thumb_func 0x81a1584
-thumb_func 0x81a15d4
+thumb_func 0x81a1584 Task_ExecuteFuncAfterButtonPress
+thumb_func 0x81a15d4 ExecuteFuncAfterButtonPress
 thumb_func 0x81a1604
 thumb_func 0x81a1628
 thumb_func 0x81a163c nullsub_110
@@ -13468,12 +13468,12 @@ thumb_func 0x81a1648
 thumb_func 0x81a16d8
 thumb_func 0x81a1810
 thumb_func 0x81a197c
-thumb_func 0x81a19c4
+thumb_func 0x81a19c4 DoSoftReset_
 thumb_func 0x81a19d0
 thumb_func 0x81a19e0
-thumb_func 0x81a1a40
+thumb_func 0x81a1a40 ShowFacilityResultsWindow
 thumb_func 0x81a1acc
-thumb_func 0x81a1af4
+thumb_func 0x81a1af4 PrintLinkBattleRecord
 thumb_func 0x81a1b8c
 thumb_func 0x81a1bc4 TowerGetWinStreak
 thumb_func 0x81a1bf4
@@ -13501,7 +13501,7 @@ thumb_func 0x81a2924
 thumb_func 0x81a2974
 thumb_func 0x81a29a4
 thumb_func 0x81a29d4
-thumb_func 0x81a2a78
+thumb_func 0x81a2a78 ScriptCmd_end
 thumb_func 0x81a2b9c
 thumb_func 0x81a2c38
 thumb_func 0x81a2c70
@@ -13511,12 +13511,12 @@ thumb_func 0x81a2de4
 thumb_func 0x81a2f90
 thumb_func 0x81a337c
 thumb_func 0x81a33a0
-thumb_func 0x81a3460
+thumb_func 0x81a3460 CopyFrontierTrainerText
 thumb_func 0x81a36a0
-thumb_func 0x81a375c
+thumb_func 0x81a375c GetCurrentFacilityWinStreak
 thumb_func 0x81a3864
 thumb_func 0x81a3898
-thumb_func 0x81a38c8
+thumb_func 0x81a38c8 GetPlayerSymbolCountForFacility
 thumb_func 0x81a38fc
 thumb_func 0x81a3ac8
 thumb_func 0x81a3af0
@@ -13531,239 +13531,239 @@ thumb_func 0x81a409c
 thumb_func 0x81a40c8
 thumb_func 0x81a4108
 thumb_func 0x81a4208
-thumb_func 0x81a4220
+thumb_func 0x81a4220 Print1PRecord
 thumb_func 0x81a42f4
 thumb_func 0x81a43f8
-thumb_func 0x81a44cc
+thumb_func 0x81a44cc Fill2PRecords
 thumb_func 0x81a45b0
-thumb_func 0x81a469c
-thumb_func 0x81a46e4
-thumb_func 0x81a4710
+thumb_func 0x81a469c ShowRankingHallRecordsWindow
+thumb_func 0x81a46e4 ScrollRankingHallRecordsWindow
+thumb_func 0x81a4710 ClearRankingHallRecords
 thumb_func 0x81a482c
 thumb_func 0x81a48ac
 thumb_func 0x81a48f8
-thumb_func 0x81a4944
-thumb_func 0x81a49a8
-thumb_func 0x81a49c8
-thumb_func 0x81a49f4
-thumb_func 0x81a4be0
-thumb_func 0x81a4c20
-thumb_func 0x81a4c50
-thumb_func 0x81a4ca0
-thumb_func 0x81a4ce0
-thumb_func 0x81a4d2c
-thumb_func 0x81a4d98
+thumb_func 0x81a4944 CopyFrontierBrainTrainerName
+thumb_func 0x81a49a8 IsFrontierBrainFemale
+thumb_func 0x81a49c8 SetFrontierBrainEventObjGfx_2
+thumb_func 0x81a49f4 CreateFrontierBrainPokemon
+thumb_func 0x81a4be0 GetFrontierBrainMonSpecies
+thumb_func 0x81a4c20 SetFrontierBrainEventObjGfx
+thumb_func 0x81a4c50 GetFrontierBrainMonMove
+thumb_func 0x81a4ca0 GetFrontierBrainMonNature
+thumb_func 0x81a4ce0 GetFrontierBrainMonEvs
+thumb_func 0x81a4d2c GetFronterBrainSymbol
+thumb_func 0x81a4d98 CopyFrontierBrainText
 thumb_func 0x81a4e28
 thumb_func 0x81a4e3c nullsub_113
-thumb_func 0x81a4e48
-thumb_func 0x81a5148
-thumb_func 0x81a5288
+thumb_func 0x81a4e48 BattleArena_ShowJudgmentWindow
+thumb_func 0x81a5148 ShowJudgmentSprite
+thumb_func 0x81a5288 SpriteCb_JudgmentIcon
 thumb_func 0x81a52a4 BattleArena_InitPoints
 thumb_func 0x81a52d8 BattleArena_AddMindPoints
-thumb_func 0x81a5308
-thumb_func 0x81a53d4
+thumb_func 0x81a5308 BattleArena_AddSkillPoints
+thumb_func 0x81a53d4 BattleArena_DeductMindPoints
 thumb_func 0x81a545c
-thumb_func 0x81a54a4
-thumb_func 0x81a5554
-thumb_func 0x81a55ec
+thumb_func 0x81a54a4 InitArenaChallenge
+thumb_func 0x81a5554 GetArenaData
+thumb_func 0x81a55ec SetArenaData
 thumb_func 0x81a56b4
-thumb_func 0x81a56f8
-thumb_func 0x81a5778
-thumb_func 0x81a57d0
-thumb_func 0x81a57e8
+thumb_func 0x81a56f8 SetArenaRewardItem
+thumb_func 0x81a5778 GiveArenaRewardItem
+thumb_func 0x81a57d0 BufferArenaOpponentName
+thumb_func 0x81a57e8 DrawArenaRefereeTextBox
 thumb_func 0x81a5ad8
 thumb_func 0x81a5c0c
 thumb_func 0x81a5c20 nullsub_1141
-thumb_func 0x81a5c2c
-thumb_func 0x81a5d40
-thumb_func 0x81a5dec
+thumb_func 0x81a5c2c InitFactoryChallenge
+thumb_func 0x81a5d40 GetBattleFactoryData
+thumb_func 0x81a5dec SetBattleFactoryData
 thumb_func 0x81a5ed4
 thumb_func 0x81a5f18 nullsub_115
 thumb_func 0x81a5f1c nullsub_114
-thumb_func 0x81a5f20
+thumb_func 0x81a5f20 SelectInitialRentalMons
 thumb_func 0x81a5f30
 thumb_func 0x81a5f3c
-thumb_func 0x81a5f48
-thumb_func 0x81a6150
-thumb_func 0x81a6164
-thumb_func 0x81a625c
-thumb_func 0x81a6584
-thumb_func 0x81a67a0
+thumb_func 0x81a5f48 GenerateOpponentMons
+thumb_func 0x81a6150 VBlankCB_EvolutionScene
+thumb_func 0x81a6164 SetRentalsToOpponentParty
+thumb_func 0x81a625c SetPlayerAndOpponentParties
+thumb_func 0x81a6584 GenerateInitialRentalMons
+thumb_func 0x81a67a0 GetOpponentMostCommonMonType
 thumb_func 0x81a6884 GetOpponentBattleStyle
-thumb_func 0x81a693c
+thumb_func 0x81a693c GetMoveBattleStyle
 thumb_func 0x81a698c InBattleFactory
-thumb_func 0x81a69b4
+thumb_func 0x81a69b4 RestorePlayerPartyHeldItems
 thumb_func 0x81a6a40 GetFactoryMonFixedIV
-thumb_func 0x81a6a68
-thumb_func 0x81a6c88
+thumb_func 0x81a6a68 FillFactoryBrainParty
+thumb_func 0x81a6c88 GetMonSetId
 thumb_func 0x81a6d08 GetNumPastRentalsRank
-thumb_func 0x81a6d4c
-thumb_func 0x81a6dbc
+thumb_func 0x81a6d4c GetAiScriptsInBattleFactory
+thumb_func 0x81a6dbc SetMonMoveAvoidReturn
 thumb_func 0x81a6dd4
 thumb_func 0x81a6de8 nullsub_117
-thumb_func 0x81a6df4
+thumb_func 0x81a6df4 SetRoomType
 thumb_func 0x81a6e08
-thumb_func 0x81a6ec0
-thumb_func 0x81a6fc8
-thumb_func 0x81a7138
+thumb_func 0x81a6ec0 GetBattlePikeData
+thumb_func 0x81a6fc8 SetBattlePikeData
+thumb_func 0x81a7138 GetInFinalRoom
 thumb_func 0x81a716c
 thumb_func 0x81a7180
 thumb_func 0x81a718c
 thumb_func 0x81a7198
 thumb_func 0x81a71e0 nullsub_118
 thumb_func 0x81a71e4 nullsub_119
-thumb_func 0x81a71e8
+thumb_func 0x81a71e8 GetRoomInflictedStatus
 thumb_func 0x81a724c
-thumb_func 0x81a7260
-thumb_func 0x81a7288
-thumb_func 0x81a7300
-thumb_func 0x81a7314
-thumb_func 0x81a73a8
-thumb_func 0x81a73fc
-thumb_func 0x81a74a8
-thumb_func 0x81a76f4
-thumb_func 0x81a776c
-thumb_func 0x81a78d8
+thumb_func 0x81a7260 HealOneOrTwoMons
+thumb_func 0x81a7288 BufferNPCMessage
+thumb_func 0x81a7300 StatusInflictionScreenFade
+thumb_func 0x81a7314 HealMon
+thumb_func 0x81a73a8 DoesAbilityPreventStatus
+thumb_func 0x81a73fc DoesTypePreventStatus
+thumb_func 0x81a74a8 TryInflictRandomStatus
+thumb_func 0x81a76f4 AtLeastOneHealthyMon
+thumb_func 0x81a776c GetNextRoomType
+thumb_func 0x81a78d8 GetNPCRoomGraphicsId
 thumb_func 0x81a7904
-thumb_func 0x81a7910
-thumb_func 0x81a7a80
+thumb_func 0x81a7910 TryGenerateBattlePikeWildMon
+thumb_func 0x81a7a80 GetBattlePikeWildMonHeaderId
 thumb_func 0x81a7ad4
-thumb_func 0x81a7b0c
-thumb_func 0x81a7b68
+thumb_func 0x81a7b0c StatusInflictionFadeOut
+thumb_func 0x81a7b68 StatusInflictionFadeIn
 thumb_func 0x81a7be0
-thumb_func 0x81a7c44
-thumb_func 0x81a7c64
-thumb_func 0x81a7cb8
+thumb_func 0x81a7c44 IsStatusInflictionScreenFadeTaskFinished
+thumb_func 0x81a7c64 Task_DoStatusInflictionScreenFade
+thumb_func 0x81a7cb8 TryHealMons
 thumb_func 0x81a7e10 GetInBattlePike
 thumb_func 0x81a7e28 InBattlePike
-thumb_func 0x81a7e5c
+thumb_func 0x81a7e5c SetHintedRoom
 thumb_func 0x81a7fdc GetHintedRoomIndex
 thumb_func 0x81a7ffc GetRoomTypeHint
-thumb_func 0x81a8024
-thumb_func 0x81a80f4
+thumb_func 0x81a8024 PrepareOneTrainer
+thumb_func 0x81a80f4 PrepareTwoTrainers
 thumb_func 0x81a8234 ClearPikeTrainerIds
-thumb_func 0x81a826c
-thumb_func 0x81a82d4
-thumb_func 0x81a8310
+thumb_func 0x81a826c BufferRecordMixingTrainerMessage
+thumb_func 0x81a82d4 AtLeastTwoAliveMons
+thumb_func 0x81a8310 GetPikeQueenFightType
 thumb_func 0x81a83bc GetCurrentRoomPikeQueenFightType
 thumb_func 0x81a83d8 HealSomeMonsBeforePikeQueen
 thumb_func 0x81a841c SetHealingRoomsDisabled
-thumb_func 0x81a8440
-thumb_func 0x81a8514
-thumb_func 0x81a8568
+thumb_func 0x81a8440 CanAnyPartyMonsBeHealed
+thumb_func 0x81a8514 BackupMonHeldItems
+thumb_func 0x81a8568 RestoreMonHeldItems
 thumb_func 0x81a85b0 InitPikeChallenge
-thumb_func 0x81a8630
+thumb_func 0x81a8630 CanEncounterWildMon
 thumb_func 0x81a868c SpeciesToPikeMonId
-thumb_func 0x81a86b4
-thumb_func 0x81a86dc
-thumb_func 0x81a8720
-thumb_func 0x81a8878
+thumb_func 0x81a86b4 InitMossdeepGymTiles
+thumb_func 0x81a86dc FinishMossdeepGymTiles
+thumb_func 0x81a8720 MossdeepGym_MoveEvents
+thumb_func 0x81a8878 MossdeepGym_TurnEvents
 thumb_func 0x81a8ae0 AddEventObject
 thumb_func 0x81a8b14
 thumb_func 0x81a8bfc
 thumb_func 0x81a8c10 nullsub_1201
-thumb_func 0x81a8c1c
-thumb_func 0x81a8cb8
-thumb_func 0x81a8dc8
+thumb_func 0x81a8c1c InitPyramidChallenge
+thumb_func 0x81a8cb8 GetBattlePyramidData
+thumb_func 0x81a8dc8 SetBattlePyramidData
 thumb_func 0x81a8eb4
-thumb_func 0x81a8efc
-thumb_func 0x81a8f7c
-thumb_func 0x81a8fd4
+thumb_func 0x81a8efc SetBattlePyramidRewardItem
+thumb_func 0x81a8f7c GiveBattlePyramidRewardItem
+thumb_func 0x81a8fd4 SeedPyramidFloor
 thumb_func 0x81a9010
-thumb_func 0x81a9140
+thumb_func 0x81a9140 HidePyramidItem
 thumb_func 0x81a918c
-thumb_func 0x81a919c
+thumb_func 0x81a919c ShowPostBattleHintText
 thumb_func 0x81a9390 UpdatePyramidWinStreak
 thumb_func 0x81a93e4 GetInBattlePyramid
-thumb_func 0x81a93fc
-thumb_func 0x81a94d4
-thumb_func 0x81a9540
-thumb_func 0x81a9554
-thumb_func 0x81a95a0
-thumb_func 0x81a95ac
-thumb_func 0x81a9710
+thumb_func 0x81a93fc UpdatePyramidLightRadius
+thumb_func 0x81a94d4 ClearPyramidPartyHeldItems
+thumb_func 0x81a9540 SetPyramidFloorPalette
+thumb_func 0x81a9554 Task_SetPyramidFloorPalette
+thumb_func 0x81a95a0 FldEff_UseSecretPowerShrub
+thumb_func 0x81a95ac RestorePyramidPlayerParty
+thumb_func 0x81a9710 GetPostBattleDirectionHintTextIndex
 thumb_func 0x81a9820
 thumb_func 0x81a983c GetBattlePyramidTrainerFlag
-thumb_func 0x81a987c
+thumb_func 0x81a987c MarkApproachingPyramidTrainersAsBattled
 thumb_func 0x81a98bc MarkPyramidTrainerAsBattled
-thumb_func 0x81a997c
+thumb_func 0x81a997c GenerateBattlePyramidWildMon
 thumb_func 0x81a9ba0 GetPyramidRunMultiplier
-thumb_func 0x81a9bb8
+thumb_func 0x81a9bb8 InBattlePyramid
 thumb_func 0x81a9be4 InBattlePyramid_
 thumb_func 0x81a9c08
-thumb_func 0x81a9c40
-thumb_func 0x81a9c54
-thumb_func 0x81a9c74
-thumb_func 0x81a9c94
-thumb_func 0x81a9cb4
+thumb_func 0x81a9c40 SoftResetInBattlePyramid
+thumb_func 0x81a9c54 CopyPyramidTrainerSpeechBefore
+thumb_func 0x81a9c74 CopyPyramidTrainerWinSpeech
+thumb_func 0x81a9c94 CopyPyramidTrainerLoseSpeech
+thumb_func 0x81a9cb4 GetBattlePyramindTrainerEncounterMusicId
 thumb_func 0x81a9cf8
-thumb_func 0x81a9d08
-thumb_func 0x81a9df0
-thumb_func 0x81a9f50
-thumb_func 0x81aa070
+thumb_func 0x81a9d08 GetUniqueTrainerId
+thumb_func 0x81a9df0 GenerateBattlePyramidFloorLayout
+thumb_func 0x81a9f50 LoadBattlePyramidEventObjectTemplates
+thumb_func 0x81aa070 LoadBattlePyramidFloorEventObjectScripts
 thumb_func 0x81aa0b4 GetPyramidEntranceAndExitSquareIds
-thumb_func 0x81aa110
-thumb_func 0x81aa250
-thumb_func 0x81aa3c0
-thumb_func 0x81aa4d8
-thumb_func 0x81aa588
+thumb_func 0x81aa110 SetPyramidObjectPositionsUniformly
+thumb_func 0x81aa250 SetPyramidObjectPositionsInAndNearSquare
+thumb_func 0x81aa3c0 SetPyramidObjectPositionsNearSquare
+thumb_func 0x81aa4d8 TrySetPyramidEventObjectPositionInSquare
+thumb_func 0x81aa588 TrySetPyramidEventObjectPositionAtCoords
 thumb_func 0x81aa6e4 GetPyramidFloorLayoutOffsets
-thumb_func 0x81aa75c
-thumb_func 0x81aa7b8
-thumb_func 0x81aa7f4
-thumb_func 0x81aa858
-thumb_func 0x81aa8e8
-thumb_func 0x81aa914
+thumb_func 0x81aa75c GetPyramidFloorTemplateId
+thumb_func 0x81aa7b8 GetNumBattlePyramidEventObjects
+thumb_func 0x81aa7f4 InitPyramidBagItems
+thumb_func 0x81aa858 GetBattlePyramidPickupItemId
+thumb_func 0x81aa8e8 ResetBagScrollPositions
+thumb_func 0x81aa914 CB2_BagMenuFromStartMenu
 thumb_func 0x81aa928
-thumb_func 0x81aa954
+thumb_func 0x81aa954 CB2_ChooseBerry
 thumb_func 0x81aa968
-thumb_func 0x81aa978
+thumb_func 0x81aa978 CB2_GoToSellMenu
 thumb_func 0x81aa98c
 thumb_func 0x81aa9a0
 thumb_func 0x81aa9c8
 thumb_func 0x81aa9e8
-thumb_func 0x81aaa08
+thumb_func 0x81aaa08 GoToBagMenu
 thumb_func 0x81aaad4
-thumb_func 0x81aaaf0
-thumb_func 0x81aab04
-thumb_func 0x81aab30
-thumb_func 0x81aadc0
-thumb_func 0x81aae2c
-thumb_func 0x81aaf60
-thumb_func 0x81aaf88
-thumb_func 0x81aafb0
+thumb_func 0x81aaaf0 c2_bag_3
+thumb_func 0x81aab04 CB2_Bag
+thumb_func 0x81aab30 SetupBagMenu
+thumb_func 0x81aadc0 BagMenu_InitBGs
+thumb_func 0x81aae2c LoadBagMenu_Graphics
+thumb_func 0x81aaf60 AccessHallOfFamePC
+thumb_func 0x81aaf88 AllocateBagItemListBuffers
+thumb_func 0x81aafb0 LoadBagItemListBuffers
 thumb_func 0x81ab10c
-thumb_func 0x81ab1c0
-thumb_func 0x81ab290
-thumb_func 0x81ab414
+thumb_func 0x81ab1c0 BagMenu_MoveCursorCallback
+thumb_func 0x81ab290 PrintItemQuantityPlusGFX
+thumb_func 0x81ab414 BagMenu_PrintDescription
 thumb_func 0x81ab4a0
-thumb_func 0x81ab4e8
-thumb_func 0x81ab508
-thumb_func 0x81ab568
+thumb_func 0x81ab4e8 BagMenu_PrintCursor_
+thumb_func 0x81ab508 BagMenu_PrintCursor
+thumb_func 0x81ab568 bag_menu_add_pocket_scroll_arrow_indicators_maybe
 thumb_func 0x81ab5d0
-thumb_func 0x81ab600
+thumb_func 0x81ab600 bag_menu_add_list_scroll_arrow_indicators_maybe
 thumb_func 0x81ab648
 thumb_func 0x81ab674
 thumb_func 0x81ab6a4
-thumb_func 0x81ab6dc
+thumb_func 0x81ab6dc TaskCloseBagMenu_2
 thumb_func 0x81ab754
 thumb_func 0x81ab818
-thumb_func 0x81ab834
+thumb_func 0x81ab834 SetInitialScrollAndCursorPositions
 thumb_func 0x81ab870 SetPocketListPositions
 thumb_func 0x81ab88c
 thumb_func 0x81ab8d8 GetItemListPosition
-thumb_func 0x81ab8f8
-thumb_func 0x81ab968
-thumb_func 0x81ab9e8
+thumb_func 0x81ab8f8 DisplayItemMessage
+thumb_func 0x81ab968 BagMenu_InitListsMenu
+thumb_func 0x81ab9e8 GetItemName
 thumb_func 0x81aba50
 thumb_func 0x81abab4
-thumb_func 0x81abc58
-thumb_func 0x81abc9c
+thumb_func 0x81abc58 set_callback3_to_bag
+thumb_func 0x81abc9c GetSwitchBagPocketDirection
 thumb_func 0x81abcfc ChangeBagPocketId
-thumb_func 0x81abd34
+thumb_func 0x81abd34 Fill1PRecords
 thumb_func 0x81abec0
 thumb_func 0x81ac000
-thumb_func 0x81ac030
+thumb_func 0x81ac030 BagMenu_DrawPocketIndicatorSquare
 thumb_func 0x81ac084
 thumb_func 0x81ac0ac
 thumb_func 0x81ac184
@@ -13772,173 +13772,173 @@ thumb_func 0x81ac354
 thumb_func 0x81ac408
 thumb_func 0x81ac8bc
 thumb_func 0x81ac938
-thumb_func 0x81ac9a8
-thumb_func 0x81ac9fc
-thumb_func 0x81aca70
+thumb_func 0x81ac9a8 unknown_item_menu_type
+thumb_func 0x81ac9fc Task_HandleInBattleItemMenuInput
+thumb_func 0x81aca70 Task_HandleOutOfBattleItemMenuInput
 thumb_func 0x81acbf4
-thumb_func 0x81acc30
-thumb_func 0x81acc74
-thumb_func 0x81accec
+thumb_func 0x81acc30 BagMenu_RemoveSomeWindow
+thumb_func 0x81acc74 ItemMenu_UseOutOfBattle
+thumb_func 0x81accec ItemMenu_Toss
 thumb_func 0x81acd80
-thumb_func 0x81ace08
-thumb_func 0x81ace3c
-thumb_func 0x81acec4
-thumb_func 0x81acf48
-thumb_func 0x81acfe4
-thumb_func 0x81ad070
-thumb_func 0x81ad0e8
-thumb_func 0x81ad104
+thumb_func 0x81ace08 BagMenu_CancelToss
+thumb_func 0x81ace3c Task_ChooseHowManyToToss
+thumb_func 0x81acec4 BagMenu_ConfirmToss
+thumb_func 0x81acf48 Task_ActuallyToss
+thumb_func 0x81acfe4 ItemMenu_Register
+thumb_func 0x81ad070 ItemMenu_Give
+thumb_func 0x81ad0e8 BagMenu_PrintThereIsNoPokemon
+thumb_func 0x81ad104 BagMenu_PrintItemCantBeHeld
 thumb_func 0x81ad148
-thumb_func 0x81ad170
-thumb_func 0x81ad190
-thumb_func 0x81ad1d4
-thumb_func 0x81ad204
-thumb_func 0x81ad214
-thumb_func 0x81ad2ac
-thumb_func 0x81ad318
-thumb_func 0x81ad3d4
+thumb_func 0x81ad170 ItemMenu_CheckTag
+thumb_func 0x81ad190 ItemMenu_Cancel
+thumb_func 0x81ad1d4 AnimRazorLeafParticle
+thumb_func 0x81ad204 bag_menu_mail_related
+thumb_func 0x81ad214 item_menu_type_2
+thumb_func 0x81ad2ac item_menu_type_b
+thumb_func 0x81ad318 UseRegisteredKeyItemOnField
+thumb_func 0x81ad3d4 DisplaySellItemAskString
 thumb_func 0x81ad478
 thumb_func 0x81ad4dc
-thumb_func 0x81ad4f4
+thumb_func 0x81ad4f4 BagMenu_CancelSell
 thumb_func 0x81ad528
 thumb_func 0x81ad57c
 thumb_func 0x81ad5a8
-thumb_func 0x81ad660
+thumb_func 0x81ad660 BagMenu_ConfirmSell
 thumb_func 0x81ad6dc
 thumb_func 0x81ad7d4
-thumb_func 0x81ad800
+thumb_func 0x81ad800 DisplayDepositItemAskString
 thumb_func 0x81ad890
 thumb_func 0x81ad928
 thumb_func 0x81ada18
-thumb_func 0x81ada60
-thumb_func 0x81ada7c
-thumb_func 0x81adb0c
-thumb_func 0x81adb7c
-thumb_func 0x81adba4
+thumb_func 0x81ada60 IsWallysBag
+thumb_func 0x81ada7c PrepareBagForWallyTutorial
+thumb_func 0x81adb0c RestoreBagAfterWallyTutorial
+thumb_func 0x81adb7c DoWallyTutorialBagMenu
+thumb_func 0x81adba4 Task_WallyTutorialBagMenu
 thumb_func 0x81adc44
 thumb_func 0x81adc78
-thumb_func 0x81adc98
+thumb_func 0x81adc98 unknown_ItemMenu_Give2
 thumb_func 0x81adcc8
-thumb_func 0x81adce8
+thumb_func 0x81adce8 unknown_ItemMenu_Confirm2
 thumb_func 0x81add0c
-thumb_func 0x81add2c
-thumb_func 0x81add94
+thumb_func 0x81add2c SetupBagMenu_Textboxes
+thumb_func 0x81add94 BagMenu_Print
 thumb_func 0x81addfc
-thumb_func 0x81ade14
+thumb_func 0x81ade14 BagMenu_AddWindow
 thumb_func 0x81ade5c
-thumb_func 0x81ade9c
+thumb_func 0x81ade9c AddItemMessageWindow
 thumb_func 0x81aded0
-thumb_func 0x81adf10
-thumb_func 0x81adf40
-thumb_func 0x81adf7c
-thumb_func 0x81adf8c
-thumb_func 0x81adfd4
+thumb_func 0x81adf10 BagMenu_YesNo
+thumb_func 0x81adf40 bag_menu_AddMoney_window
+thumb_func 0x81adf7c bag_menu_remove_money_window
+thumb_func 0x81adf8c BagMenu_PrepareTMHMMoveWindow
+thumb_func 0x81adfd4 PrintTMHMMoveData
 thumb_func 0x81ae130 nullsub_121
-thumb_func 0x81ae134
-thumb_func 0x81ae25c
-thumb_func 0x81ae288
-thumb_func 0x81ae2dc
-thumb_func 0x81ae3a0
-thumb_func 0x81ae3e4
+thumb_func 0x81ae134 DoMysteryGiftListMenu
+thumb_func 0x81ae25c ListMenuInit
+thumb_func 0x81ae288 ListMenuInitInRect
+thumb_func 0x81ae2dc ListMenu_ProcessInput
+thumb_func 0x81ae3a0 DestroyListMenuTask
+thumb_func 0x81ae3e4 RedrawListMenu
 thumb_func 0x81ae428 ChangeListMenuPals
-thumb_func 0x81ae46c
+thumb_func 0x81ae46c ChangeListMenuCoords
 thumb_func 0x81ae4a8 ListMenuTestInput
 thumb_func 0x81ae510 ListMenuGetCurrentItemArrayId
 thumb_func 0x81ae538 ListMenuGetScrollAndRow
-thumb_func 0x81ae564
-thumb_func 0x81ae5ac
-thumb_func 0x81ae68c
-thumb_func 0x81ae740
-thumb_func 0x81ae7f8
-thumb_func 0x81ae8f0
-thumb_func 0x81ae950
+thumb_func 0x81ae564 ListMenuGetYCoordForPrintingArrowCursor
+thumb_func 0x81ae5ac ListMenuInitInternal
+thumb_func 0x81ae68c ListMenuPrint
+thumb_func 0x81ae740 ListMenuPrintEntries
+thumb_func 0x81ae7f8 ListMenuDrawCursor
+thumb_func 0x81ae8f0 ListMenuAddCursorObject
+thumb_func 0x81ae950 ListMenuErasePrintedCursor
 thumb_func 0x81ae9d8 ListMenuUpdateSelectedRowIndexAndScrollOffset
-thumb_func 0x81aeac8
-thumb_func 0x81aec00
-thumb_func 0x81aecd8
+thumb_func 0x81aeac8 ListMenuScroll
+thumb_func 0x81aec00 ListMenuChangeSelection
+thumb_func 0x81aecd8 ListMenuCallSelectionChangedCallback
 thumb_func 0x81aed00 ListMenuOverrideSetColors
-thumb_func 0x81aed50
-thumb_func 0x81aed64
-thumb_func 0x81aee34
-thumb_func 0x81aef3c
-thumb_func 0x81aefc8
-thumb_func 0x81af058
-thumb_func 0x81af178
-thumb_func 0x81af1dc
-thumb_func 0x81af274
-thumb_func 0x81af2f8
+thumb_func 0x81aed50 ListMenuDefaultCursorMoveFunc
+thumb_func 0x81aed64 ListMenuGetUnkIndicatorsStructFields
+thumb_func 0x81aee34 ListMenuSetUnkIndicatorsStructField
+thumb_func 0x81aef3c SpriteCallback_ScrollIndicatorArrow
+thumb_func 0x81aefc8 AddScrollIndicatorArrowObject
+thumb_func 0x81af058 AddScrollIndicatorArrowPair
+thumb_func 0x81af178 AddScrollIndicatorArrowPairParameterized
+thumb_func 0x81af1dc Task_ScrollIndicatorArrowPair
+thumb_func 0x81af274 Task_ScrollIndicatorArrowPairOnMainMenu
+thumb_func 0x81af2f8 RemoveScrollIndicatorArrowPair
 thumb_func 0x81af358 ListMenuAddCursorObjectInternal
 thumb_func 0x81af374 ListMenuUpdateCursorObject
 thumb_func 0x81af39c ListMenuRemoveCursorObject
 thumb_func 0x81af3bc nullsub_28
 thumb_func 0x81af3c0 ListMenuGetRedOutlineCursorSpriteCount
 thumb_func 0x81af3fc ListMenuSetUpRedOutlineCursorSpriteOamTable
-thumb_func 0x81af500
+thumb_func 0x81af500 ListMenuAddRedOutlineCursorObject
 thumb_func 0x81af66c ListMenuUpdateRedOutlineCursorObject
-thumb_func 0x81af6b0
+thumb_func 0x81af6b0 ListMenuRemoveRedOutlineCursorObject
 thumb_func 0x81af708 SpriteCallback_RedArrowCursor
 thumb_func 0x81af734 nullsub_120
-thumb_func 0x81af738
+thumb_func 0x81af738 ListMenuAddRedArrowCursorObject
 thumb_func 0x81af840 ListMenuUpdateRedArrowCursorObject
-thumb_func 0x81af878
+thumb_func 0x81af878 ListMenuRemoveRedArrowCursorObject
 thumb_func 0x81af8c8 DynamicPlaceholderTextUtil_Reset
 thumb_func 0x81af8e4 DynamicPlaceholderTextUtil_SetPlaceholderPtr
-thumb_func 0x81af900
+thumb_func 0x81af900 DynamicPlaceholderTextUtil_ExpandPlaceholders
 thumb_func 0x81af94c
-thumb_func 0x81af95c
-thumb_func 0x81af9a4
-thumb_func 0x81af9b4
+thumb_func 0x81af95c IsCurMapInLocationList
+thumb_func 0x81af9a4 IsCurMapPokeCenter
+thumb_func 0x81af9b4 IsCurMapReloadLocation
 thumb_func 0x81af9c4
-thumb_func 0x81af9d4
-thumb_func 0x81afa04
+thumb_func 0x81af9d4 TrySetPokeCenterWarpStatus
+thumb_func 0x81afa04 TrySetReloadWarpStatus
 thumb_func 0x81afa34
-thumb_func 0x81afa64
+thumb_func 0x81afa64 TrySetMapSaveWarpStatus
 thumb_func 0x81afa78
 thumb_func 0x81afaa8
-thumb_func 0x81afabc
-thumb_func 0x81afafc
-thumb_func 0x81afb1c
-thumb_func 0x81afb48
-thumb_func 0x81afc0c
+thumb_func 0x81afabc AllocItemIconTemporaryBuffers
+thumb_func 0x81afafc FreeItemIconTemporaryBuffers
+thumb_func 0x81afb1c CopyItemIconPicTo4x4Buffer
+thumb_func 0x81afb48 AddItemIconSprite
+thumb_func 0x81afc0c AddCustomItemIconSprite
 thumb_func 0x81afcd4 GetItemIconPicOrPalette
-thumb_func 0x81afd10
-thumb_func 0x81afe88
+thumb_func 0x81afd10 InitPartyMenu
+thumb_func 0x81afe88 PartyMenuCallback
 thumb_func 0x81afea4
-thumb_func 0x81afeb8
-thumb_func 0x81afee4
-thumb_func 0x81b0194
-thumb_func 0x81b01d0
+thumb_func 0x81afeb8 PartyMenuInitCallback
+thumb_func 0x81afee4 PartyMenuSetup
+thumb_func 0x81b0194 PartyMenuExit
+thumb_func 0x81b01d0 PartyMenuExitTask
 thumb_func 0x81b0204 reset_brm
-thumb_func 0x81b0228
-thumb_func 0x81b02a0
-thumb_func 0x81b0398
-thumb_func 0x81b03cc
-thumb_func 0x81b0418
-thumb_func 0x81b04b8
-thumb_func 0x81b0620
-thumb_func 0x81b06e8
-thumb_func 0x81b0774
-thumb_func 0x81b07e0
-thumb_func 0x81b0838
+thumb_func 0x81b0228 AllocPartyMenuBg
+thumb_func 0x81b02a0 AllocPartyMiscGfx
+thumb_func 0x81b0398 PartyPaletteBufferCopy
+thumb_func 0x81b03cc FreePartyPointers
+thumb_func 0x81b0418 PartyMenuInitHelperStructs
+thumb_func 0x81b04b8 RenderPartyMenuBox
+thumb_func 0x81b0620 DisplayPartyPokemonData
+thumb_func 0x81b06e8 DisplayPartyPokemonSelectData
+thumb_func 0x81b0774 DisplayPartyPokemonSelectForBattle
+thumb_func 0x81b07e0 DisplayPartyPokemonSelectForContest
+thumb_func 0x81b0838 DisplayPartyPokemonSelectForRelearner
 thumb_func 0x81b0870
-thumb_func 0x81b089c
+thumb_func 0x81b089c DisplayPartyPokemonSelectHeldItemRelated
 thumb_func 0x81b08d4
-thumb_func 0x81b096c
+thumb_func 0x81b096c DisplayPartyPokemonSelectToTeachMove
 thumb_func 0x81b09c4
 thumb_func 0x81b0a70
-thumb_func 0x81b0aa4
-thumb_func 0x81b0ab8
-thumb_func 0x81b0bc4
+thumb_func 0x81b0aa4 GetPartyMiscGraphicsTile
+thumb_func 0x81b0ab8 party_menu_add_per_mon_objects_internal
+thumb_func 0x81b0bc4 party_menu_add_per_mon_objects
 thumb_func 0x81b0bf8
 thumb_func 0x81b0c9c
-thumb_func 0x81b0dc8
-thumb_func 0x81b0e5c
+thumb_func 0x81b0dc8 GetPartyBoxPalBitfield
+thumb_func 0x81b0e5c PartyBoxPal_ParnterOrDisqualifiedInArena
 thumb_func 0x81b0edc
-thumb_func 0x81b0f20
+thumb_func 0x81b0f20 IsMultiBattle
 thumb_func 0x81b0f58
 thumb_func 0x81b0f90
-thumb_func 0x81b0fc8
-thumb_func 0x81b1024
+thumb_func 0x81b0fc8 c3_0811FAB4
+thumb_func 0x81b1024 GetCursorSelectionMonId
 thumb_func 0x81b1030
 thumb_func 0x81b1040
 thumb_func 0x81b10bc
@@ -13948,15 +13948,15 @@ thumb_func 0x81b12a0
 thumb_func 0x81b1330
 thumb_func 0x81b13a4
 thumb_func 0x81b13d8
-thumb_func 0x81b1430
-thumb_func 0x81b14c8
-thumb_func 0x81b1524
-thumb_func 0x81b162c
+thumb_func 0x81b1430 PartyMenuButtonHandler
+thumb_func 0x81b14c8 UpdateCurrentPartySelection
+thumb_func 0x81b1524 SetNewPartySelectTarget1
+thumb_func 0x81b162c SetNewPartySelectTarget2
 thumb_func 0x81b17d0
-thumb_func 0x81b1814
+thumb_func 0x81b1814 GetMonNickname
 thumb_func 0x81b182c
 thumb_func 0x81b185c
-thumb_func 0x81b18a4
+thumb_func 0x81b18a4 LoadListMenuArrowsGfx
 thumb_func 0x81b18b8
 thumb_func 0x81b18ec
 thumb_func 0x81b1954
@@ -13964,13 +13964,13 @@ thumb_func 0x81b19a0
 thumb_func 0x81b19ec
 thumb_func 0x81b1a38
 thumb_func 0x81b1a88
-thumb_func 0x81b1ad0
-thumb_func 0x81b1b18
+thumb_func 0x81b1ad0 InitEventObjectPalettes
+thumb_func 0x81b1b18 pokemon_item_not_removed
 thumb_func 0x81b1b30
 thumb_func 0x81b1be8
 thumb_func 0x81b1c78
 thumb_func 0x81b1ce4 pokemon_ailments_get_primary
-thumb_func 0x81b1d2c
+thumb_func 0x81b1d2c GetMonAilment
 thumb_func 0x81b1d6c
 thumb_func 0x81b1e04
 thumb_func 0x81b1e34
@@ -13979,32 +13979,32 @@ thumb_func 0x81b1e7c
 thumb_func 0x81b1ee0
 thumb_func 0x81b1f18
 thumb_func 0x81b1f4c
-thumb_func 0x81b1fa8
+thumb_func 0x81b1fa8 CanMonLearnTMTutor
 thumb_func 0x81b2030
-thumb_func 0x81b2040
+thumb_func 0x81b2040 CanLearnTutorMove
 thumb_func 0x81b206c
 thumb_func 0x81b20f8
-thumb_func 0x81b2200
-thumb_func 0x81b2214
-thumb_func 0x81b22f4
-thumb_func 0x81b2358
+thumb_func 0x81b2200 GetPartyMenuPaletteFromBuffer
+thumb_func 0x81b2214 BlitBitmapToPartyWindow
+thumb_func 0x81b22f4 BlitBitmapToPartyWindow_Default1
+thumb_func 0x81b2358 BlitBitmapToPartyWindow_Default2
 thumb_func 0x81b23bc DrawEmptySlot
-thumb_func 0x81b23e4
-thumb_func 0x81b26d8
-thumb_func 0x81b270c
-thumb_func 0x81b2764
-thumb_func 0x81b27dc
-thumb_func 0x81b2828
-thumb_func 0x81b2890
-thumb_func 0x81b2970
-thumb_func 0x81b29d8
-thumb_func 0x81b2a08
-thumb_func 0x81b2a70
-thumb_func 0x81b2abc
-thumb_func 0x81b2af8
+thumb_func 0x81b23e4 UpdateSelectedPartyBox
+thumb_func 0x81b26d8 DisplayPartyPokemonBarDetail
+thumb_func 0x81b270c DisplayPartyPokemonNickname
+thumb_func 0x81b2764 DisplayPartyPokemonLevelCheck
+thumb_func 0x81b27dc DisplayPartyPokemonLevel
+thumb_func 0x81b2828 DisplayPartyPokemonGenderNidoranCheck
+thumb_func 0x81b2890 DisplayPartyPokemonGender
+thumb_func 0x81b2970 DisplayPartyPokemonHPCheck
+thumb_func 0x81b29d8 DisplayPartyPokemonHP
+thumb_func 0x81b2a08 DisplayPartyPokemonMaxHPCheck
+thumb_func 0x81b2a70 DisplayPartyPokemonMaxHP
+thumb_func 0x81b2abc DisplayPartyPokemonHPBarCheck
+thumb_func 0x81b2af8 DisplayPartyPokemonHPBar
 thumb_func 0x81b2c3c
 thumb_func 0x81b2cb0
-thumb_func 0x81b2cd8
+thumb_func 0x81b2cd8 display_pokemon_menu_message
 thumb_func 0x81b2dd0
 thumb_func 0x81b2e34
 thumb_func 0x81b2f90
@@ -14012,15 +14012,15 @@ thumb_func 0x81b2fdc
 thumb_func 0x81b3004
 thumb_func 0x81b3034
 thumb_func 0x81b3054
-thumb_func 0x81b30b4
+thumb_func 0x81b30b4 CreateActionList
 thumb_func 0x81b31dc
 thumb_func 0x81b32a8
 thumb_func 0x81b339c
-thumb_func 0x81b33d0
+thumb_func 0x81b33d0 HandleMenuInput
 thumb_func 0x81b349c
 thumb_func 0x81b34c8
 thumb_func 0x81b3534
-thumb_func 0x81b357c
+thumb_func 0x81b357c CursorCb_Switch
 thumb_func 0x81b35d8
 thumb_func 0x81b3778
 thumb_func 0x81b37e0
@@ -14030,13 +14030,13 @@ thumb_func 0x81b3960
 thumb_func 0x81b39e8
 thumb_func 0x81b3b00
 thumb_func 0x81b3bb0 oamt_swap_pos
-thumb_func 0x81b3c7c
+thumb_func 0x81b3c7c swap_pokemon_and_oams
 thumb_func 0x81b3d1c
-thumb_func 0x81b3d74
-thumb_func 0x81b3dd4
+thumb_func 0x81b3d74 CursorCb_Cancel1
+thumb_func 0x81b3dd4 CursorCb_Item
 thumb_func 0x81b3e38
 thumb_func 0x81b3e64
-thumb_func 0x81b3e90
+thumb_func 0x81b3e90 c2_8123744
 thumb_func 0x81b3f70
 thumb_func 0x81b3ff0
 thumb_func 0x81b4048
@@ -14046,100 +14046,100 @@ thumb_func 0x81b41cc
 thumb_func 0x81b4218
 thumb_func 0x81b42c4
 thumb_func 0x81b433c
-thumb_func 0x81b43c4
-thumb_func 0x81b4480
+thumb_func 0x81b43c4 CursorCb_TakeItem
+thumb_func 0x81b4480 CursorCb_Toss
 thumb_func 0x81b4548
-thumb_func 0x81b457c
+thumb_func 0x81b457c BagMenu_TossItems
 thumb_func 0x81b4628
-thumb_func 0x81b46a8
-thumb_func 0x81b470c
+thumb_func 0x81b46a8 CursorCb_Mail
+thumb_func 0x81b470c CursorCb_Read
 thumb_func 0x81b4738
 thumb_func 0x81b4780
-thumb_func 0x81b47c0
+thumb_func 0x81b47c0 CursorCb_TakeMail
 thumb_func 0x81b480c
 thumb_func 0x81b4840
 thumb_func 0x81b4900
 thumb_func 0x81b4934
-thumb_func 0x81b4a18
-thumb_func 0x81b4acc
-thumb_func 0x81b4b2c
+thumb_func 0x81b4a18 CursorCb_Cancel2
+thumb_func 0x81b4acc CursorCb_SendMon
+thumb_func 0x81b4b2c CursorCb_Enter
 thumb_func 0x81b4c28
-thumb_func 0x81b4c48
-thumb_func 0x81b4d4c
-thumb_func 0x81b4d68
-thumb_func 0x81b4e74
-thumb_func 0x81b4f84
-thumb_func 0x81b509c
+thumb_func 0x81b4c48 CursorCb_NoEntry
+thumb_func 0x81b4d4c CursorCb_Store
+thumb_func 0x81b4d68 CursorCb_Register
+thumb_func 0x81b4e74 CursorCb_Trade1
+thumb_func 0x81b4f84 CursorCb_Trade2
+thumb_func 0x81b509c GetFlavorRelationByPersonality
 thumb_func 0x81b50d0
-thumb_func 0x81b5110
+thumb_func 0x81b5110 CursorCb_FieldMove
 thumb_func 0x81b5314
 thumb_func 0x81b5344
 thumb_func 0x81b5378
-thumb_func 0x81b53d8
-thumb_func 0x81b53f0
-thumb_func 0x81b542c
+thumb_func 0x81b53d8 FieldCallback_PrepareFadeInFromMenu
+thumb_func 0x81b53f0 task_launch_hm_phase_2
+thumb_func 0x81b542c brm_get_selected_species
 thumb_func 0x81b5454 task_brm_cancel_1_on_keypad_a_or_b
 thumb_func 0x81b547c
 thumb_func 0x81b54a4
-thumb_func 0x81b54c0
+thumb_func 0x81b54c0 SetUpFieldMove_Surf
 thumb_func 0x81b5504
-thumb_func 0x81b5524
+thumb_func 0x81b5524 SetUpFieldMove_Fly
 thumb_func 0x81b5548
-thumb_func 0x81b5574
-thumb_func 0x81b5590
+thumb_func 0x81b5574 hm2_waterfall
+thumb_func 0x81b5590 SetUpFieldMove_Waterfall
 thumb_func 0x81b55f8
-thumb_func 0x81b5614
-thumb_func 0x81b5654
-thumb_func 0x81b56cc
+thumb_func 0x81b5614 SetUpFieldMove_Dive
+thumb_func 0x81b5654 party_menu_icon_anim
+thumb_func 0x81b56cc party_menu_link_mon_icon_anim
 thumb_func 0x81b572c
 thumb_func 0x81b57d8
-thumb_func 0x81b580c
-thumb_func 0x81b587c
-thumb_func 0x81b58a8
-thumb_func 0x81b58b4
-thumb_func 0x81b58e8
+thumb_func 0x81b580c AnimateSelectedPartyIcon
+thumb_func 0x81b587c UpdatePartyMonIconFrameAndBounce
+thumb_func 0x81b58a8 UpdatePartyMonIconFrame
+thumb_func 0x81b58b4 party_menu_held_item_object
+thumb_func 0x81b58e8 party_menu_link_mon_held_item_object
 thumb_func 0x81b5934
 thumb_func 0x81b5950
 thumb_func 0x81b59d0
 thumb_func 0x81b59ec
 thumb_func 0x81b5a90
-thumb_func 0x81b5b14
-thumb_func 0x81b5b6c
+thumb_func 0x81b5b14 SpriteCB_HeldItem
+thumb_func 0x81b5b6c party_menu_pokeball_object
 thumb_func 0x81b5b94
 thumb_func 0x81b5bd4
 thumb_func 0x81b5c14
 thumb_func 0x81b5c38
 thumb_func 0x81b5c5c
-thumb_func 0x81b5ce0
-thumb_func 0x81b5d04
-thumb_func 0x81b5d38
-thumb_func 0x81b5d84
-thumb_func 0x81b5d9c
-thumb_func 0x81b5e00
+thumb_func 0x81b5ce0 LoadPartyMenuPokeballGfx
+thumb_func 0x81b5d04 party_menu_status_condition_object
+thumb_func 0x81b5d38 party_menu_link_mon_status_condition_object
+thumb_func 0x81b5d84 party_menu_get_status_condition_and_update_object
+thumb_func 0x81b5d9c party_menu_update_status_condition_object
+thumb_func 0x81b5e00 LoadPartyMenuAilmentGfx
 thumb_func 0x81b5e1c
-thumb_func 0x81b5ef4
+thumb_func 0x81b5ef4 c2_815ABFC
 thumb_func 0x81b5f20
-thumb_func 0x81b5f70
-thumb_func 0x81b5fb0
-thumb_func 0x81b6170
+thumb_func 0x81b5f70 IsHPRecoveryItem
+thumb_func 0x81b5fb0 GetMedicineItemEffectMessage
+thumb_func 0x81b6170 UsingHPEVItemOnShedinja
 thumb_func 0x81b61a4 IsItemFlute
-thumb_func 0x81b61c0
-thumb_func 0x81b6228
+thumb_func 0x81b61c0 ExecuteTableBasedItemEffect__
+thumb_func 0x81b6228 ItemUseCB_Medicine
 thumb_func 0x81b63cc
 thumb_func 0x81b6434
 thumb_func 0x81b6468
-thumb_func 0x81b65bc
-thumb_func 0x81b663c
+thumb_func 0x81b65bc ItemEffectToMonEv
+thumb_func 0x81b663c ItemEffectToStatString
 thumb_func 0x81b66b0
-thumb_func 0x81b677c
-thumb_func 0x81b67c4
-thumb_func 0x81b6848
+thumb_func 0x81b677c ether_effect_related_3
+thumb_func 0x81b67c4 dp05_ether
+thumb_func 0x81b6848 ether_effect_related_2
 thumb_func 0x81b687c
 thumb_func 0x81b68b4
-thumb_func 0x81b6978
-thumb_func 0x81b69b4
-thumb_func 0x81b69cc
-thumb_func 0x81b69fc
+thumb_func 0x81b6978 dp05_pp_up
+thumb_func 0x81b69b4 ItemIdToBattleMoveId
+thumb_func 0x81b69cc IsMoveHm
+thumb_func 0x81b69fc MonKnowsMove
 thumb_func 0x81b6a2c
 thumb_func 0x81b6a50
 thumb_func 0x81b6a7c
@@ -14158,7 +14158,7 @@ thumb_func 0x81b6ee0
 thumb_func 0x81b6f44
 thumb_func 0x81b6f78
 thumb_func 0x81b7090
-thumb_func 0x81b70b0
+thumb_func 0x81b70b0 dp05_rare_candy
 thumb_func 0x81b71f8
 thumb_func 0x81b7280
 thumb_func 0x81b72e0
@@ -14172,12 +14172,12 @@ thumb_func 0x81b75b8
 thumb_func 0x81b7644
 thumb_func 0x81b768c
 thumb_func 0x81b76cc
-thumb_func 0x81b77f0
+thumb_func 0x81b77f0 task_sacred_ash_party_loop
 thumb_func 0x81b78b4
 thumb_func 0x81b7918
-thumb_func 0x81b7990
+thumb_func 0x81b7990 GetItemEffectType
 thumb_func 0x81b7af0
-thumb_func 0x81b7bd4
+thumb_func 0x81b7bd4 CB2_PartyMenuFromStartMenu
 thumb_func 0x81b7c00
 thumb_func 0x81b7c4c
 thumb_func 0x81b7ce4
@@ -14193,10 +14193,10 @@ thumb_func 0x81b8090
 thumb_func 0x81b80bc
 thumb_func 0x81b80e8
 thumb_func 0x81b8114
-thumb_func 0x81b81b8
+thumb_func 0x81b81b8 InitChooseHalfPartyForBattle
 thumb_func 0x81b81f8
 thumb_func 0x81b820c
-thumb_func 0x81b824c
+thumb_func 0x81b824c GetBattleEntryEligibility
 thumb_func 0x81b82fc
 thumb_func 0x81b8410
 thumb_func 0x81b843c
@@ -14209,7 +14209,7 @@ thumb_func 0x81b85a4
 thumb_func 0x81b85cc
 thumb_func 0x81b85f8
 thumb_func 0x81b8624
-thumb_func 0x81b864c
+thumb_func 0x81b864c OpenPartyMenuInBattle
 thumb_func 0x81b8690
 thumb_func 0x81b86cc
 thumb_func 0x81b871c
@@ -14221,7 +14221,7 @@ thumb_func 0x81b8b20
 thumb_func 0x81b8bd8
 thumb_func 0x81b8c0c
 thumb_func 0x81b8c50
-thumb_func 0x81b8c8c
+thumb_func 0x81b8c8c pokemon_order_func
 thumb_func 0x81b8cd0
 thumb_func 0x81b8d20
 thumb_func 0x81b8d70
@@ -14235,8 +14235,8 @@ thumb_func 0x81b8f34
 thumb_func 0x81b8fc8
 thumb_func 0x81b8ff4
 thumb_func 0x81b9030
-thumb_func 0x81b9068
-thumb_func 0x81b9080
+thumb_func 0x81b9068 hm_add_c3_without_phase_2
+thumb_func 0x81b9080 TossPokeblockChoice_No
 thumb_func 0x81b90a4
 thumb_func 0x81b90c4
 thumb_func 0x81b9110
@@ -14248,7 +14248,7 @@ thumb_func 0x81b9228
 thumb_func 0x81b9280
 thumb_func 0x81b92c0
 thumb_func 0x81b92e0
-thumb_func 0x81b932c
+thumb_func 0x81b932c ForcedMovement_Slip
 thumb_func 0x81b9370
 thumb_func 0x81b93b8
 thumb_func 0x81b9410
@@ -14280,21 +14280,21 @@ thumb_func 0x81b99c8
 thumb_func 0x81b9a1c
 thumb_func 0x81b9a38
 thumb_func 0x81b9a54
-thumb_func 0x81b9a98
+thumb_func 0x81b9a98 GetTrainerEncounterMusicId
 thumb_func 0x81b9ac0
 thumb_func 0x81b9b18
 thumb_func 0x81b9b28
 thumb_func 0x81b9b34 InSlateportBattleTent
 thumb_func 0x81b9b60
 thumb_func 0x81b9ce0
-thumb_func 0x81b9ef0
-thumb_func 0x81ba308
+thumb_func 0x81b9ef0 Font6Func
+thumb_func 0x81ba308 DecompressGlyphFont6
 thumb_func 0x81ba36c MultiBootInit
-thumb_func 0x81ba3a8
+thumb_func 0x81ba3a8 MultiBootMain
 thumb_func 0x81ba798 MultiBootSend
 thumb_func 0x81ba7e4 MultiBootStartProbe
-thumb_func 0x81ba808
-thumb_func 0x81ba8cc
+thumb_func 0x81ba808 MultiBootStartMaster
+thumb_func 0x81ba8cc MultiBootCheckComplete
 thumb_func 0x81ba8e0 MultiBootHandShake
 thumb_func 0x81ba9cc MultiBootWaitCycles
 thumb_func 0x81ba9e4 MultiBootWaitSendDone
@@ -14310,7 +14310,7 @@ thumb_func 0x81bacc8
 thumb_func 0x81bae70
 thumb_func 0x81baeb0
 thumb_func 0x81baf20
-thumb_func 0x81baf38
+thumb_func 0x81baf38 Task_GiveExpToMon
 thumb_func 0x81bb0b0
 thumb_func 0x81bb180
 thumb_func 0x81bb2c4
@@ -14318,137 +14318,137 @@ thumb_func 0x81bb324
 thumb_func 0x81bb3dc
 thumb_func 0x81bb428
 thumb_func 0x81bb4c4
-thumb_func 0x81bb534
+thumb_func 0x81bb534 CompleteOnInactiveTextPrinter
 thumb_func 0x81bb54c
 thumb_func 0x81bb5c8
 thumb_func 0x81bb63c
 thumb_func 0x81bb690
 thumb_func 0x81bb784
-thumb_func 0x81bb828
+thumb_func 0x81bb828 PlayerPartnerBufferExecCompleted
 thumb_func 0x81bb8a0
 thumb_func 0x81bb8d0
-thumb_func 0x81bb900
-thumb_func 0x81bb974
+thumb_func 0x81bb900 PlayerPartnerHandleGetMonData
+thumb_func 0x81bb974 CopyPlayerPartnerMonData
 thumb_func 0x81bc120
 thumb_func 0x81bc12c
-thumb_func 0x81bc184
+thumb_func 0x81bc184 SetPlayerPartnerMonData
 thumb_func 0x81bcb80
-thumb_func 0x81bcbf4
-thumb_func 0x81bcd10
+thumb_func 0x81bcbf4 PlayerPartnerHandleLoadMonSprite
+thumb_func 0x81bcd10 PlayerPartnerHandleSwitchInAnim
 thumb_func 0x81bcd80
 thumb_func 0x81bcefc
 thumb_func 0x81bcf8c
-thumb_func 0x81bd018
-thumb_func 0x81bd258
+thumb_func 0x81bd018 PlayerPartnerHandleDrawTrainerPic
+thumb_func 0x81bd258 PlayerPartnerHandleTrainerSlide
 thumb_func 0x81bd264
-thumb_func 0x81bd310
-thumb_func 0x81bd3fc
-thumb_func 0x81bd408
-thumb_func 0x81bd414
-thumb_func 0x81bd420
-thumb_func 0x81bd42c
-thumb_func 0x81bd564
-thumb_func 0x81bd6e8
+thumb_func 0x81bd310 PlayerPartnerHandleFaintAnimation
+thumb_func 0x81bd3fc PlayerPartnerHandlePaletteFade
+thumb_func 0x81bd408 PlayerPartnerHandleSuccessBallThrowAnim
+thumb_func 0x81bd414 PlayerPartnerHandleBallThrowAnim
+thumb_func 0x81bd420 PlayerPartnerHandlePause
+thumb_func 0x81bd42c PlayerPartnerHandleMoveAnimation
+thumb_func 0x81bd564 PlayerPartnerDoMoveAnimation
+thumb_func 0x81bd6e8 PlayerPartnerHandlePrintString
 thumb_func 0x81bd73c
-thumb_func 0x81bd748
-thumb_func 0x81bd758
-thumb_func 0x81bd764
+thumb_func 0x81bd748 PlayerPartnerHandleChooseAction
+thumb_func 0x81bd758 PlayerPartnerHandleUnknownYesNoBox
+thumb_func 0x81bd764 PlayerPartnerHandleChooseMove
 thumb_func 0x81bd80c
-thumb_func 0x81bd818
+thumb_func 0x81bd818 PlayerPartnerHandleChoosePokemon
 thumb_func 0x81bd8a0
 thumb_func 0x81bd8ac
-thumb_func 0x81bd99c
-thumb_func 0x81bda38
-thumb_func 0x81bdab0
+thumb_func 0x81bd99c PlayerPartnerHandleExpUpdate
+thumb_func 0x81bda38 PlayerPartnerHandleStatusIconUpdate
+thumb_func 0x81bdab0 PlayerPartnerHandleStatusAnimation
 thumb_func 0x81bdb18
 thumb_func 0x81bdb24
 thumb_func 0x81bdb30
 thumb_func 0x81bdb3c
 thumb_func 0x81bdb48
-thumb_func 0x81bdb54
-thumb_func 0x81bdb60
-thumb_func 0x81bdb6c
-thumb_func 0x81bdb78
+thumb_func 0x81bdb54 PlayerPartnerHandleTwoReturnValues
+thumb_func 0x81bdb60 PlayerPartnerHandleChosenMonReturnValue
+thumb_func 0x81bdb6c PlayerPartnerHandleOneReturnValue
+thumb_func 0x81bdb78 PlayerPartnerHandleOneReturnValue_Duplicate
 thumb_func 0x81bdb84 PlayerPartnerHandleCmd37
 thumb_func 0x81bdba0 PlayerPartnerHandleCmd38
 thumb_func 0x81bdbd8 PlayerPartnerHandleCmd39
 thumb_func 0x81bdbf0 PlayerPartnerHandleCmd40
-thumb_func 0x81bdc18
-thumb_func 0x81bdc88
-thumb_func 0x81bdc94
-thumb_func 0x81bdcd8
-thumb_func 0x81bdd34
+thumb_func 0x81bdc18 PlayerPartnerHandleHitAnimation
+thumb_func 0x81bdc88 PlayerPartnerHandleCmd42
+thumb_func 0x81bdc94 PlayerPartnerHandlePlaySE
+thumb_func 0x81bdcd8 PlayerPartnerHandlePlayFanfareOrBGM
+thumb_func 0x81bdd34 PlayerPartnerHandleFaintingCry
 thumb_func 0x81bdd74
-thumb_func 0x81bdda8
+thumb_func 0x81bdda8 PlayerPartnerHandleIntroTrainerBallThrow
 thumb_func 0x81bdf64
-thumb_func 0x81be070
+thumb_func 0x81be070 PlayerPartnerHandleDrawPartyStatusSummary
 thumb_func 0x81be134
 thumb_func 0x81be17c PlayerPartnerHandleHidePartyStatusSummary
-thumb_func 0x81be1cc
+thumb_func 0x81be1cc PlayerPartnerHandleEndBounceEffect
 thumb_func 0x81be1d8
-thumb_func 0x81be238
-thumb_func 0x81be2a0
-thumb_func 0x81be2ac
-thumb_func 0x81be2b8
+thumb_func 0x81be238 PlayerPartnerHandleBattleAnimation
+thumb_func 0x81be2a0 PlayerPartnerHandleLinkStandbyMsg
+thumb_func 0x81be2ac PlayerPartnerHandleResetActionMoveSelection
+thumb_func 0x81be2b8 FullSaveGame
 thumb_func 0x81be304 nullsub_127
-thumb_func 0x81be308
-thumb_func 0x81be334
+thumb_func 0x81be308 IsMirageTowerVisible
+thumb_func 0x81be334 UpdateMirageTowerPulseBlend
 thumb_func 0x81be348
-thumb_func 0x81be354
-thumb_func 0x81be3c8
-thumb_func 0x81be438
-thumb_func 0x81be490
-thumb_func 0x81be4a4
-thumb_func 0x81be538
-thumb_func 0x81be59c
-thumb_func 0x81be604
-thumb_func 0x81be630
+thumb_func 0x81be354 TryStartMirageTowerPulseBlendEffect
+thumb_func 0x81be3c8 ClearMirageTowerPulseBlendEffect
+thumb_func 0x81be438 SetMirageTowerVisibility
+thumb_func 0x81be490 StartPlayerDescendMirageTower
+thumb_func 0x81be4a4 PlayerDescendMirageTower
+thumb_func 0x81be538 StartScreenShake
+thumb_func 0x81be59c DoScreenShake
+thumb_func 0x81be604 IncrementCeilingCrumbleFinishedCount
+thumb_func 0x81be630 DoMirageTowerCeilingCrumble
 thumb_func 0x81be65c WaitCeilingCrumble
-thumb_func 0x81be69c
-thumb_func 0x81be6bc
-thumb_func 0x81be774
-thumb_func 0x81be7c0
+thumb_func 0x81be69c FinishCeilingCrumbleTask
+thumb_func 0x81be6bc CreateCeilingCrumbleSprites
+thumb_func 0x81be774 MoveCeilingCrumbleSprite
+thumb_func 0x81be7c0 SetInvisibleMirageTowerMetatiles
 thumb_func 0x81be7f0
 thumb_func 0x81be804
 thumb_func 0x81be818
-thumb_func 0x81be82c
-thumb_func 0x81be850
-thumb_func 0x81be890
-thumb_func 0x81be9ec
-thumb_func 0x81becc4
+thumb_func 0x81be82c SetBgShakeOffsets
+thumb_func 0x81be850 UpdateBgShake
+thumb_func 0x81be890 InitMirageTowerShake
+thumb_func 0x81be9ec DoMirageTowerDisintegration
+thumb_func 0x81becc4 DoFossilFallAndSink
 thumb_func 0x81beee4
 thumb_func 0x81bef54
 thumb_func 0x81bf020
 thumb_func 0x81bf0b0
 thumb_func 0x81bf0bc
-thumb_func 0x81bf280
+thumb_func 0x81bf280 ShowPokemonSummaryScreen
 thumb_func 0x81bf3cc ShowSelectMovePokemonSummaryScreen
-thumb_func 0x81bf414
-thumb_func 0x81bf430
-thumb_func 0x81bf444
-thumb_func 0x81bf470
-thumb_func 0x81bf784
-thumb_func 0x81bf810
-thumb_func 0x81bf9f8
-thumb_func 0x81bfa50
+thumb_func 0x81bf414 CallBattlePyramidFunction
+thumb_func 0x81bf430 SummaryScreen_VBlank
+thumb_func 0x81bf444 SummaryScreen_LoadingCB2
+thumb_func 0x81bf470 SummaryScreen_LoadGraphics
+thumb_func 0x81bf784 InitBGs
+thumb_func 0x81bf810 SummaryScreen_DecompressGraphics
+thumb_func 0x81bf9f8 CopyMonToSummaryStruct
+thumb_func 0x81bfa50 ExtractMonDataToSummaryStruct
 thumb_func 0x81bfc7c
 thumb_func 0x81bfd68
-thumb_func 0x81bfd80
-thumb_func 0x81bfdb8
-thumb_func 0x81bfe44
-thumb_func 0x81bff38
+thumb_func 0x81bfd80 BeginCloseSummaryScreen
+thumb_func 0x81bfdb8 CloseSummaryScreen
+thumb_func 0x81bfe44 HandleInput
+thumb_func 0x81bff38 ChangeSummaryPokemon
 thumb_func 0x81c0038
 thumb_func 0x81c022c
 thumb_func 0x81c02e8
 thumb_func 0x81c0384
-thumb_func 0x81c03c0
-thumb_func 0x81c04c0
-thumb_func 0x81c059c
-thumb_func 0x81c05f8
-thumb_func 0x81c0678
+thumb_func 0x81c03c0 ChangePage
+thumb_func 0x81c04c0 PssScrollRight
+thumb_func 0x81c059c PssScrollRightEnd
+thumb_func 0x81c05f8 PssScrollLeft
+thumb_func 0x81c0678 PssScrollLeftEnd
 thumb_func 0x81c0758 CheckExperienceProgressBar
 thumb_func 0x81c077c
-thumb_func 0x81c0878
+thumb_func 0x81c0878 HandleInput_MoveSelect
 thumb_func 0x81c0974
 thumb_func 0x81c09a4
 thumb_func 0x81c0b28
@@ -14458,12 +14458,12 @@ thumb_func 0x81c0ce4
 thumb_func 0x81c0df0
 thumb_func 0x81c0f20
 thumb_func 0x81c1050
-thumb_func 0x81c1080
-thumb_func 0x81c11dc
-thumb_func 0x81c1228
-thumb_func 0x81c1274
+thumb_func 0x81c1080 HandleReplaceMoveInput
+thumb_func 0x81c11dc CanReplaceMove
+thumb_func 0x81c1228 ShowHMMovesCantBeForgottenWindow
+thumb_func 0x81c1274 HandleHMMovesCantBeForgottenInput
 thumb_func 0x81c14c8
-thumb_func 0x81c14d4
+thumb_func 0x81c14d4 DrawPagination
 thumb_func 0x81c15e4
 thumb_func 0x81c16d8
 thumb_func 0x81c1754
@@ -14472,88 +14472,88 @@ thumb_func 0x81c18b4
 thumb_func 0x81c19a8
 thumb_func 0x81c1a24
 thumb_func 0x81c1ac8
-thumb_func 0x81c1b5c
+thumb_func 0x81c1b5c DrawPokerusCuredSymbol
 thumb_func 0x81c1bc0
-thumb_func 0x81c1c00
-thumb_func 0x81c1d40
-thumb_func 0x81c1e58
-thumb_func 0x81c1e88
-thumb_func 0x81c1ed8
+thumb_func 0x81c1c00 DrawExperienceProgressBar
+thumb_func 0x81c1d40 DrawContestMoveHearts
+thumb_func 0x81c1e58 LimitEggSummaryPageDisplay
+thumb_func 0x81c1e88 ResetWindows
+thumb_func 0x81c1ed8 SummaryScreen_PrintTextOnWindow
 thumb_func 0x81c1f1c
 thumb_func 0x81c1f5c
 thumb_func 0x81c20d8
-thumb_func 0x81c2120
+thumb_func 0x81c2120 GetBgType
 thumb_func 0x81c219c
 thumb_func 0x81c21cc
 thumb_func 0x81c23d4
 thumb_func 0x81c251c
-thumb_func 0x81c2620
-thumb_func 0x81c265c
-thumb_func 0x81c2690
+thumb_func 0x81c2620 AddWindowFromTemplateList
+thumb_func 0x81c265c SummaryScreen_RemoveWindowByIndex
+thumb_func 0x81c2690 PrintPageSpecificText
 thumb_func 0x81c26c4
-thumb_func 0x81c26d8
-thumb_func 0x81c26f4
-thumb_func 0x81c2734
+thumb_func 0x81c26d8 CreateTextPrinterTask
+thumb_func 0x81c26f4 PrintInfoPageText
+thumb_func 0x81c2734 Task_PrintInfoPage
 thumb_func 0x81c27b8
 thumb_func 0x81c2828
 thumb_func 0x81c288c
 thumb_func 0x81c28e0
 thumb_func 0x81c2934
-thumb_func 0x81c2a4c
+thumb_func 0x81c2a4c PrintMonTrainerMemo
 thumb_func 0x81c2a78
-thumb_func 0x81c2ac4
-thumb_func 0x81c2af4
-thumb_func 0x81c2bb4
-thumb_func 0x81c2bd8
-thumb_func 0x81c2bfc
+thumb_func 0x81c2ac4 GetMetLevelString
+thumb_func 0x81c2af4 DoesMonOTMatchOwner
+thumb_func 0x81c2bb4 DidMonComeFromGBAGames
+thumb_func 0x81c2bd8 DidMonComeFromRSE
+thumb_func 0x81c2bfc IsInGamePartnerMon
 thumb_func 0x81c2c54
 thumb_func 0x81c2c84
-thumb_func 0x81c2cb4
-thumb_func 0x81c2d28
-thumb_func 0x81c2dbc
-thumb_func 0x81c2de0
+thumb_func 0x81c2cb4 PrintEggState
+thumb_func 0x81c2d28 PrintEggMemo
+thumb_func 0x81c2dbc PrintSkillsPageText
+thumb_func 0x81c2de0 Task_PrintSkillsPage
 thumb_func 0x81c2e70
 thumb_func 0x81c2f08
-thumb_func 0x81c2f74
+thumb_func 0x81c2f74 BufferLeftColumnStats
 thumb_func 0x81c303c
-thumb_func 0x81c3068
+thumb_func 0x81c3068 BufferRightColumnStats
 thumb_func 0x81c30f0
 thumb_func 0x81c311c
-thumb_func 0x81c31d8
-thumb_func 0x81c3244
-thumb_func 0x81c335c
-thumb_func 0x81c3498
-thumb_func 0x81c3544
-thumb_func 0x81c3590
-thumb_func 0x81c3668
-thumb_func 0x81c36d4
+thumb_func 0x81c31d8 PrintBattleMoves
+thumb_func 0x81c3244 Task_PrintBattleMoves
+thumb_func 0x81c335c CB2_HandleStartMultiPartnerBattle
+thumb_func 0x81c3498 PrintMovePowerAndAccuracy
+thumb_func 0x81c3544 PrintContestMoves
+thumb_func 0x81c3590 Task_PrintContestMoves
+thumb_func 0x81c3668 PrintContestMoveDescription
+thumb_func 0x81c36d4 PrintMoveDetails
 thumb_func 0x81c377c
 thumb_func 0x81c3888
 thumb_func 0x81c38c4
-thumb_func 0x81c3978
+thumb_func 0x81c3978 PrintHMMovesCantBeForgotten
 thumb_func 0x81c39b4 ResetSpriteIds
-thumb_func 0x81c39e4
+thumb_func 0x81c39e4 DestroySpriteInArray
 thumb_func 0x81c3a28 SetSpriteInvisibility
 thumb_func 0x81c3a70 HidePageSpecificSprites
-thumb_func 0x81c3aa4
-thumb_func 0x81c3aec
-thumb_func 0x81c3b3c
-thumb_func 0x81c3bc4
-thumb_func 0x81c3c44
-thumb_func 0x81c3ca8
-thumb_func 0x81c3d14
+thumb_func 0x81c3aa4 SetTypeIcons
+thumb_func 0x81c3aec CreateMoveTypeIcons
+thumb_func 0x81c3b3c SetMoveTypeSpritePosAndType
+thumb_func 0x81c3bc4 SetMonTypeIcons
+thumb_func 0x81c3c44 SetMoveTypeIcons
+thumb_func 0x81c3ca8 SetContestMoveTypeIcons
+thumb_func 0x81c3d14 SetNewMoveTypeIcon
 thumb_func 0x81c3d8c
-thumb_func 0x81c3e18
-thumb_func 0x81c3f80
+thumb_func 0x81c3e18 CreatePokemonSprite
+thumb_func 0x81c3f80 PlayMonCry
 thumb_func 0x81c3fbc
-thumb_func 0x81c404c
+thumb_func 0x81c404c SpriteCB_Pokemon
 thumb_func 0x81c4094
-thumb_func 0x81c40a0
-thumb_func 0x81c40bc
-thumb_func 0x81c40f8
-thumb_func 0x81c418c
-thumb_func 0x81c41e8
-thumb_func 0x81c4210
+thumb_func 0x81c40a0 SummaryScreen_DestroyUnknownTask
+thumb_func 0x81c40bc SummaryScreen_DoesSpriteHaveCallback
+thumb_func 0x81c40f8 StopPokemonAnimations
+thumb_func 0x81c418c CreateMonMarkingsSprite
+thumb_func 0x81c41e8 RemoveAndCreateMonMarkingsSprite
+thumb_func 0x81c4210 CreateCaughtBallSprite
 thumb_func 0x81c4290
 thumb_func 0x81c4300
 thumb_func 0x81c43ec
@@ -14564,8 +14564,8 @@ thumb_func 0x81c4578
 thumb_func 0x81c4698
 thumb_func 0x81c46bc
 thumb_func 0x81c46d8
-thumb_func 0x81c46f4
-thumb_func 0x81c4704
+thumb_func 0x81c46f4 InitBattlePyramidBagCursorPosition
+thumb_func 0x81c4704 CB2_PyramidBagMenuFromStartMenu
 thumb_func 0x81c4718
 thumb_func 0x81c472c
 thumb_func 0x81c474c
@@ -14577,16 +14577,16 @@ thumb_func 0x81c4854
 thumb_func 0x81c4880
 thumb_func 0x81c49e4
 thumb_func 0x81c4a40
-thumb_func 0x81c4b1c
-thumb_func 0x81c4c14
-thumb_func 0x81c4c68
-thumb_func 0x81c4d20
-thumb_func 0x81c4dd4
-thumb_func 0x81c4e70
+thumb_func 0x81c4b1c SetBagItemsListTemplate
+thumb_func 0x81c4c14 PyramidBag_CopyItemName
+thumb_func 0x81c4c68 PyramidBagMoveCursorFunc
+thumb_func 0x81c4d20 PrintItemQuantity
+thumb_func 0x81c4dd4 PrintItemDescription
+thumb_func 0x81c4e70 AddScrollArrow
 thumb_func 0x81c4ec8
 thumb_func 0x81c4ef4
 thumb_func 0x81c4f34 SwapItems
-thumb_func 0x81c4fa4
+thumb_func 0x81c4fa4 MovePyramidBagItemSlotInList
 thumb_func 0x81c5068 CompactItems
 thumb_func 0x81c5120
 thumb_func 0x81c51b8
@@ -14595,38 +14595,38 @@ thumb_func 0x81c5294
 thumb_func 0x81c52b4
 thumb_func 0x81c5310
 thumb_func 0x81c5348
-thumb_func 0x81c53c4
+thumb_func 0x81c53c4 Task_HandlePyramidBagInput
 thumb_func 0x81c551c
 thumb_func 0x81c56a8
 thumb_func 0x81c5724
-thumb_func 0x81c5794
-thumb_func 0x81c5810
-thumb_func 0x81c5998
+thumb_func 0x81c5794 HandleFewMenuActionsInput
+thumb_func 0x81c5810 HandleMenuActionInput
+thumb_func 0x81c5998 IsValidMenuAction
 thumb_func 0x81c59d4
-thumb_func 0x81c5a0c
-thumb_func 0x81c5a84
+thumb_func 0x81c5a0c BagAction_UseOnField
+thumb_func 0x81c5a84 BagAction_Cancel
 thumb_func 0x81c5ac8
-thumb_func 0x81c5af0
+thumb_func 0x81c5af0 BagAction_Toss
 thumb_func 0x81c5b7c
-thumb_func 0x81c5bfc
+thumb_func 0x81c5bfc DontTossItem
 thumb_func 0x81c5c30
 thumb_func 0x81c5c7c
 thumb_func 0x81c5cc4
-thumb_func 0x81c5d5c
+thumb_func 0x81c5d5c TossItem
 thumb_func 0x81c5ddc
-thumb_func 0x81c5e58
+thumb_func 0x81c5e58 BagAction_Give
 thumb_func 0x81c5ebc
 thumb_func 0x81c5efc
 thumb_func 0x81c5f24
 thumb_func 0x81c5f5c
-thumb_func 0x81c5fac
+thumb_func 0x81c5fac BagAction_UseInBattle
 thumb_func 0x81c5fdc
-thumb_func 0x81c60c8
-thumb_func 0x81c617c
+thumb_func 0x81c60c8 Task_ItemSwapHandleInput
+thumb_func 0x81c617c PerformItemSwap
 thumb_func 0x81c622c
 thumb_func 0x81c62ac
 thumb_func 0x81c63f0
-thumb_func 0x81c6454
+thumb_func 0x81c6454 PrintOnWindow_Font1
 thumb_func 0x81c64ac
 thumb_func 0x81c64c8
 thumb_func 0x81c64e4
@@ -14639,137 +14639,137 @@ thumb_func 0x81c6658
 thumb_func 0x81c66b4
 thumb_func 0x81c66e0
 thumb_func 0x81c6728
-thumb_func 0x81c6750
+thumb_func 0x81c6750 ShowItemImage
 thumb_func 0x81c67b8
 thumb_func 0x81c67cc
 thumb_func 0x81c67e8
 thumb_func 0x81c680c
-thumb_func 0x81c6838
-thumb_func 0x81c6898
-thumb_func 0x81c68e4
+thumb_func 0x81c6838 CreateLoopedTask
+thumb_func 0x81c6898 IsLoopedTaskActive
+thumb_func 0x81c68e4 FuncIsActiveLoopedTask
 thumb_func 0x81c6930
-thumb_func 0x81c69a4
+thumb_func 0x81c69a4 Task_RunLoopedTask_LinkMode
 thumb_func 0x81c6a10
 thumb_func 0x81c6a64
 thumb_func 0x81c6a7c
-thumb_func 0x81c6af4
+thumb_func 0x81c6af4 FreePokenavResources
 thumb_func 0x81c6b20 InitPokenavResources
-thumb_func 0x81c6b48
+thumb_func 0x81c6b48 AnyMonHasRibbon
 thumb_func 0x81c6bc0
-thumb_func 0x81c6bd8
+thumb_func 0x81c6bd8 VBlankCB_Pokenav
 thumb_func 0x81c6bec
-thumb_func 0x81c6d2c
+thumb_func 0x81c6d2c SetActivePokenavMenu
 thumb_func 0x81c6d48
 thumb_func 0x81c6d94
 thumb_func 0x81c6da0
 thumb_func 0x81c6dac nullsub_128
-thumb_func 0x81c6db4
+thumb_func 0x81c6db4 SetVBlankCallback_
 thumb_func 0x81c6dc0
-thumb_func 0x81c6dcc
-thumb_func 0x81c6ddc
-thumb_func 0x81c6dfc
-thumb_func 0x81c6e10
-thumb_func 0x81c6e3c
-thumb_func 0x81c6e48
+thumb_func 0x81c6dcc SetPokenavVBlankCallback
+thumb_func 0x81c6ddc AllocSubstruct
+thumb_func 0x81c6dfc GetSubstructPtr
+thumb_func 0x81c6e10 FreePokenavSubstruct
+thumb_func 0x81c6e3c GetPokenavMode
+thumb_func 0x81c6e48 SetPokenavMode
 thumb_func 0x81c6e54
 thumb_func 0x81c6e6c
-thumb_func 0x81c6e78
-thumb_func 0x81c6e84
-thumb_func 0x81c6ebc
-thumb_func 0x81c6ed0
-thumb_func 0x81c6ef8
-thumb_func 0x81c6f24
+thumb_func 0x81c6e78 CanViewRibbonsMenu
+thumb_func 0x81c6e84 InitPokenavMainMenu
+thumb_func 0x81c6ebc PokenavMainMenuLoopedTaskIsActive
+thumb_func 0x81c6ed0 CB2_TradeEvolutionSceneUpdate
+thumb_func 0x81c6ef8 WaitForPokenavShutdownFade
+thumb_func 0x81c6f24 LoopedTask_InitPokenavMenu
 thumb_func 0x81c6ff4
 thumb_func 0x81c7010
 thumb_func 0x81c702c
 thumb_func 0x81c703c nullsub_129
 thumb_func 0x81c7040
 thumb_func 0x81c7060
-thumb_func 0x81c7080
-thumb_func 0x81c7094
-thumb_func 0x81c70dc
-thumb_func 0x81c7104
-thumb_func 0x81c711c
+thumb_func 0x81c7080 MainMenuLoopedTaskIsBusy
+thumb_func 0x81c7094 LoopedTask_ScrollMenuHeaderDown
+thumb_func 0x81c70dc LoopedTask_ScrollMenuHeaderUp
+thumb_func 0x81c7104 ClearBottomWindow
+thumb_func 0x81c711c Pokenav_AllocAndLoadPalettes
 thumb_func 0x81c7150
 thumb_func 0x81c717c
 thumb_func 0x81c7280
 thumb_func 0x81c72f4
 thumb_func 0x81c7300
-thumb_func 0x81c7314
+thumb_func 0x81c7314 InitBgTemplates
 thumb_func 0x81c7334
 thumb_func 0x81c7364
 thumb_func 0x81c73a8
 thumb_func 0x81c73b8
-thumb_func 0x81c73e8
-thumb_func 0x81c7454
-thumb_func 0x81c7474
-thumb_func 0x81c748c
+thumb_func 0x81c73e8 InitPokenavMainMenuResources
+thumb_func 0x81c7454 CleanupPokenavMainMenuResources
+thumb_func 0x81c7474 SpriteCB_SpinningPokenav
+thumb_func 0x81c748c PauseSpinningPokenavSprite
 thumb_func 0x81c74a4 ResumeSpinningPokenavSprite
-thumb_func 0x81c74e8
-thumb_func 0x81c75bc
+thumb_func 0x81c74e8 InitHoennMapHeaderSprites
+thumb_func 0x81c75bc LoadLeftHeaderGfxForIndex
 thumb_func 0x81c75d4
 thumb_func 0x81c7618
-thumb_func 0x81c76cc
+thumb_func 0x81c76cc LoadLeftHeaderGfxForSubMenu
 thumb_func 0x81c7748
 thumb_func 0x81c776c
 thumb_func 0x81c7784
 thumb_func 0x81c77b8
-thumb_func 0x81c77e4
-thumb_func 0x81c7830
-thumb_func 0x81c787c
-thumb_func 0x81c78b8
-thumb_func 0x81c78f4
+thumb_func 0x81c77e4 ShowLeftHeaderSprites
+thumb_func 0x81c7830 ShowLeftHeaderSubmenuSprites
+thumb_func 0x81c787c HideLeftHeaderSprites
+thumb_func 0x81c78b8 HideLeftHeaderSubmenuSprites
+thumb_func 0x81c78f4 MoveLeftHeader
 thumb_func 0x81c7924 SpriteCB_MoveLeftHeader
 thumb_func 0x81c797c
 thumb_func 0x81c79cc
 thumb_func 0x81c79dc
-thumb_func 0x81c79fc
+thumb_func 0x81c79fc LoopedTask_sub_81C8254
 thumb_func 0x81c7a8c
 thumb_func 0x81c7b04
 thumb_func 0x81c7b24
 thumb_func 0x81c7b54
 thumb_func 0x81c7b88
-thumb_func 0x81c7b98
-thumb_func 0x81c7c4c
-thumb_func 0x81c7c68
-thumb_func 0x81c7c90
+thumb_func 0x81c7b98 LoopedTask_sub_81C83F0
+thumb_func 0x81c7c4c ShouldShowUpArrow
+thumb_func 0x81c7c68 ShouldShowDownArrow
+thumb_func 0x81c7c90 MatchCall_MoveWindow
 thumb_func 0x81c7d10
-thumb_func 0x81c7d48
-thumb_func 0x81c7dd8
-thumb_func 0x81c7dec
+thumb_func 0x81c7d48 LoopedTask_sub_81C85A0
+thumb_func 0x81c7dd8 MatchCall_GetMessage_Type2
+thumb_func 0x81c7dec GetMatchCallWindowStruct
 thumb_func 0x81c7e00 MatchCall_MoveCursorUp
 thumb_func 0x81c7e34 MatchCall_MoveCursorDown
 thumb_func 0x81c7e74 MatchCall_PageUp
 thumb_func 0x81c7eb4 MatchCall_PageDown
-thumb_func 0x81c7f04
-thumb_func 0x81c7f18
+thumb_func 0x81c7f04 GetSelectedMatchCall
+thumb_func 0x81c7f18 GetMatchCallListTopIndex
 thumb_func 0x81c7f24
 thumb_func 0x81c7f54
 thumb_func 0x81c7f98
 thumb_func 0x81c7fc8
 thumb_func 0x81c7fe0
-thumb_func 0x81c8018
-thumb_func 0x81c8100
-thumb_func 0x81c81d0
+thumb_func 0x81c8018 LoopedTask_sub_81C8870
+thumb_func 0x81c8100 LoopedTask_sub_81C8958
+thumb_func 0x81c81d0 LoopedTask_sub_81C8A28
 thumb_func 0x81c8318
 thumb_func 0x81c840c
 thumb_func 0x81c845c
 thumb_func 0x81c8484
 thumb_func 0x81c84f4
 thumb_func 0x81c8510
-thumb_func 0x81c8564
+thumb_func 0x81c8564 PrintMatchCallFieldNames
 thumb_func 0x81c85fc
 thumb_func 0x81c867c
 thumb_func 0x81c86a4
 thumb_func 0x81c8794
-thumb_func 0x81c87bc
-thumb_func 0x81c8834
-thumb_func 0x81c8854
-thumb_func 0x81c88a8
-thumb_func 0x81c88fc
+thumb_func 0x81c87bc ToggleMatchCallArrows
+thumb_func 0x81c8834 c3_0802FDF4
+thumb_func 0x81c8854 SpriteCB_MatchCallDownArrow
+thumb_func 0x81c88a8 SpriteCB_MatchCallUpArrow
+thumb_func 0x81c88fc ToggleMatchCallVerticalArrows
 thumb_func 0x81c8914
 thumb_func 0x81c8960
-thumb_func 0x81c8a14
+thumb_func 0x81c8a14 GetPokenavMainMenuType
 thumb_func 0x81c8a44
 thumb_func 0x81c8a78
 thumb_func 0x81c8ab0
@@ -14815,7 +14815,7 @@ thumb_func 0x81c9674
 thumb_func 0x81c96a4
 thumb_func 0x81c96d4
 thumb_func 0x81c9770
-thumb_func 0x81c9798
+thumb_func 0x81c9798 PrintLeftColumnStats
 thumb_func 0x81c97d8
 thumb_func 0x81c9840
 thumb_func 0x81c9874
@@ -14841,7 +14841,7 @@ thumb_func 0x81c9f80
 thumb_func 0x81c9fa0
 thumb_func 0x81c9fb4
 thumb_func 0x81c9fc4
-thumb_func 0x81c9ffc
+thumb_func 0x81c9ffc Overworld_ResetStateAfterFly
 thumb_func 0x81ca010
 thumb_func 0x81ca048
 thumb_func 0x81ca05c
@@ -14866,21 +14866,21 @@ thumb_func 0x81ca5b4
 thumb_func 0x81ca5d4
 thumb_func 0x81ca5e4
 thumb_func 0x81ca5f4
-thumb_func 0x81ca604
-thumb_func 0x81ca618
+thumb_func 0x81ca604 unref_sub_81CAE58
+thumb_func 0x81ca618 unref_sub_81CAE6C
 thumb_func 0x81ca640
 thumb_func 0x81ca650
 thumb_func 0x81ca668
 thumb_func 0x81ca6b0
 thumb_func 0x81ca71c
-thumb_func 0x81ca77c
+thumb_func 0x81ca77c GroundEffect_DeepSandTracks
 thumb_func 0x81ca7c0
 thumb_func 0x81ca7d0
-thumb_func 0x81ca7f4
+thumb_func 0x81ca7f4 DoHitAnimHealthboxEffect
 thumb_func 0x81ca86c
 thumb_func 0x81ca888
 thumb_func 0x81ca8cc
-thumb_func 0x81ca910
+thumb_func 0x81ca910 unref_sub_81CB16C
 thumb_func 0x81ca974
 thumb_func 0x81caa04
 thumb_func 0x81caa40
@@ -14892,7 +14892,7 @@ thumb_func 0x81caac8
 thumb_func 0x81cacb4
 thumb_func 0x81cad20
 thumb_func 0x81cad8c
-thumb_func 0x81cadf8
+thumb_func 0x81cadf8 DestroyFog1Sprites
 thumb_func 0x81cae64
 thumb_func 0x81caea8
 thumb_func 0x81caed0
@@ -14926,7 +14926,7 @@ thumb_func 0x81cb760
 thumb_func 0x81cb780
 thumb_func 0x81cb7a4
 thumb_func 0x81cb7e8
-thumb_func 0x81cb81c
+thumb_func 0x81cb81c OpponentHandlePaletteFade
 thumb_func 0x81cb82c
 thumb_func 0x81cb854
 thumb_func 0x81cb86c
@@ -14956,9 +14956,9 @@ thumb_func 0x81cbd30
 thumb_func 0x81cbd38
 thumb_func 0x81cbd48
 thumb_func 0x81cbd80
-thumb_func 0x81cbdb0
+thumb_func 0x81cbdb0 PlayerHandleOneReturnValue
 thumb_func 0x81cbdc0 nullsub_130
-thumb_func 0x81cbdc4
+thumb_func 0x81cbdc4 Cb_PlaceMon
 thumb_func 0x81cbdf8
 thumb_func 0x81cbe10
 thumb_func 0x81cbe24
@@ -14967,7 +14967,7 @@ thumb_func 0x81cbf9c
 thumb_func 0x81cbfcc
 thumb_func 0x81cc02c
 thumb_func 0x81cc0b0
-thumb_func 0x81cc114
+thumb_func 0x81cc114 InitMoveRelearnerWindows
 thumb_func 0x81cc140
 thumb_func 0x81cc170
 thumb_func 0x81cc250
@@ -15030,7 +15030,7 @@ thumb_func 0x81cdd44
 thumb_func 0x81cde1c
 thumb_func 0x81cde60
 thumb_func 0x81cde98
-thumb_func 0x81cdeb4
+thumb_func 0x81cdeb4 GiveMailToMon
 thumb_func 0x81ce068
 thumb_func 0x81ce098
 thumb_func 0x81ce0c4
@@ -15078,7 +15078,7 @@ thumb_func 0x81ced14
 thumb_func 0x81ced7c
 thumb_func 0x81cede4
 thumb_func 0x81cee4c
-thumb_func 0x81cee8c
+thumb_func 0x81cee8c CB2_MoveRelearnerMain
 thumb_func 0x81ceebc
 thumb_func 0x81ceee8
 thumb_func 0x81cef4c
@@ -15132,9 +15132,9 @@ thumb_func 0x81cfd14
 thumb_func 0x81cfd38
 thumb_func 0x81cfd74
 thumb_func 0x81cfd84
-thumb_func 0x81cfd94
-thumb_func 0x81cfe10
-thumb_func 0x81cfe88
+thumb_func 0x81cfd94 GetCurrMonInfo1
+thumb_func 0x81cfe10 GetCurrMonInfo2
+thumb_func 0x81cfe88 GetCurrMonRibbonCount
 thumb_func 0x81cfec4
 thumb_func 0x81cffc4
 thumb_func 0x81cffdc
@@ -15158,7 +15158,7 @@ thumb_func 0x81d05ac
 thumb_func 0x81d067c
 thumb_func 0x81d06a0
 thumb_func 0x81d076c
-thumb_func 0x81d07b8
+thumb_func 0x81d07b8 DisplayItemMessageInBattlePyramid
 thumb_func 0x81d081c
 thumb_func 0x81d0864
 thumb_func 0x81d0894
@@ -15177,24 +15177,24 @@ thumb_func 0x81d0b64
 thumb_func 0x81d0c1c
 thumb_func 0x81d0c40
 thumb_func 0x81d0c54
-thumb_func 0x81d0c90
-thumb_func 0x81d0cd8
-thumb_func 0x81d0ce8
-thumb_func 0x81d0d10
+thumb_func 0x81d0c90 MatchCallGetFunctionIndex
+thumb_func 0x81d0cd8 GetTrainerIdxByRematchIdx
+thumb_func 0x81d0ce8 GetRematchIdxByTrainerIdx
+thumb_func 0x81d0d10 MatchCallFlagGetByIndex
 thumb_func 0x81d0d44
 thumb_func 0x81d0d68
 thumb_func 0x81d0d8c
-thumb_func 0x81d0db0
-thumb_func 0x81d0de8
-thumb_func 0x81d0df8
+thumb_func 0x81d0db0 MatchCallGetFlag_Type4
+thumb_func 0x81d0de8 MatchCallGetFlag_Type3
+thumb_func 0x81d0df8 MatchCallMapSecGetByIndex
 thumb_func 0x81d0e30
 thumb_func 0x81d0e34
 thumb_func 0x81d0e38
 thumb_func 0x81d0e6c
 thumb_func 0x81d0e70
-thumb_func 0x81d0e74
+thumb_func 0x81d0e74 MatchCall_IsRematchable
 thumb_func 0x81d0ea8 nullsub_137
-thumb_func 0x81d0eac
+thumb_func 0x81d0eac MatchCall_IsRematchable_Type1
 thumb_func 0x81d0edc MatchCall_IsRematchable_Type2
 thumb_func 0x81d0efc
 thumb_func 0x81d0f00 nullsub_138
@@ -15204,18 +15204,18 @@ thumb_func 0x81d0f60 nullsub_139
 thumb_func 0x81d0f64 nullsub_1401
 thumb_func 0x81d0f68 nullsub_141
 thumb_func 0x81d0f6c nullsub_140
-thumb_func 0x81d0f70
+thumb_func 0x81d0f70 MatchCall_GetRematchTableIdx
 thumb_func 0x81d0fa4
 thumb_func 0x81d0fa8
 thumb_func 0x81d0fac
 thumb_func 0x81d0fb0
 thumb_func 0x81d0fb4
-thumb_func 0x81d0fb8
-thumb_func 0x81d0fec
-thumb_func 0x81d0ff8
+thumb_func 0x81d0fb8 MatchCall_GetMessage
+thumb_func 0x81d0fec MatchCall_GetMessage_Type0
+thumb_func 0x81d0ff8 MatchCall_GetMessage_Type1
 thumb_func 0x81d1018
-thumb_func 0x81d1024
-thumb_func 0x81d1030
+thumb_func 0x81d1024 MatchCall_GetMessage_Type4
+thumb_func 0x81d1030 MatchCall_GetMessage_Type3
 thumb_func 0x81d103c
 thumb_func 0x81d109c
 thumb_func 0x81d1178
@@ -15224,13 +15224,13 @@ thumb_func 0x81d11bc MatchCall_GetNameAndDesc_Type1
 thumb_func 0x81d11dc MatchCall_GetNameAndDesc_Type2
 thumb_func 0x81d11f4
 thumb_func 0x81d1200
-thumb_func 0x81d120c
+thumb_func 0x81d120c MatchCall_GetNameAndDescByRematchIdx
 thumb_func 0x81d123c
 thumb_func 0x81d12cc
 thumb_func 0x81d12f4
-thumb_func 0x81d131c
+thumb_func 0x81d131c SetMatchCallRegisteredFlag
 thumb_func 0x81d1340
-thumb_func 0x81d1380
+thumb_func 0x81d1380 UpdateWorldOfMastersAndPutItOnTheAir
 thumb_func 0x81d13b4
 thumb_func 0x81d13e4
 thumb_func 0x81d13f4
@@ -15247,16 +15247,16 @@ thumb_func 0x81d1824
 thumb_func 0x81d1878
 thumb_func 0x81d18c0
 thumb_func 0x81d1aec
-thumb_func 0x81d1c48
+thumb_func 0x81d1c48 MatchCallGetMapSec_Type2
 thumb_func 0x81d1d70
 thumb_func 0x81d1e40
 thumb_func 0x81d1ee0
-thumb_func 0x81d1fd8
+thumb_func 0x81d1fd8 LoadMoveRelearnerMovesList
 thumb_func 0x81d200c
-thumb_func 0x81d2208
-thumb_func 0x81d2250
-thumb_func 0x81d2264
-thumb_func 0x81d227c
+thumb_func 0x81d2208 MoveRelearnerPrintText
+thumb_func 0x81d2250 MoveRelearnerRunTextPrinters
+thumb_func 0x81d2264 MoveRelearnerCreateYesNoMenu
+thumb_func 0x81d227c GetBoxOrPartyMonData
 thumb_func 0x81d22e4
 thumb_func 0x81d24ac
 thumb_func 0x81d2504
@@ -15280,20 +15280,20 @@ thumb_func 0x81d2b50
 thumb_func 0x81d2b7c
 thumb_func 0x81d2b94
 thumb_func 0x81d2c18
-thumb_func 0x81d2c70
-thumb_func 0x81d2db4
-thumb_func 0x81d2eb8
+thumb_func 0x81d2c70 DrawLevelUpWindowPg1
+thumb_func 0x81d2db4 DrawLevelUpWindowPg2
+thumb_func 0x81d2eb8 GetMonLevelUpWindowStats
 thumb_func 0x81d2f00
-thumb_func 0x81d2f28
+thumb_func 0x81d2f28 Struct_Unk81D38FC_ValidateChecksum
 thumb_func 0x81d2f4c
-thumb_func 0x81d2f9c
+thumb_func 0x81d2f9c TrainerHill_VerifyChecksum
 thumb_func 0x81d2fc8
 thumb_func 0x81d3130
-thumb_func 0x81d3158
-thumb_func 0x81d318c
-thumb_func 0x81d31b4
-thumb_func 0x81d31d4
-thumb_func 0x81d3268
+thumb_func 0x81d3158 TryReadTrainerHill_r
+thumb_func 0x81d318c TryReadTrainerHill
+thumb_func 0x81d31b4 ReadTrainerHillAndValidate
+thumb_func 0x81d31d4 unref_sub_81D3B54
+thumb_func 0x81d3268 unref_sub_81D3BE8
 thumb_func 0x81d32fc
 thumb_func 0x81d333c
 thumb_func 0x81d33b4
@@ -15309,13 +15309,13 @@ thumb_func 0x81d37f0
 thumb_func 0x81d3820
 thumb_func 0x81d3874
 thumb_func 0x81d38b8
-thumb_func 0x81d38d8
-thumb_func 0x81d38fc
-thumb_func 0x81d3eb4
+thumb_func 0x81d38d8 GetMewEventObjectId
+thumb_func 0x81d38fc GetMewMoveDirection
+thumb_func 0x81d3eb4 CanMewWalkToCoords
 thumb_func 0x81d3f10
-thumb_func 0x81d4018
-thumb_func 0x81d4068
-thumb_func 0x81d4094
+thumb_func 0x81d4018 UpdateFarawayIslandStepCounter
+thumb_func 0x81d4068 EventObjectIsFarawayIslandMew
+thumb_func 0x81d4094 IsMewPlayingHideAndSeek
 thumb_func 0x81d40d8
 thumb_func 0x81d4110
 thumb_func 0x81d426c
@@ -15337,22 +15337,22 @@ thumb_func 0x81d46e4
 thumb_func 0x81d4704
 thumb_func 0x81d4b14
 thumb_func 0x81d4b3c
-thumb_func 0x81d4b80
-thumb_func 0x81d4b90
-thumb_func 0x81d4bb4
-thumb_func 0x81d4be4
+thumb_func 0x81d4b80 GetFloorId
+thumb_func 0x81d4b90 GetTrainerHillOpponentClass
+thumb_func 0x81d4bb4 ScrCmd_showmonpic
+thumb_func 0x81d4be4 GetTrainerHillTrainerFrontSpriteId
 thumb_func 0x81d4c30
 thumb_func 0x81d4cf0
-thumb_func 0x81d4d0c
+thumb_func 0x81d4d0c SetUpDataStruct
 thumb_func 0x81d4d64
-thumb_func 0x81d4d80
-thumb_func 0x81d4e70
+thumb_func 0x81d4d80 CopyTrainerHillTrainerText
+thumb_func 0x81d4e70 TrainerHillStartChallenge
 thumb_func 0x81d4f2c
 thumb_func 0x81d4f78
 thumb_func 0x81d5024
-thumb_func 0x81d50a8
-thumb_func 0x81d50ec
-thumb_func 0x81d5108
+thumb_func 0x81d50a8 TrainerHillResumeTimer
+thumb_func 0x81d50ec TrainerHillSetPlayerLost
+thumb_func 0x81d5108 TrainerHillGetChallengeStatus
 thumb_func 0x81d5164
 thumb_func 0x81d51f4
 thumb_func 0x81d5238
@@ -15368,18 +15368,18 @@ thumb_func 0x81d5840
 thumb_func 0x81d58b0
 thumb_func 0x81d590c
 thumb_func 0x81d5a10 InTrainerHill
-thumb_func 0x81d5a38
+thumb_func 0x81d5a38 GetCurrentTrainerHillMapId
 thumb_func 0x81d5a9c
 thumb_func 0x81d5abc
 thumb_func 0x81d5ad0
 thumb_func 0x81d5b1c
-thumb_func 0x81d5b38
-thumb_func 0x81d5b84
+thumb_func 0x81d5b38 GetHillTrainerFlag
+thumb_func 0x81d5b84 SetHillTrainerFlag
 thumb_func 0x81d5c48
 thumb_func 0x81d5c50
 thumb_func 0x81d5c68
-thumb_func 0x81d5d20
-thumb_func 0x81d5d38
+thumb_func 0x81d5d20 FillHillTrainerParty
+thumb_func 0x81d5d38 FillHillTrainersParties
 thumb_func 0x81d5d60
 thumb_func 0x81d5d64
 thumb_func 0x81d5dcc
@@ -15392,68 +15392,68 @@ thumb_func 0x81d5eb8
 thumb_func 0x81d5ed4
 thumb_func 0x81d5f08
 thumb_func 0x81d5f40
-thumb_func 0x81d5f98
-thumb_func 0x81d605c
-thumb_func 0x81d60b0
+thumb_func 0x81d5f98 AllocOamMatrix
+thumb_func 0x81d605c DoRayquazaScene
+thumb_func 0x81d60b0 CB2_InitRayquazaScene
 thumb_func 0x81d610c
-thumb_func 0x81d6128
-thumb_func 0x81d613c
-thumb_func 0x81d617c
+thumb_func 0x81d6128 VBlankCB_RayquazaScene
+thumb_func 0x81d613c Task_EndAfterFadeScreen
+thumb_func 0x81d617c Task_SetNextAnim
 thumb_func 0x81d6204
 thumb_func 0x81d6240
-thumb_func 0x81d6258
+thumb_func 0x81d6258 Task_HandleDuoFightPre
 thumb_func 0x81d62c0
 thumb_func 0x81d635c
 thumb_func 0x81d64b8
 thumb_func 0x81d665c
-thumb_func 0x81d690c
+thumb_func 0x81d690c VBlankCB_DuoFight
 thumb_func 0x81d691c
 thumb_func 0x81d69a8
-thumb_func 0x81d6a70
+thumb_func 0x81d6a70 Task_DuoFightAnim
 thumb_func 0x81d6b64
-thumb_func 0x81d6ca8
+thumb_func 0x81d6ca8 Task_HandleDuoFight
 thumb_func 0x81d6d74
 thumb_func 0x81d6dbc
 thumb_func 0x81d6e04
 thumb_func 0x81d6e48
 thumb_func 0x81d6e68
-thumb_func 0x81d6ef0
-thumb_func 0x81d6f3c
+thumb_func 0x81d6ef0 DuoFightEnd
+thumb_func 0x81d6f3c Task_DuoFightEnd
 thumb_func 0x81d6fa0
 thumb_func 0x81d703c
 thumb_func 0x81d719c
 thumb_func 0x81d71f8
 thumb_func 0x81d739c
 thumb_func 0x81d7650
-thumb_func 0x81d774c
+thumb_func 0x81d774c MoveSelectionDisplayPpString
 thumb_func 0x81d77d8
-thumb_func 0x81d7888
-thumb_func 0x81d78fc
-thumb_func 0x81d7aa0
+thumb_func 0x81d7888 Task_RayTakesFlightAnim
+thumb_func 0x81d78fc Task_HandleRayTakesFlight
+thumb_func 0x81d7aa0 Task_RayTakesFlightEnd
 thumb_func 0x81d7ae0
 thumb_func 0x81d7b9c
 thumb_func 0x81d7bec
 thumb_func 0x81d7c94
 thumb_func 0x81d7d88
-thumb_func 0x81d7e28
-thumb_func 0x81d7eb8
+thumb_func 0x81d7e28 Task_RayDescendsAnim
+thumb_func 0x81d7eb8 Task_HandleRayDescends
 thumb_func 0x81d7fc0
 thumb_func 0x81d8008
 thumb_func 0x81d8088
 thumb_func 0x81d8164
 thumb_func 0x81d820c
-thumb_func 0x81d82bc
-thumb_func 0x81d831c
+thumb_func 0x81d82bc Task_RayChargesAnim
+thumb_func 0x81d831c Task_HandleRayCharges
 thumb_func 0x81d8414
 thumb_func 0x81d8468
 thumb_func 0x81d84f0
-thumb_func 0x81d8528
+thumb_func 0x81d8528 Task_RayChargesEnd
 thumb_func 0x81d8574
 thumb_func 0x81d8600
-thumb_func 0x81d86f0
-thumb_func 0x81d87bc
+thumb_func 0x81d86f0 Task_RayChasesAwayAnim
+thumb_func 0x81d87bc Task_HandleRayChasesAway
 thumb_func 0x81d88ec
-thumb_func 0x81d8970
+thumb_func 0x81d8970 Task_RayChasesAwayEnd
 thumb_func 0x81d89e4
 thumb_func 0x81d8bb0
 thumb_func 0x81d8c74
@@ -15465,11 +15465,11 @@ thumb_func 0x81d8f58
 thumb_func 0x81d911c
 thumb_func 0x81d91a4
 thumb_func 0x81d91f0
-thumb_func 0x81d92f8
-thumb_func 0x81d9320
-thumb_func 0x81d9358
-thumb_func 0x81d93d4
-thumb_func 0x81d9400
+thumb_func 0x81d92f8 TryBufferWaldaPhrase
+thumb_func 0x81d9320 DoWaldaNamingScreen
+thumb_func 0x81d9358 CB2_HandleGivenWaldaPhrase
+thumb_func 0x81d93d4 GetWaldaPhraseInputCase
+thumb_func 0x81d9400 TryGetWallpaperWithWaldaPhrase
 thumb_func 0x81d947c
 thumb_func 0x81d9574
 thumb_func 0x81d95c0
@@ -15489,10 +15489,10 @@ thumb_func 0x81d9ad4
 thumb_func 0x81d9b78
 thumb_func 0x81d9c48
 thumb_func 0x81d9d18
-thumb_func 0x81d9dcc
-thumb_func 0x81d9e24
-thumb_func 0x81d9f1c
-thumb_func 0x81d9f50
+thumb_func 0x81d9dcc UpdateGymLeaderRematch
+thumb_func 0x81d9e24 UpdateGymLeaderRematchFromArray
+thumb_func 0x81d9f1c GetRematchIndex
+thumb_func 0x81d9f50 StopCry
 thumb_func 0x81d9f9c
 thumb_func 0x81da098
 thumb_func 0x81da10c


### PR DESCRIPTION
By changing `graph_search.py` to use stricter matching criteria, and running it until it stopped finding many matches, I was able to match >8000 functions with names from US Emerald. I'm still unsure over whether it's possible for the matching algorithm to make a mistake, but from looking through the config, everything seems correct.

**Don't merge this until reasonably sure it's correct and has minimal, if any, mislabeling.**

Closes #3.